### PR TITLE
WIP: Set up automated tests for accessibility

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
@@ -21,6 +21,36 @@ public class IntegrationTests {
     public static final DateTimeFormatter DATE_FORMATTER =
             DateTimeFormatter.ofPattern("MM/dd/yyyy");
 
+    public static final String ACCESSIBILITY_SNIFFER = "(function() {\n" +
+            "    var _p = '//squizlabs.github.io/HTML_CodeSniffer/build/';\n" +
+            "    var _i = function(s, cb) {\n" +
+            "        var sc = document.createElement('script');\n" +
+            "        sc.onload = function() {\n" +
+            "            sc.onload = null;\n" +
+            "            sc.onreadystatechange = null;\n" +
+            "            cb.call(this);\n" +
+            "        };\n" +
+            "        sc.onreadystatechange = function() {\n" +
+            "            if (/^(complete|loaded)$/.test(this.readyState) === true) {\n" +
+            "                sc.onreadystatechange = null;\n" +
+            "                sc.onload();\n" +
+            "            }\n" +
+            "        };\n" +
+            "        sc.src = s;\n" +
+            "        if (document.head) {\n" +
+            "            document.head.appendChild(sc);\n" +
+            "        } else {\n" +
+            "            document.getElementsByTagName('head')[0].appendChild(sc);\n" +
+            "        }\n" +
+            "    };\n" +
+            "    var options = {\n" +
+            "        path: _p\n" +
+            "    };\n" +
+            "    _i(_p + 'HTMLCS.js', function() {\n" +
+            "        HTMLCSAuditor.run('WCAG2AA', null, options);\n" +
+            "    });\n" +
+            "})();";
+
     public static String format(LocalDate date) {
         return date.format(DATE_FORMATTER);
     }
@@ -28,5 +58,10 @@ public class IntegrationTests {
     public static void click(PageObject pageObject, WebElement target) {
         pageObject.evaluateJavascript("arguments[0].scrollIntoView()", target);
         pageObject.clickOn(target);
+    }
+
+    public static void accessibilitySniffer(PageObject pageObject) {
+        pageObject.evaluateJavascript(ACCESSIBILITY_SNIFFER);
+
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
@@ -15,6 +15,11 @@ public class LoginStepDefinitions {
         loginPage.open();
     }
 
+    @Then("^I should have no accessibility issues$")
+    public void i_should_have_no_accessibility_issues() {
+        loginPage.checkAccessibility();
+    }
+
     @Given("^I enter my username and password$")
     public void i_enter_my_username_and_password()  {
         loginPage.enterProviderCredentials();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
@@ -4,10 +4,35 @@ import net.thucydides.core.pages.PageObject;
 import net.thucydides.core.annotations.DefaultUrl;
 
 import static gov.medicaid.features.IntegrationTests.click;
+import static gov.medicaid.features.IntegrationTests.accessibilitySniffer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DefaultUrl("http://localhost:8080/cms")
 public class LoginPage extends PageObject {
+
+    public void checkAccessibility() {
+        accessibilitySniffer(this);
+
+        // We need to wait for the widget to load/update before accessing it.
+        // TODO: This is a bad way to wait for the widget to refresh.
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        $("#HTMLCS-settings-use-standard-select").selectByVisibleText("WCAG2AA");
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        String errorCount = $("#HTMLCS-settings-issue-count > .HTMLCS-error > .HTMLCS-tile-text strong").getText();
+
+        assertThat(errorCount).isEqualTo("0");
+    }
 
     public void enterProviderCredentials() {
         $("#username").sendKeys("p1");

--- a/psm-app/integration-tests/src/test/resources/features/general/login.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/login.feature
@@ -8,3 +8,6 @@ Feature: Log into the Application as Provider
     When I click on Login
     Then I should see my dashboard page
 
+  Scenario:
+    Given I have the application open in my browser
+    Then I should have no accessibility issues


### PR DESCRIPTION
This is a proof of concept.  A new test checks the login page using the "WCAG2AA" accessibility standard and successfully detects that the number of errors are more than 0.

Still to do:
- Find a better way to wait for the widget to load/refresh.  The existing wait-and-retry mechanisms in the `$` helper do not handle this case and lead to unsuccessful results.  (See http://www.seleniumhq.org/exceptions/stale_element_reference.jsp)
- How to organize the accessibility tests for the whole site?  Would be nice to be able to run them with their own command like `./gradlew accessibility-tests:test`.

Issue #518: Implement accessibility checking in CI