### PR TITLE
Fix duplicate ID for `Next` buttons (accessibility)

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
@@ -31,7 +31,7 @@
 
     <a href="javascript:submitFormById('enrollmentForm', '${prevPageUrl}')" class="greyBtn prevBtn"><span class="btR"><span class="btM"><span class="icon">Previous</span></span></span></a>
     <c:if test="${not isInSubmissionPage}">
-      <a id="nextBtn" class="greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
+      <a class="nextBtn greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
     </c:if>
     <c:if test="${isInSubmissionPage}">
       <a href="javascript:submitFormById('enrollmentForm', '${submitUrl}')" class="purpleBtn"><span class="btR"><span class="btM">Submit Enrollment</span></span></a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/select_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/select_type.jsp
@@ -19,7 +19,7 @@
     <div class="buttonBox">
       <input type="hidden" name="pageName" value="${pageName}"/>
       <c:url var="nextPageUrl" value="/provider/enrollment/steps/next" />
-      <a id="nextBtn" class="greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
+      <a class="nextBtn greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
     </div>
   </form>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary.jsp
@@ -10,7 +10,7 @@
   <c:url var="saveUrl" value="/provider/enrollment/save" />
 
   <a href="javascript:submitFormById('enrollmentForm', '${prevPageUrl}')" class="greyBtn prevBtn"><span class="btR"><span class="btM"><span class="icon">Previous</span></span></span></a>
-  <a id="nextBtn" class="greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
+  <a class="nextBtn greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
   <a href="javascript:submitFormById('enrollmentForm', '${saveUrl}')" class="greyBtn"><span class="btR"><span class="btM">Save as Draft</span></span></a>
   <a href="javascript:printThis();" class="greyBtn printModalBtn"><span class="btR"><span class="btM"><img src="<c:url value="/i/icon-print.png" />" alt=""/>Print</span></span></a>
 </div>
@@ -52,7 +52,7 @@
   <div class="buttonBox topButtonBox">
     <input type="hidden" name="pageName" value="${pageName}"/>
     <a href="javascript:submitFormById('enrollmentForm', '${prevPageUrl}')" class="greyBtn prevBtn"><span class="btR"><span class="btM"><span class="icon">Previous</span></span></span></a>
-    <a id="nextBtn" class="greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
+    <a class="nextBtn greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
     <a href="javascript:submitFormById('enrollmentForm', '${saveUrl}')" class="greyBtn"><span class="btR"><span class="btM">Save as Draft</span></span></a>
     <a href="javascript:printThis();" class="greyBtn printModalBtn"><span class="btR"><span class="btM"><img src="<c:url value="/i/icon-print.png" />" alt=""/>Print</span></span></a>
   </div>

--- a/psm-app/cms-web/WebContent/js/admin/script.js
+++ b/psm-app/cms-web/WebContent/js/admin/script.js
@@ -767,7 +767,7 @@ $(document).ready(function () {
   });
 
   //Next Button
