### PR TITLE
Add HTML comments to easily identify source JSP templates

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Register"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Registration Complete"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Dashboard"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/error.jsp
@@ -9,6 +9,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Error" />
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/help.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/help.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Help"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/help_detail.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/help_detail.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Help"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/header.jsp
@@ -9,6 +9,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <head>
     <meta http-equiv="Content-Type"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screening_log.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screening_log.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_help_item.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_help_item.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_help_items.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_help_items.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_help_item.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_help_item.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
@@ -8,6 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Category of Service"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Category of Service"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Status Query"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_advanced.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_advanced.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Advanced Search"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_approved.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_approved.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_draft.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_draft.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_notes.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_notes.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_pending.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_pending.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_print.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_print.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_quick.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_quick.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Search Results"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_rejected.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_rejected.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
@@ -7,6 +7,7 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="View Enrollment - ${profile.status.description}"/>
   <c:set var="adminPage" value="true" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -7,6 +7,7 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <c:choose>
   <c:when test="${principalUser ne null}">
+    <!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
     <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
       <c:set var="title" value="Server Error"/>
       <h:handlebars template="includes/html_head" context="${pageContext}"/>
@@ -65,6 +66,7 @@
   </c:when>
   <c:otherwise>
     <%@page import="org.springframework.security.web.WebAttributes"%>
+    <!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
     <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
       <c:set var="title" value="Login"/>
       <c:set var="ctx" value="${pageContext.request.contextPath}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Forgot Password"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Login"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Login"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Welcome"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Welcome"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -4,6 +4,7 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Dashboard"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -4,6 +4,7 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Dashboard"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -4,6 +4,7 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -4,6 +4,7 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Import Profiles"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Confirm Action"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Import Profiles"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+<!-- <c:out value="${pageScope['javax.servlet.jsp.jspPage']}"></c:out> -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set var="title" value="Link Account"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>


### PR DESCRIPTION
The comments are automatically generated, for all top-level JSP templates.  This makes it easy to `view page source` in a browser and determine the top-level template that generated the page.