### PR TITLE
Upgrade hapi-fhir to 3.1.0

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 }
 
 def jbpm_version = '5.4.0.Final'
+def hapi_fhir_version = '3.1.0'
 def spring_core_version = '4.3.12.RELEASE'
 def spring_security_version = '4.2.3.RELEASE'
 def serenity_version = '1.5.5'
@@ -25,7 +26,8 @@ ext.libs = [
     commons_io: 'commons-io:commons-io:2.6',
     commons_lang: 'commons-lang:commons-lang:2.6',
     commons_lang3: 'org.apache.commons:commons-lang3:3.7',
-    hapi_fhir: 'ca.uhn.hapi.fhir:hapi-fhir-client-okhttp:2.5',
+    hapi_fhir: "ca.uhn.hapi.fhir:hapi-fhir-client-okhttp:${hapi_fhir_version}",
+    hapi_fhir_structures: "ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:${hapi_fhir_version}",
     handlebars: 'com.github.jknack:handlebars:4.0.6',
     handlebars_springmvc: 'com.github.jknack:handlebars-springmvc:4.0.6',
     itext: 'com.lowagie:itext:2.1.7',
@@ -137,6 +139,7 @@ project(':cms-business-process') {
         compile libs.commons_lang
         compile libs.commons_lang3
         compile libs.hapi_fhir
+        compile libs.hapi_fhir_structures
         compile libs.itext
         compile libs.jbpm_human_task_core
         compile libs.spring_security_core
@@ -243,6 +246,7 @@ project(':cms-portal-services') {
         earlib libs.commons_lang
         earlib libs.commons_lang3
         earlib libs.hapi_fhir
+        earlib libs.hapi_fhir_structures
         earlib libs.itext
         earlib libs.jasypt
         earlib libs.jbpm_human_task_core

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ExcludedProvidersScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ExcludedProvidersScreeningHandler.java
@@ -17,10 +17,10 @@
 package gov.medicaid.process.enrollment;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.client.IGenericClient;
-import ca.uhn.fhir.rest.client.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
 import ca.uhn.fhir.rest.gclient.StringClientParam;
-import ca.uhn.fhir.rest.server.EncodingEnum;
 import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.EnrollmentProcess;
 import gov.medicaid.domain.model.ExternalSourcesScreeningResultType;


### PR DESCRIPTION
We use the [hapi-fhir library](http://hapifhir.io/) to communicate with our LEIE API. Version 3 was a major upgrade with several package and dependency changes, but aside from accomdating those, none of our code needed updating.

In order to test this, I had to fix (temporarily) #546 by giving the system administrator full permissions again:

<details>
  <summary>git diff (24 lines)</summary>

```diff
diff --git a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
index bbb423f..eb37585 100644
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -77,7 +77,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -107,8 +106,9 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     /**
      * List of roles with full access to all profiles and tickets.
      */
-    private static final List<String> FULL_ACCESS = Collections.singletonList(
-            ViewStatics.ROLE_SERVICE_ADMINISTRATOR
+    private static final List<String> FULL_ACCESS = Arrays.asList(
+            ViewStatics.ROLE_SERVICE_ADMINISTRATOR,
+            ViewStatics.ROLE_SYSTEM_ADMINISTRATOR
     );
 
     /**
```
</details>

It is not yet obvious that this is the fix we're going to go with, but we wanted to get this upgrade done as part of #16.

So, after making that change, I was able to resubmit a previous enrollment that I'd created with an excluded provider, and verified that the PSM checked the LEIE, found the exclusions for that provider, and recorded them in the screening log. I also resubmitted an enrollment without an exclusion, and verified that the LEIE API was checked and no records were matched.

Issue #16 Manage sets of dependencies via Gradle or another tool