### PR TITLE
Upgraded jaxb

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -194,9 +194,9 @@ project(':cms-business-model') {
     System.setProperty('javax.xml.accessExternalSchema', 'file')
 
     dependencies {
-         jaxb 'com.sun.xml.bind:jaxb-xjc:2.2.7'
-         jaxb 'com.sun.xml.bind:jaxb-impl:2.2.7'
-         jaxb 'javax.xml.bind:jaxb-api:2.2.7'
+         jaxb 'org.glassfish.jaxb:jaxb-xjc:2.2.11'
+         jaxb 'org.glassfish.jaxb:jaxb-runtime:2.2.11'
+         jaxb 'javax.xml.bind:jaxb-api:2.2.11'
     }
 
     sourceSets {


### PR DESCRIPTION
This PR upgreades jaxb to a version released in 2015, but not to the latest version.  It also moves the core repo to the officially recommended glassfish group (com.sun.xml.bind is used for legacy support only at this point).

The patch notes can be found at https://javaee.github.io/jaxb-v2/doc/user-guide/release-documentation.html#a-2-2-11

The latest version of jaxb (2.3) doesn't work with a simple swap -- the errors are not particularly descriptive (they happen during an ant step that is buried inside of a gradle plugin) but I saw some evidence in my debug search that there may actually be an issue with the library's dependency sets.  I would like us to consider waiting to see if a patch build comes out in the near future and revisiting the upgrade at that point.