### PR TITLE
Link to GitHub Pages site in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ and design assumptions.
 The [psm-app](psm-app) subdirectory holds the source code to the PSM
 proper.
 
+[solutionguidance.github.io](https://solutionguidance.github.io/psm/)
+is our GitHub Pages site, where we publish the user manual as well as
+documentation for the PSM's web API.
+
 The `ext-sources-app` subdirectory has been removed.  It held the source
 code to the semi-separate middleware application that provided a service
 wrapper around external data sources.  This will be replaced as

--- a/psm-app/userhelp/README.mdwn
+++ b/psm-app/userhelp/README.mdwn
@@ -7,7 +7,8 @@ Sphinx](https://docs.readthedocs.io/en/latest/getting_started.html) is
 a good guide to our usage of Sphinx.
 
 We also publish HTML, PDF, and ePub versions of the PSM documentation
-to a GitHub Pages site that is updated every few weeks (see [the GitHub
+to [a GitHub Pages site](https://solutionguidance.github.io/psm/) that
+is updated every few weeks (see [the GitHub
 issue](https://github.com/SolutionGuidance/psm/issues/452)).
 
 ## HTML generation

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,10 @@ administrators or our build systems.
   to install the PSM.
 * `push-javadoc-to-gh-pages.sh` lets TravisCI build our automated API
   documentation using Javadoc and push it to the `gh-pages` branch,
-  which can automatically update a GitHub Pages site.
+  which can automatically update [our GitHub Pages
+  site](https://solutionguidance.github.io/psm/). It's [currently
+  under
+  construction](https://github.com/solutionguidance/psm/pull/478).
 * `drools-microservice.sh` sets up a copy of jBPM and Guvnor on a
   standalone server, which the core application can then be configured
   to communicate with.


### PR DESCRIPTION
Now that https://solutionguidance.github.io/psm/ is running, undo some changes from 8bd39161c65cff0016f6a2e57ab802647c152740 and link to site in relevant READMEs.

I've checked out how the Markdown renders [via the GitHub web UI for my branch](https://github.com/brainwane/psm/tree/link-to-gh-pages) and as a technical matter I'm confident in this branch; I'm filing the PR to ensure there are a few more eyes on it before I merge it tomorrow, in case there are issues around wording.