### PR TITLE
Change GitHub links to new organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ conduct](docs/CODE_OF_CONDUCT.md).
 ## Submitting and Reviewing Code
 
 This repository has a home on
-[GitHub](https://github.com/OpenTechStrategies/psm).  Please submit
+[GitHub](https://github.com/SolutionGuidance/psm).  Please submit
 [pull requests](https://help.github.com/articles/about-pull-requests/)
 (PRs) there.
 
@@ -18,7 +18,7 @@ Please submit changes via pull request, even if you have direct commit
 access to the repository.  The PR process allows us to get additional
 eyes on change proposals, and ensures that your changed code [builds
 cleanly via Travis CI's automated Gradle
-build](https://travis-ci.org/OpenTechStrategies/psm).  We have caught
+build](https://travis-ci.org/SolutionGuidance/psm).  We have caught
 issues at this stage in even simple patches.
 
 As you work on your branch, try to test it locally to ensure that it
@@ -48,10 +48,10 @@ conversation around a change has concluded.  If you're unsure, ask!
 conversation.
 
 If your PR fixes a bug or adds a feature, please write a test to go with
-the change (see [TESTING.md](https://github.com/OpenTechStrategies/psm/blob/master/docs/TESTING.md) for details on our testing
+the change (see [TESTING.md](https://github.com/SolutionGuidance/psm/blob/master/docs/TESTING.md) for details on our testing
 framework).  If the change involves libraries or would be difficult to
 test, please use a Given-When-Then description like [this
-one](https://github.com/OpenTechStrategies/psm/blob/master/psm-app/cms-web/src/main/test/resources/features/enrollment/create_enrollment.feature)
+one](https://github.com/SolutionGuidance/psm/blob/master/psm-app/cms-web/src/main/test/resources/features/enrollment/create_enrollment.feature)
 or describe in your PR message how reviewers should test that your
 change works as expected.  
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -152,7 +152,7 @@ configuration for a development install.
    called `psm`.
 
    ```ShellSession
-   $ git clone https://github.com/OpenTechStrategies/psm.git
+   $ git clone https://github.com/SolutionGuidance/psm.git
    ```
 
 ## Configure WildFly
@@ -430,7 +430,7 @@ NGINX.  You will want to set maximum uploaded file size in both NGINX
 get quite large, especially if they are multi-page PDFs of scanned
 documents.  We do not yet have a recommended size to set this to, but
 we will set a sane default in `cms.properties` when we do.  See [issue
-263 in GitHub](https://github.com/OpenTechStrategies/psm/issues/263)
+263 in GitHub](https://github.com/SolutionGuidance/psm/issues/263)
 for some discussion of the problem.
 
 ## Configuration options

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Provider Screening Module for Medicare/Medicaid Provider Enrollment
 ===================================================================
 
-Current build status:  ![Build status](https://travis-ci.org/OpenTechStrategies/psm.svg?branch=master)
+Current build status:  ![Build status](https://travis-ci.org/SolutionGuidance/psm.svg?branch=master)
 
 Contents:
 
@@ -29,7 +29,7 @@ Development activity now takes place on the `master` branch, with
 short-lived development branches used for specific tasks.  Code
 contribution guidelines are in [CONTRIBUTING.md](CONTRIBUTING.md).
 Please feel free to [file issue
-tickets](https://github.com/OpenTechStrategies/psm/issues/new) in this
+tickets](https://github.com/SolutionGuidance/psm/issues/new) in this
 repository to ask questions.
 
 See the "Background" section for the provenance of this project.
@@ -40,10 +40,10 @@ help us organize legacy code for eventual landing or rearrangement on
 (soon to be WildFly), the WebSphere side (which is divided into two
 subtrees in the original repository), and the documentation changes:
 
-* [jboss-core](https://github.com/OpenTechStrategies/coeci-cms-mpsp/tree/jboss-core)
-* [was-core](https://github.com/OpenTechStrategies/coeci-cms-mpsp/tree/was-core)
-* [was-ext](https://github.com/OpenTechStrategies/coeci-cms-mpsp/tree/was-ext)
-* [documentation](https://github.com/OpenTechStrategies/coeci-cms-mpsp/tree/documentation)
+* [jboss-core](https://github.com/SolutionGuidance/coeci-cms-mpsp/tree/jboss-core)
+* [was-core](https://github.com/SolutionGuidance/coeci-cms-mpsp/tree/was-core)
+* [was-ext](https://github.com/SolutionGuidance/coeci-cms-mpsp/tree/was-ext)
+* [documentation](https://github.com/SolutionGuidance/coeci-cms-mpsp/tree/documentation)
 
 The point of the replay branches is to give us a clean, disentangled
 view of the changes that happened in each line of development.  They
@@ -178,11 +178,11 @@ We welcome questions and contributions.  You can:
   are public, and anyone can post.  The posting guidelines are fairly
   loose -- as long as your question is about the PSM, it's on-topic.
 
-* File a new issue ticket at https://github.com/OpenTechStrategies/psm/issues.
+* File a new issue ticket at https://github.com/SolutionGuidance/psm/issues.
 
 * Submit a [pull
   request](https://help.github.com/articles/about-pull-requests/) to
-  the [repository](https://github.com/OpenTechStrategies/psm/). Here's
+  the [repository](https://github.com/SolutionGuidance/psm/). Here's
   [our guide for code contributors](CONTRIBUTING.md).
 
 * Chat with us in real time using [Zulip](https://zulipchat.com/).  Our

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -45,7 +45,7 @@ advances
 
 We all share a responsibility to create an environment that encourages
 behavior that meets these standards.  In addition,
-[Project maintainers](https://github.com/orgs/OpenTechStrategies/teams/psm?query=role%3Aowner)
+[Project maintainers](https://github.com/orgs/SolutionGuidance/teams/psm?query=role%3Aowner)
 are responsible for clarifying the standards of acceptable behavior
 and are expected to take appropriate and fair corrective action in
 response to instances of unacceptable behavior.  Their own behavior

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -19,7 +19,7 @@ for more details on component versions and installation requirements.
 
 ***NOTE:2017-07-03: [We no longer use `ext-sources-app` and are
    rewriting this section
-   accordingly.](https://github.com/OpenTechStrategies/psm/issues/165).***
+   accordingly.](https://github.com/SolutionGuidance/psm/issues/165).***
 
 The two pieces of this application (`psm-app` and `ext-sources-app`)
 communicate via a web service which is provided by the `ext-sources-app`.
@@ -76,7 +76,7 @@ common superclass.
 
 This all means that the API is currently brittle; it hasn't been
 engineered or documented (see [this
-milestone](https://github.com/OpenTechStrategies/psm/milestone/4)), and
+milestone](https://github.com/SolutionGuidance/psm/milestone/4)), and
 writing a client for it isn't predictable (you would have to look at the
 POJO to know what kind of return to expect).
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,7 +12,7 @@ We use [Selenium](http://www.seleniumhq.org/) for integration testing.
 Specifically, we use the
 [cucumber](https://github.com/selenium-cucumber/selenium-cucumber-java)
 framework.  See [the Selenium
-README](https://github.com/OpenTechStrategies/psm/blob/master/psm-app/integration-tests/README.md)
+README](https://github.com/SolutionGuidance/psm/blob/master/psm-app/integration-tests/README.md)
 for more details on how to set up and run these tests.
 
 To add a new Selenium test, do the following:
@@ -36,7 +36,7 @@ buttons in the `ui` subdirectory.
 4. Write the test in the `steps` subdirectory (being sure to import the
 `ui` file you created, if any).
 
-See [PR #348](https://github.com/OpenTechStrategies/psm/pull/348) for an
+See [PR #348](https://github.com/SolutionGuidance/psm/pull/348) for an
 example of adding a new Selenium test.
 
 ### Running Browser Tests
@@ -61,10 +61,10 @@ Labs account.
 ## API Tests
 
 See [the relevant
-README](https://github.com/OpenTechStrategies/psm/blob/master/etl/leie/README.mdwn)
+README](https://github.com/SolutionGuidance/psm/blob/master/etl/leie/README.mdwn)
 for details.  This set of tests uses `pytest`.  The full list of
 dependencies is in the LEIE API's README -- see the [Testing
-section](https://github.com/OpenTechStrategies/psm/blob/master/etl/leie/README.mdwn#Testing).
+section](https://github.com/SolutionGuidance/psm/blob/master/etl/leie/README.mdwn#Testing).
 To run the tests, get those dependencies and then do:
 
     $ cd {path-to-psm}/etl/leie
@@ -77,7 +77,7 @@ If you add new functionality to the ETL process, add a new test in
 
 We use [Spock](http://spockframework.org/) for our unit tests.
 Currently the framework is set up with a few example tests.  Look at [PR
-#253](https://github.com/OpenTechStrategies/psm/pull/253) to see where
+#253](https://github.com/SolutionGuidance/psm/pull/253) to see where
 to add one or more new unit tests in each of the subprojects.  To run
 the unit tests, do:
 
@@ -102,7 +102,7 @@ user-visible change, use
 [HTML_CodeSniffer](https://squizlabs.github.io/HTML_CodeSniffer/) as a
 bookmarklet in your browser. Choose "Section508" in the "Standards"
 dropdown [since that's the standard we need to comply
-with](https://github.com/OpenTechStrategies/psm/issues/415). [This
+with](https://github.com/SolutionGuidance/psm/issues/415). [This
 checklist](https://www.section508.gov/content/build/website-accessibility-improvement/major-web-issues)
 is useful to help you find major accessibility problems.
 

--- a/docs/handlebars.md
+++ b/docs/handlebars.md
@@ -56,7 +56,7 @@ Additional helpers can be implemented, however, this should not be necessary as 
 ## Particulars in converting from JSP
 
 ### 1. Page Context Data
-Data that is not part of the rendered model but accessed and used in JSP via separate taglibs like spring security tags will have to be added to the model. For example, this convenience method `addContextInfoToModel(ModelAndView model)` in [`ControllerHelper.java`](https://github.com/OpenTechStrategies/psm/blob/master/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java) should be used in each controller to add context data to the model passed to the view, for example in [UserController.java](https://github.com/OpenTechStrategies/psm/blob/3fd8a0a14fc802cb7a5061eddc5109c091ecb85d/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java]) we do
+Data that is not part of the rendered model but accessed and used in JSP via separate taglibs like spring security tags will have to be added to the model. For example, this convenience method `addContextInfoToModel(ModelAndView model)` in [`ControllerHelper.java`](https://github.com/SolutionGuidance/psm/blob/master/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java) should be used in each controller to add context data to the model passed to the view, for example in [UserController.java](https://github.com/SolutionGuidance/psm/blob/3fd8a0a14fc802cb7a5061eddc5109c091ecb85d/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java]) we do
 
 ```java
 model.addObject("user", user);

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
@@ -7,7 +7,7 @@
 --%>
 <!-- 
      Commenting this alert out for now, as per
-     github.com/OpenTechStrategies/psm/issues/53.
+     github.com/SolutionGuidance/psm/issues/53.
      We can put it back when a) we know how to
      conditionalize it on the presence of some
      actual "high"-risk provider in the pagination

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -79,7 +79,7 @@
 
           <%--
                              Commenting this alert out for now, as per
-                             github.com/OpenTechStrategies/psm/issues/53.
+                             github.com/SolutionGuidance/psm/issues/53.
                              We can put it back when a) we know how to
                              conditionalize it on the presence of some
                              actual "high"-risk provider in the pagination

--- a/psm-app/cms-web/WebContent/WEB-INF/spring-security.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/spring-security.xml
@@ -72,7 +72,7 @@
   <s:authentication-manager alias="authenticationManagerAlias">
     <s:authentication-provider ref="PrimaryDatabaseProvider"/>
     <!-- todo: dive deep into user authentication; see issue #34
-     https://github.com/OpenTechStrategies/psm/issues/34
+     https://github.com/SolutionGuidance/psm/issues/34
     <s:authentication-provider ref="PrimaryLdapProvider" />
     <s:authentication-provider ref="MNITSAuthenticationProvider" />
 -->

--- a/psm-app/cms-web/WebContent/templates/includes/footer.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/footer.template.html
@@ -1,4 +1,4 @@
 <div id="footer">
-  <strong>This module is open source.</strong>  <a href="https://github.com/OpenTechStrategies/psm">Contributions welcome</a>.
+  <strong>This module is open source.</strong>  <a href="https://github.com/SolutionGuidance/psm">Contributions welcome</a>.
 </div>
 <!-- #footer -->

--- a/psm-app/integration-tests/README.md
+++ b/psm-app/integration-tests/README.md
@@ -76,7 +76,7 @@ starting the gradle task like so:
 On Linux, the only way we've found to force an interactive Chrome session is
 to delete [the line in `build.gradle` in the test settings
 for
-`integration-tests`](https://github.com/OpenTechStrategies/psm/blob/master/psm-app/build.gradle#L264):
+`integration-tests`](https://github.com/SolutionGuidance/psm/blob/master/psm-app/build.gradle#L264):
 
 `environment "DISPLAY", System.getenv('XVFB_DISPLAY')`
 

--- a/psm-app/userhelp/README.mdwn
+++ b/psm-app/userhelp/README.mdwn
@@ -9,7 +9,7 @@ a good guide to our usage of Sphinx.
 We also publish HTML, PDF, and ePub versions of the PSM documentation
 on [our GitHub Pages site](https://opentechstrategies.github.io/psm/),
 and update those versions every few weeks (see [the GitHub
-issue](https://github.com/OpenTechStrategies/psm/issues/452)).
+issue](https://github.com/SolutionGuidance/psm/issues/452)).
 
 ## HTML generation
 

--- a/psm-app/userhelp/source/account-help.rst
+++ b/psm-app/userhelp/source/account-help.rst
@@ -69,7 +69,7 @@ Can I delete my account?
 ------------------------
 
 No, you cannot. `A future version of the PSM may let you do
-so. <https://github.com/OpenTechStrategies/psm/issues/327>`__
+so. <https://github.com/SolutionGuidance/psm/issues/327>`__
 
 I stopped using the PSM for a while and when I came back I had to log in again.  Is that normal?
 ------------------------------------------------------------------------------------------------

--- a/psm-app/userhelp/source/conf.py
+++ b/psm-app/userhelp/source/conf.py
@@ -50,7 +50,6 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Provider Screening Module user manual'
-copyright = u'2017, Open Tech Strategies, LLC'
 author = u'Open Tech Strategies, LLC'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -166,7 +165,7 @@ latex_toplevel_sectioning = 'chapter'
 # Bibliographic Dublin Core info.
 epub_title = "Provider Service Module user manual"
 epub_author = "Open Tech Strategies"
-epub_publisher = "Open Tech Strategies https://github.com/OpenTechStrategies/psm/"
+epub_publisher = "Solution Guidance Corporation https://github.com/SolutionGuidance/psm/"
 epub_copyright = copyright
 
 # The unique identifier of the text. This can be a ISBN number

--- a/psm-app/userhelp/source/enrollment.rst
+++ b/psm-app/userhelp/source/enrollment.rst
@@ -52,12 +52,12 @@ approved, and pending enrollments).
 A service agent or state Medicaid agency staffer can view all
 enrollments (including draft, rejected, approved, and pending
 enrollments). (`The PSM may limit this ability in a future
-version. <https://github.com/OpenTechStrategies/psm/issues/10>`__)
+version. <https://github.com/SolutionGuidance/psm/issues/10>`__)
 
 A system admin should not be able to view any enrollments. `The PSM
 currently allows a system admin to view enrollments, but will remove
 that capability in a future
-version. <https://github.com/OpenTechStrategies/psm/issues/10>`__
+version. <https://github.com/SolutionGuidance/psm/issues/10>`__
 
 Which enrollment information can a provider, service agent, or state Medicaid agency staffer modify or delete?
 --------------------------------------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ status of each enrollment.
 Right now, a provider does not receive any email notifications about
 their enrollment. (`A future version of the PSM will send email
 notifications to providers when the status of your enrollment
-changes. <https://github.com/OpenTechStrategies/psm/issues/341>`__)
+changes. <https://github.com/SolutionGuidance/psm/issues/341>`__)
 
 Can I create an enrollment for someone else?
 --------------------------------------------
@@ -111,7 +111,7 @@ How do I renew an enrollment or update an enrollment?
 
 Right now that's not something the PSM can do, but `it'll be possible in
 a future
-version. <https://github.com/OpenTechStrategies/psm/issues/401>`__
+version. <https://github.com/SolutionGuidance/psm/issues/401>`__
 
 Can I change something in a pending enrollment after I submit it?
 -----------------------------------------------------------------
@@ -125,7 +125,7 @@ How will I find out when my enrollment is accepted or rejected?
 Right now, this site does not notify you via email or paper mail when
 the state accepts or rejects an enrollment you have submitted. `This
 will change in a future version of the Provider Screening
-Module. <https://github.com/OpenTechStrategies/psm/issues/341>`__
+Module. <https://github.com/SolutionGuidance/psm/issues/341>`__
 
 When you log into the PSM, you'll see any enrollments you've submitted
 or saved as a draft. You'll be able to see the status of each
@@ -251,5 +251,5 @@ How do I end (terminate) my own active enrollment?
 
 Currently the PSM does not give you a way to terminate an approved
 enrollment, but `a future version of the PSM
-will <https://github.com/OpenTechStrategies/psm/issues/407>`__. Please
+will <https://github.com/SolutionGuidance/psm/issues/407>`__. Please
 contact the state Medicaid office directly to terminate an enrollment.

--- a/psm-app/userhelp/source/index.rst
+++ b/psm-app/userhelp/source/index.rst
@@ -8,12 +8,12 @@ Welcome to Provider Screening Module's documentation!
 
 This code is a work-in-progress and is not yet ready for production
 deployment. Please see `our code repository
-<https://github.com/OpenTechStrategies/psm/>`__
+<https://github.com/SolutionGuidance/psm/>`__
 for details, and check our current status.
 
 If you have suggestions for improving this user help guide, please add
 them `as comments on this issue
-<https://github.com/OpenTechStrategies/psm/issues/338>`__ or `as
+<https://github.com/SolutionGuidance/psm/issues/338>`__ or `as
 emails to this mailing list
 <https://groups.google.com/forum/#!forum/psm-dev>`__. Thank you!
 

--- a/psm-app/userhelp/source/provider-help.rst
+++ b/psm-app/userhelp/source/provider-help.rst
@@ -30,7 +30,7 @@ account; you will need to contact a system administrator at your state
 Medicaid office to do this.
 
 `A future version of the PSM will allow you to change your name in the
-system. <https://github.com/OpenTechStrategies/psm/issues/408>`__
+system. <https://github.com/SolutionGuidance/psm/issues/408>`__
 
 How do I update my contact information for an approved enrollment? Can I update it in one place for all my enrollments?
 -----------------------------------------------------------------------------------------------------------------------
@@ -38,7 +38,7 @@ How do I update my contact information for an approved enrollment? Can I update 
 Once an enrollment has been approved, you cannot change the contact
 information in it via this system (although `a future version of the PSM
 will allow you to do
-this <https://github.com/OpenTechStrategies/psm/issues/416>`__); please
+this <https://github.com/SolutionGuidance/psm/issues/416>`__); please
 contact the state Medicaid office directly.
 
 How do I update my license/certification information for an approved enrollment (e.g., if I have renewed my license)?
@@ -47,5 +47,5 @@ How do I update my license/certification information for an approved enrollment 
 Once an enrollment has been approved, you cannot change the license and
 certification information in it via this system (although `a future
 version of the PSM will allow you to do
-this <https://github.com/OpenTechStrategies/psm/issues/416>`__); please
+this <https://github.com/SolutionGuidance/psm/issues/416>`__); please
 contact the state Medicaid office directly.

--- a/psm-app/userhelp/source/service-agent-help.rst
+++ b/psm-app/userhelp/source/service-agent-help.rst
@@ -20,7 +20,7 @@ When the state accepts or rejects an enrollment I've submitted, how do I find ou
 Right now, this site does not notify you via email or paper mail when
 the state accepts or rejects an enrollment you have submitted. `This
 will change in a future version of the Provider Screening
-Module. <https://github.com/OpenTechStrategies/psm/issues/341>`__
+Module. <https://github.com/SolutionGuidance/psm/issues/341>`__
 
 When you log into the PSM, you'll see any enrollments you've submitted
 or started drafting via your PSM user account. You'll be able to see the
@@ -39,7 +39,7 @@ you can click on the draft enrollment and edit the provider's name. If
 you have already submitted the enrollment, then it is not possible to
 edit the provider's name. `A future version of the PSM will allow you to
 change a provider's name in the
-system. <https://github.com/OpenTechStrategies/psm/issues/408>`__
+system. <https://github.com/SolutionGuidance/psm/issues/408>`__
 
 Currently you cannot update multiple draft enrollments at once.
 
@@ -51,7 +51,7 @@ you can click on the draft enrollment and edit the provider's contact
 information. If you have already submitted the enrollment, then it is
 not possible to edit the provider's contact information. However, `a
 future version of the PSM will let you do
-this. <https://github.com/OpenTechStrategies/psm/issues/416>`__
+this. <https://github.com/SolutionGuidance/psm/issues/416>`__
 
 Currently you cannot update multiple draft enrollments at once.
 
@@ -61,12 +61,12 @@ How do I update the license/certification information for an approved enrollment
 Currently, the PSM does not allow you to update information for an
 approved enrollment. You'll need to contact the state Medicaid office
 directly. `A future version of the PSM will let you do
-this. <https://github.com/OpenTechStrategies/psm/issues/416>`__
+this. <https://github.com/SolutionGuidance/psm/issues/416>`__
 
 How do I terminate an enrollment (e.g., if a provider retires or dies)?
 -----------------------------------------------------------------------
 
 Currently the PSM does not give you a way to terminate an approved
 enrollment, but `a future version of the PSM
-will <https://github.com/OpenTechStrategies/psm/issues/407>`__. Please
+will <https://github.com/SolutionGuidance/psm/issues/407>`__. Please
 contact the state Medicaid office directly to terminate an enrollment.

--- a/psm-app/userhelp/source/system-admin-help.rst
+++ b/psm-app/userhelp/source/system-admin-help.rst
@@ -8,7 +8,7 @@ What's the difference among the different user roles?
 -----------------------------------------------------
 
 See the "User types" section of `the design overview
-<https://github.com/OpenTechStrategies/psm/blob/master/docs/DESIGN.md#user-content-user-types>`__
+<https://github.com/SolutionGuidance/psm/blob/master/docs/DESIGN.md#user-content-user-types>`__
 for the differences between providers, service agents, service admins,
 and system admins.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -121,14 +121,14 @@ pgrep mailcatcher > /dev/null || mailcatcher
 # codebase.  If we are, then cd to the dir above the git tree so we
 # can put wildfly in a dir that is parallel to the psm repo.
 pushd $(dirname $0) > /dev/null
-if git remote -v | grep -q "OpenTechStrategies/psm.git"; then
+if git remote -v | grep -q "SolutionGuidance/psm.git"; then
 	printf "Install script is in a PSM repo, so we'll use that repo for the install.\n"
 	cd $(git rev-parse --show-toplevel)
 	cd ..
 else
 	printf "Downloading the PSM from git.\n"
 	popd  > /dev/null
-	git clone https://github.com/OpenTechStrategies/psm.git
+	git clone https://github.com/SolutionGuidance/psm.git
 fi
 
 # Generate a password to use when passwords are needed and save to

--- a/scripts/push-javadoc-to-gh-pages.sh
+++ b/scripts/push-javadoc-to-gh-pages.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Adaptation of code from https://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
-if [ "$TRAVIS_REPO_SLUG" == "OpenTechStrategies/psm" ] \
+if [ "$TRAVIS_REPO_SLUG" == "SolutionGuidance/psm" ] \
        && [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] \
        && [ "$TRAVIS_PULL_REQUEST" == "false" ] \
        && [ "$TRAVIS_BRANCH" == "master" ]; then
@@ -14,7 +14,7 @@ if [ "$TRAVIS_REPO_SLUG" == "OpenTechStrategies/psm" ] \
 
   cd $HOME
   git clone --quiet --branch=gh-pages \
-      https://${GH_TOKEN}@github.com/OpenTechStrategies/psm gh-pages > /dev/null
+      https://${GH_TOKEN}@github.com/SolutionGuidance/psm gh-pages > /dev/null
 
   cd gh-pages
   git rm -rf ./javadoc

--- a/team-notes/meetings/20170427-tech-status/20170427-tech-status-meeting-notes.txt
+++ b/team-notes/meetings/20170427-tech-status/20170427-tech-status-meeting-notes.txt
@@ -10,7 +10,7 @@ Attendees: James, Dan, Karl, Jason, Cecilia
 
 * GitHub repos restructuring, and reflecting structure in README.md   
 ** DONE File a ticket about separating ext-srcs.                    :CECILIA:
-   https://github.com/OpenTechStrategies/psm/issues/11
+   https://github.com/SolutionGuidance/psm/issues/11
 * Any need for an Oracle DB server?
     - Dan points out that the process of getting WebSphere up (in the
       previous phase) was not easy
@@ -72,7 +72,7 @@ Attendees: James, Dan, Karl, Jason, Cecilia
     - Oracle dependencies
     - Find WebSphere 
 ** DONE Ticket this just for tracking                               :CECILIA:
-   https://github.com/OpenTechStrategies/psm/issues/12
+   https://github.com/SolutionGuidance/psm/issues/12
 ** DONE Karl to post on psm-dev about this                             :KARL:
 
 # Please leave this block here.  For people using Emacs Org Mode

--- a/team-notes/meetings/20170427-tech-status/20170427-tech-status-report.md
+++ b/team-notes/meetings/20170427-tech-status/20170427-tech-status-report.md
@@ -11,7 +11,7 @@
 
      (Note that we may later separate core and ext projects into two
      repositories.  For now, that idea is filed in
-     [github.com/OpenTechStrategies/psm/issues/11](https://github.com/OpenTechStrategies/psm/issues/11),
+     [github.com/SolutionGuidance/psm/issues/11](https://github.com/OpenTechStrategies/psm/issues/11),
      as it is not urgent and does not affect current development.)
 
 2. Jason: convert was-core to WildFly + PSQL and deploy on local or


### PR DESCRIPTION
In preparation for moving the repo to the SGC organization, change links
in docs.

There may be some trouble changing the Travis links, especially in the
`scripts` directory and in the image in the README.

Note that Zulip and IRC still refer to OTS.

@kfogel, please take a look at this.  This should *not* be merged until after the repo is moved to the SGC organization.