-  $('#nextBtn').live('click', function () {
+  $('.nextBtn').live('click', function () {
     if ($('.flyout').is(':hidden')) {
       $('.flyout').show();
       if ($(this).offset().left + $('.flyout').width() > $('body').width() - 50) {
@@ -1011,61 +1011,61 @@ $(document).ready(function () {
   $('#urlRelead').live('change', function () {
     switch ($(this).val()){
     case 'Audiologist' :
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-audiologist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-audiologist-personal.html');
     break;
     case 'Certified Mental Health Rehab Prof':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Certified Professional Midwife':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Certified Registered Nurse Anesthetist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-certified-registered-nurse-anesthetists-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-certified-registered-nurse-anesthetists-personal.html');
     break;
     case 'Chiropractor':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Clinical Nurse Specialist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Community Health Care Worker':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-community-health-workers-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-community-health-workers-personal.html');
     break;
     case 'Dental Hygienist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Dentists':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Nurse':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Licensed Marriage and Family Therapist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Licensed Psychologist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-licensed-psychologist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-licensed-psychologist-personal.html');
     break;
     case 'PCA Individual':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Pharmacist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Physician':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Physician Assistant':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Physical Therapist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-physical-therapist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-physical-therapist-personal.html');
     break;
     case 'Podiatrist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-podiatrist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-podiatrist-personal.html');
     break;
     default:
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
   }
   });
 

--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -319,7 +319,7 @@ $(document).ready(function () {
   });
 
   //Next Button
-  $('#nextBtn').live('click', function () {
+  $('.nextBtn').live('click', function () {
     if ($('.flyout').is(':hidden')) {
       $('.flyout').show();
       if ($(this).offset().left + $('.flyout').width() > $('body').width() - 50) {
@@ -846,64 +846,64 @@ $(document).ready(function () {
   $('#urlRelead').live('change', function () {
     switch ($(this).val()){
     case 'Audiologist' :
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-audiologist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-audiologist-personal.html');
     break;
     case 'Certified Mental Health Rehab Prof':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Certified Professional Midwife':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Certified Registered Nurse Anesthetist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-certified-registered-nurse-anesthetists-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-certified-registered-nurse-anesthetists-personal.html');
     break;
     case 'Chiropractor':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Clinical Nurse Specialist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Community Health Care Worker':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-community-health-workers-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-community-health-workers-personal.html');
     break;
     case 'Dental Hygienist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Dentists':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Nurse':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Licensed Marriage and Family Therapist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Licensed Psychologist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-licensed-psychologist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-licensed-psychologist-personal.html');
     break;
     case 'PCA Individual':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Pharmacist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Physician':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Physician Assistant':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Physical Therapist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-physical-therapist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-physical-therapist-personal.html');
     break;
     case 'Podiatrist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-podiatrist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-podiatrist-personal.html');
     break;
     case 'Home Health Agency':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-required-home-health-agency.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-required-home-health-agency.html');
     break;
     default:
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
   }
   });
 

--- a/psm-app/cms-web/WebContent/js/system/script.js
+++ b/psm-app/cms-web/WebContent/js/system/script.js
@@ -298,7 +298,7 @@ $(document).ready(function () {
   });
 
   //Next Button
-  $('#nextBtn').live('click', function () {
+  $('.nextBtn').live('click', function () {
     if ($('.flyout').is(':hidden')) {
       $('.flyout').show();
       if ($(this).offset().left + $('.flyout').width() > $('body').width() - 50) {
@@ -542,61 +542,61 @@ $(document).ready(function () {
   $('#urlRelead').live('change', function () {
     switch ($(this).val()){
     case 'Audiologist' :
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-audiologist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-audiologist-personal.html');
     break;
     case 'Certified Mental Health Rehab Prof':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Certified Professional Midwife':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Certified Registered Nurse Anesthetist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-certified-registered-nurse-anesthetists-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-certified-registered-nurse-anesthetists-personal.html');
     break;
     case 'Chiropractor':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Clinical Nurse Specialist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Community Health Care Worker':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-community-health-workers-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-community-health-workers-personal.html');
     break;
     case 'Dental Hygienist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Dentists':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Nurse':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Licensed Marriage and Family Therapist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Licensed Psychologist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-licensed-psychologist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-licensed-psychologist-personal.html');
     break;
     case 'PCA Individual':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Pharmacist':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Physician':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Physician Assistant':
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
     break;
     case 'Physical Therapist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-physical-therapist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-physical-therapist-personal.html');
     break;
     case 'Podiatrist':
-      $('#nextBtn').attr('href', 'new-enrollment-no-payment-podiatrist-personal.html');
+      $('.nextBtn').attr('href', 'new-enrollment-no-payment-podiatrist-personal.html');
     break;
     default:
-      $('#nextBtn').attr('href', 'javascript:;');
+      $('.nextBtn').attr('href', 'javascript:;');
   }
   });
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
@@ -10,7 +10,7 @@ import static gov.medicaid.features.IntegrationTests.click;
 
 public class EnrollmentPage extends PageObject {
     public void clickNext() {
-        click(this, $("#nextBtn"));
+        click(this, $(".nextBtn"));
     }
 
     void setNoForRadioButton(String name) {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
@@ -176,7 +176,7 @@ public class IndividualSummaryPage extends PageObject {
     }
 
     public void clickNext() {
-        click(this, $("#nextBtn"));
+        click(this, $(".nextBtn"));
     }
 
     private String textOf(String xpathOrCssSelector) {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
@@ -56,7 +56,7 @@ public class LicenseInfoPage extends PageObject {
     }
 
     public void clickNext() {
-        click(this, $("#nextBtn"));
+        click(this, $(".nextBtn"));
         assertThat(getTitle()).contains("Practice Information");
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
@@ -50,7 +50,7 @@ public class PersonalInfoPage extends PageObject {
     }
 
     public void clickNext() {
-        click(this, $("#nextBtn"));
+        click(this, $(".nextBtn"));
     }
 
     public void checkForTooYoungError() throws Exception {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
@@ -99,6 +99,6 @@ public class PracticeInfoPage extends PageObject {
     }
 
     public void clickNext() {
-        click(this, $("#nextBtn"));
+        click(this, $(".nextBtn"));
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
@@ -16,7 +16,7 @@ public class DashboardPage extends PageObject {
     }
 
     public void clickNext() {
-        click(this, $("#nextBtn"));
+        click(this, $(".nextBtn"));
     }
 
 }


### PR DESCRIPTION
Convert `nextBtn` from an HTML/CSS ID to a class throughout the app (templates, JavaScript files, and integration tests). This allows more than one `Next` button on a page without duplicate IDs (which is an accessibility problem).

There is currently only one page with two `nextBtn` instances, the Summary page in the enrollment workflow.  

Tested by running Selenium web UI tests, and by manually checking the two next buttons on the Summary page before and after the change and by using browser dev tools to confirm that the same "click" event listener function is being attached to both next buttons before and after the change.

Resolves #516: duplicate ID for Next button on Summary...