### PR TITLE
Fix missing "change password" link for providers

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
@@ -12,6 +12,8 @@ import javax.validation.constraints.NotNull;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
+import static gov.medicaid.entities.SystemId.CMS_ONLINE;
+
 public class HandlebarsInterceptor extends HandlerInterceptorAdapter {
     @Override
     public void postHandle(
@@ -50,6 +52,13 @@ public class HandlebarsInterceptor extends HandlerInterceptorAdapter {
                 );
             }
 
+            if (CMS_ONLINE.equals(principal.getAuthenticatedBySystem())) {
+                modelAndView.addObject(
+                        "isInternalUser",
+                        true
+                );
+            }
+
             // <sec:authentication property="principal.loginDate" var="loginDate"/>
             // <fmt:setLocale value="en_US" scope="session"/>
             // Last login: <fmt:formatDate value="${loginDate}" pattern="EEEE, d MMMM yyyy hh:mm:ss a zzz"/>
@@ -61,12 +70,6 @@ public class HandlebarsInterceptor extends HandlerInterceptorAdapter {
                     "loginDate",
                     dateFormat.format(principal.getLoginDate())
             );
-
-            // TODO for provider/profile/list template of MyProfileController
-            // <sec:authentication property="principal.authenticatedBySystem" var="authenticatedBySystem"/>
-            // <sec:authentication property="principal" var="requestPrincipal"/>
-            // <spring:eval expression="authenticatedBySystem == T(gov.medicaid.entities.SystemId).CMS_ONLINE" var="isInternalUser" />
-            // if (principal.authenticatedBySystem == gov.medicaid.entities.SystemId.CMS_ONLINE) model.addObject("isInternalUser", true);
         }
     }
 }


### PR DESCRIPTION
The "change password" link is hidden behind a check that the user is an internal user, as the PSM is not able to change the password for, eg, users that signed in via LDAP. The variable that was set was accidentally removed but not replaced in PR #538 as part of the switch to handlebars.

Set the `isInternalUser` variable in the interceptor, so that it is available to JSPs and Handlebars templates alike. (It is currently only used in one place.)

I tested this by logging in as a provider and verifying that the link was present on the My Profile page, for both a provider with approved enrollments and one without.

Issue #238 Templatize UI
PR #538 Use handlebars header, footer, logo, and nav templates in JSP templates