### PR TITLE
De-automate Javadocs publication to GitHub Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_script:
 
 install: true
 
-# The build step here also builds our Javadocs.
 script:
   - cd psm-app
   - ./gradlew --no-daemon --console=plain
@@ -39,10 +38,6 @@ script:
   - ./gradlew --no-daemon --info
         test
   - cd ../
-
-# Push the new Javadocs to our GitHub Pages site.
-after_success:
-  - ./scripts/push-javadoc-to-gh-pages.sh
 
 # Build the Continuous Deployment private key
 before_deploy:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,12 +3,10 @@ administrators or our build systems.
 
 * `rhel-install.sh` is an automated script Red Hat sysadmins can use
   to install the PSM.
-* `push-javadoc-to-gh-pages.sh` lets TravisCI build our automated API
-  documentation using Javadoc and push it to the `gh-pages` branch,
-  which can automatically update [our GitHub Pages
-  site](https://solutionguidance.github.io/psm/). It's [currently
-  under
-  construction](https://github.com/solutionguidance/psm/pull/478).
+* `push-javadoc-to-gh-pages.sh` lets a developer build our automated
+  API documentation using Javadoc and push it to the `gh-pages`
+  branch, which updates [our GitHub Pages
+  site](https://solutionguidance.github.io/psm/javadoc/api-docs/).
 * `drools-microservice.sh` sets up a copy of jBPM and Guvnor on a
   standalone server, which the core application can then be configured
   to communicate with.

--- a/scripts/push-javadoc-to-gh-pages.sh
+++ b/scripts/push-javadoc-to-gh-pages.sh
@@ -1,30 +1,64 @@
 #!/bin/bash
-set -ex
 
-# Adaptation of code from https://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
+# Script for a developer to use to push new version of Javadoc to
+# GitHub Pages site.
+# Before running, ensure that you have committed any local changes
+# in your current branch.
+#
+# Code partially adapted from
+# https://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
-if [ "$TRAVIS_REPO_SLUG" == "SolutionGuidance/psm" ] \
-       && [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] \
-       && [ "$TRAVIS_PULL_REQUEST" == "false" ] \
-       && [ "$TRAVIS_BRANCH" == "master" ]; then
+set -x  # Avoiding -e because we need an exit code on `git diff`
 
-  echo -e "Publishing Javadoc...\n"
-
-  cp -R cms-web/build/reports/api-docs $HOME/javadoc-latest
-
-  cd $HOME
-  git clone --quiet --branch=gh-pages \
-      https://${GH_TOKEN}@github.com/SolutionGuidance/psm gh-pages > /dev/null
-
-  cd gh-pages
-  git rm -rf ./javadoc
-  cp -Rf $HOME/javadoc-latest ./javadoc
-  git add -f .
-  git commit -m "Javadoc published from Travis build ${TRAVIS_BUILD_NUMBER}" \
-      -m "Generated from commit ${TRAVIS_COMMIT}, pushed to gh-pages" \
-      --author="Travis CI automated push <psm-dev@googlegroups.com>"
-  git push -fq origin gh-pages > /dev/null
-
-  echo -e "Published Javadoc to gh-pages branch.\n"
-
+if [[ "$(pwd)" != "$(git rev-parse --show-toplevel)" ]]
+then
+    set +x
+    echo "Please run this from the root of the project by running:"
+    echo "   ./scripts/push-javadoc-to-gh-pages.sh"
+    echo "This script switches branches;"
+    echo "running from the root ensures you won't end up in a deleted directory."
+    exit 1
 fi
+
+COMMIT=$(git rev-parse HEAD)
+echo "Generating Javadoc..."
+
+cd psm-app
+./gradlew clean cms-web:apiDocs || exit 1
+
+DOCSDIR=$(mktemp -d /tmp/docXXXX)
+cp -R cms-web/build/reports/api-docs $DOCSDIR || exit 1
+cd ..
+
+echo "Publishing Javadoc..."
+
+git fetch git@github.com:SolutionGuidance/psm.git gh-pages || exit 1
+git rev-parse --verify --quiet "gh-pages"  # Check whether branch exists
+if [ $? -eq 0 ]  # Check for truth
+then
+    git checkout gh-pages || exit 1 #  Will fail if you have uncommitted local changes.
+    git pull git@github.com:SolutionGuidance/psm.git gh-pages || exit 1
+else
+    git fetch git@github.com:SolutionGuidance/psm.git gh-pages:gh-pages || exit 1
+    git checkout gh-pages || exit 1 #  Will fail if you have uncommitted local changes.
+fi
+
+git rm -rf ./javadoc || exit 1
+mv -f $DOCSDIR ./javadoc || exit 1
+git add -f ./javadoc/.
+
+git diff --staged --quiet --exit-code  # Check for changed files
+if [ $? -eq 1 ]  # Check for differences
+then
+    git commit -m "Publish Javadocs from $COMMIT and push to gh-pages" || exit 1
+    git push -q git@github.com:SolutionGuidance/psm.git gh-pages || exit 1
+    echo "Published Javadocs from $COMMIT to gh-pages branch."
+else
+    echo "No changes; nothing to commit."
+fi
+
+echo "Finished."
+
+# Return to branch and directory where user started
+
+git checkout -


### PR DESCRIPTION
1fcb87f1eaa587324d7a232c8542b1c843390b74 broke the
GitHub Pages syndication of our Javadocs, and I suspect it's because of a changed directory in .travis.yml.

This temporary commit should copy the most recent version of the Javadocs to our GitHub Pages site.
Once it's in and tested with Travis, I'll revise this PR to add back the constraint on how often Travis will push updates.
