### PR TITLE
Fix button accessibility where there are more than one submit button per form

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -31,7 +31,10 @@
 
           <div class="tabSection">
 
-            <form action="<c:url value="/provider/enrollment/steps/rebind" />" id="changeProviderTypeForm" method="post" enctype="multipart/form-data">
+            <form action="<c:url value="/provider/enrollment/steps/rebind" />"
+                id="changeProviderTypeForm"
+                method="post"
+                enctype="multipart/form-data">
               <sec:csrfInput />
               <c:if test="${isReopened}">
                 <div class="detailPanel" style="width: 940px;">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -100,6 +100,13 @@
             <%@include file="/WEB-INF/pages/provider/enrollment/steps/errors.jsp" %>
 
             <!-- /.detailPanel -->
+            <form action="<c:url value="/provider/enrollment/page" />"
+                  id="enrollmentForm"
+                  method="post"
+                  enctype="multipart/form-data">
+              <sec:csrfInput />
+              <input type="hidden" name="pageName" value="${pageName}"/>
+
             <div class="tabHead" style="width: 958px;">
               <div class="tabR">
                 <div class="tabM">
@@ -145,9 +152,7 @@
               <!-- /.requiredInfo -->
 
               <div class="editTabWrapper">
-                <form action="" id="enrollmentForm" method="post" enctype="multipart/form-data">
-                  <sec:csrfInput />
-                  <input type="hidden" name="pageName" value="${pageName}"/>
+
                   <c:choose>
                     <c:when test="${viewModel.currentTab eq 'Notes'}">
                       <%@include file="/WEB-INF/pages/provider/notes.jsp" %>
@@ -162,7 +167,6 @@
                       </c:forEach>
                     </c:otherwise>
                   </c:choose>
-                </form>
                 <div class="br"></div>
                 <div class="bl"></div>
               </div>
@@ -171,59 +175,44 @@
                 <c:when test="${viewModel.currentTab eq 'Notes'}">
                   <div class="buttonBox">
                     <c:url var="cancelUrl" value="/provider/search/pending?statuses=Pending&showFilterPanel=true"/>
-                    <c:url var="submitUrl" value="/provider/enrollment/saveNote"/>
                     <a class="greyBtn" href="${cancelUrl}">
                       <span class="btR">
                         <span class="btM">Cancel</span>
                       </span>
                     </a>
-                    <a href="javascript:submitFormById('enrollmentForm', '${submitUrl}')" class="purpleBtn">
-                      <span class="btR">
-                        <span class="btM">Save Note</span>
-                      </span>
-                    </a>
+                    <button class="purpleBtn" type="submit" name="saveNote">
+                      Save Note
+                    </button>
                   </div>
                 </c:when>
                 <c:when test="${isReopened}">
                   <div class="buttonBox">
-                    <c:url var="resubmitUrl" value="/provider/enrollment/resubmitWithChanges"/>
                     <c:url var="cancelUrl" value="/provider/search/pending?statuses=Pending&showFilterPanel=true"/>
-
                     <a class="greyBtn" href="${cancelUrl}">
                       <span class="btR">
                         <span class="btM">Cancel</span>
                       </span>
                     </a>
-                    <a href="javascript:submitFormById('enrollmentForm', '${resubmitUrl}')" class="purpleBtn">
-                      <span class="btR">
-                        <span class="btM">Re-Submit Enrollment</span>
-                      </span>
-                    </a>
+                    <button class="purpleBtn" type="submit" name="resubmitWithChanges" />
+                      Re-Submit Enrollment
+                    </button>
                   </div>
                 </c:when>
                 <c:otherwise>
                   <div class="buttonBox">
                     <input type="hidden" name="pageName" value="${pageName}"/>
-                    <c:url var="saveUrl" value="/provider/enrollment/save"/>
-                    <c:url var="submitUrl" value="/provider/enrollment/submit"/>
                     <c:url var="cancelUrl" value="/provider/dashboard/drafts"/>
-                    <c:url var="prevPageUrl" value="/provider/enrollment/steps/prev"/>
-
                     <a class="greyBtn" href="${cancelUrl}">
                       <span class="btR">
                         <span class="btM">Cancel</span>
                       </span>
                     </a>
-                    <a href="javascript:submitFormById('enrollmentForm', '${submitUrl}')" class="purpleBtn">
-                      <span class="btR">
-                        <span class="btM">Submit Enrollment</span>
-                      </span>
-                    </a>
-                    <a href="javascript:submitFormById('enrollmentForm', '${saveUrl}')" class="greyBtn">
-                      <span class="btR">
-                        <span class="btM">Save as Draft</span>
-                      </span>
-                    </a>
+                    <button class="purpleBtn" type="submit" name="submit">
+                      Submit Enrollment
+                    </button>
+                    <button class="greyBtn" type="submit" name="save">
+                      Save as Draft
+                    </button>
                   </div>
                 </c:otherwise>
               </c:choose>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
@@ -9,7 +9,10 @@
 </div>
 <!-- /.requiredInfo -->
 
-<form action="" id="enrollmentForm" method="post" enctype="multipart/form-data">
+<form action="<c:url value="/provider/enrollment/page" />"
+      id="enrollmentForm"
+      method="post"
+      enctype="multipart/form-data">
   <sec:csrfInput />
   <!-- /.errorInfo -->
   <%@include file="/WEB-INF/pages/provider/enrollment/steps/errors.jsp" %>
@@ -24,19 +27,23 @@
 
   <div class="buttonBox">
     <input type="hidden" name="pageName" value="${pageName}"/>
-    <c:url var="saveUrl" value="/provider/enrollment/save" />
-    <c:url var="submitUrl" value="/provider/enrollment/submit" />
-    <c:url var="nextPageUrl" value="/provider/enrollment/steps/next" />
-    <c:url var="prevPageUrl" value="/provider/enrollment/steps/prev" />
 
-    <a href="javascript:submitFormById('enrollmentForm', '${prevPageUrl}')" class="greyBtn prevBtn"><span class="btR"><span class="btM"><span class="icon">Previous</span></span></span></a>
+    <button type="submit" class="greyBtn prevBtn" name="previous">
+      <span class="icon">Previous</span>
+    </button>
     <c:if test="${not isInSubmissionPage}">
-      <a class="nextBtn greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
+      <button type="submit" class="nextBtn greyBtn" name="next">
+        <span class="icon">Next</span>
+      </button>
     </c:if>
     <c:if test="${isInSubmissionPage}">
-      <a href="javascript:submitFormById('enrollmentForm', '${submitUrl}')" class="purpleBtn"><span class="btR"><span class="btM">Submit Enrollment</span></span></a>
+      <button type="submit" class="purpleBtn" name="submit">
+        Submit Enrollment
+      </button>
     </c:if>
-    <a href="javascript:submitFormById('enrollmentForm', '${saveUrl}')" class="greyBtn"><span class="btR"><span class="btM">Save as Draft</span></span></a>
+    <button type="submit" class="greyBtn" name="save">
+      Save as Draft
+    </button>
   </div>
   <!-- /.buttonBox -->
 </form>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/select_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/select_type.jsp
@@ -1,7 +1,9 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 <div class="tabSection">
-  <form action="" id="enrollmentForm" method="post">
+  <form action="<c:url value="/provider/enrollment/steps/next" />"
+        id="enrollmentForm"
+        method="post">
     <sec:csrfInput />
     <%@include file="/WEB-INF/pages/provider/enrollment/steps/errors.jsp" %>
 
@@ -18,8 +20,7 @@
 
     <div class="buttonBox">
       <input type="hidden" name="pageName" value="${pageName}"/>
-      <c:url var="nextPageUrl" value="/provider/enrollment/steps/next" />
-      <a class="nextBtn greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
+      <button type="submit" class="nextBtn greyBtn"><span class="icon">Next</span></button>
     </div>
   </form>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary.jsp
@@ -3,21 +3,25 @@
 
 <div class="clearFixed"></div>
 <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp" %>
-
-<div class="buttonBox topButtonBox">
-  <c:url var="nextPageUrl" value="/provider/enrollment/steps/next" />
-  <c:url var="prevPageUrl" value="/provider/enrollment/steps/prev" />
-  <c:url var="saveUrl" value="/provider/enrollment/save" />
-
-  <a href="javascript:submitFormById('enrollmentForm', '${prevPageUrl}')" class="greyBtn prevBtn"><span class="btR"><span class="btM"><span class="icon">Previous</span></span></span></a>
-  <a class="nextBtn greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
-  <a href="javascript:submitFormById('enrollmentForm', '${saveUrl}')" class="greyBtn"><span class="btR"><span class="btM">Save as Draft</span></span></a>
-  <a href="javascript:printThis();" class="greyBtn printModalBtn"><span class="btR"><span class="btM"><img src="<c:url value="/i/icon-print.png" />" alt=""/>Print</span></span></a>
-</div>
-
-<!-- /.buttonBox -->
-<form action="" id="enrollmentForm" method="post" enctype="multipart/form-data">
+<form action="<c:url value="/provider/enrollment/page" />"
+    id="enrollmentForm"
+    method="post"
+    enctype="multipart/form-data">
   <sec:csrfInput />
+  <div class="buttonBox topButtonBox">
+    <button class="greyBtn prevBtn" type="submit" name="previous">
+      <span class="icon">Previous</span>
+    </button>
+    <button class="nextBtn greyBtn" type="submit" name="next">
+      <span class="icon">Next</span>
+    </button>
+    <button class="greyBtn" type="submit" name="save">
+      Save as Draft
+    </button>
+    <a href="javascript:printThis();" class="greyBtn printModalBtn"><span class="btR"><span class="btM"><img src="<c:url value="/i/icon-print.png" />" alt=""/>Print</span></span></a>
+  </div>
+
+  <!-- /.buttonBox -->
   <div class="personalPanel summaryPageWrapper">
     <c:set var="afterSummary" value="${false}"></c:set>
     <c:forEach var="tabName" items="${viewModel.tabNames}" varStatus="status">
@@ -51,9 +55,15 @@
 
   <div class="buttonBox topButtonBox">
     <input type="hidden" name="pageName" value="${pageName}"/>
-    <a href="javascript:submitFormById('enrollmentForm', '${prevPageUrl}')" class="greyBtn prevBtn"><span class="btR"><span class="btM"><span class="icon">Previous</span></span></span></a>
-    <a class="nextBtn greyBtn" href="javascript:submitFormById('enrollmentForm', '${nextPageUrl}')"><span class="btR"><span class="btM"><span class="icon">Next</span></span></span></a>
-    <a href="javascript:submitFormById('enrollmentForm', '${saveUrl}')" class="greyBtn"><span class="btR"><span class="btM">Save as Draft</span></span></a>
+    <button class="greyBtn prevBtn" type="submit" name="previous">
+      <span class="icon">Previous</span>
+    </button>
+    <button class="nextBtn greyBtn" type="submit" name="next">
+      <span class="icon">Next</span>
+    </button>
+    <button class="greyBtn" type="submit" name="save">
+      Save as Draft
+    </button>
     <a href="javascript:printThis();" class="greyBtn printModalBtn"><span class="btR"><span class="btM"><img src="<c:url value="/i/icon-print.png" />" alt=""/>Print</span></span></a>
   </div>
   <!-- /.buttonBox -->

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -464,7 +464,6 @@ public class EnrollmentPageFlowController extends BaseController {
      *
      * @param enrollment the current enrollment model
      * @param request    the request
-     * @param model      the request model
      * @return the previous page, or the same page if there were errors
      * @throws PortalServiceException for any errors encountered
      * @endpoint "provider/enrollment/steps/prev"
@@ -473,8 +472,7 @@ public class EnrollmentPageFlowController extends BaseController {
     @RequestMapping(value = "/steps/prev", method = RequestMethod.POST)
     public ModelAndView previousPage(
             @ModelAttribute("enrollment") EnrollmentType enrollment,
-            HttpServletRequest request,
-            Model model
+            HttpServletRequest request
     ) throws PortalServiceException {
         String[] formNames = request.getParameterValues("formNames");
         String pageName = request.getParameter("pageName");
@@ -496,7 +494,6 @@ public class EnrollmentPageFlowController extends BaseController {
      *
      * @param enrollment the current enrollment model
      * @param request    the request
-     * @param model      the request model
      * @return the next page, or the same page if there were errors
      * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/enrollment/steps/next"
@@ -505,8 +502,7 @@ public class EnrollmentPageFlowController extends BaseController {
     @RequestMapping(value = "/steps/next", method = RequestMethod.POST)
     public ModelAndView nextPage(
             @ModelAttribute("enrollment") EnrollmentType enrollment,
-            HttpServletRequest request,
-            Model model
+            HttpServletRequest request
     ) throws PortalServiceException {
         String pageName = request.getParameter("pageName");
         String[] formNames = request.getParameterValues("formNames");
@@ -608,6 +604,35 @@ public class EnrollmentPageFlowController extends BaseController {
             @ModelAttribute("enrollment") EnrollmentType enrollment
     ) throws PortalServiceException {
         return showPage(enrollment.getProgressPage(), enrollment);
+    }
+
+    /**
+     * Handles requests where request parameters indicate the destination page.
+     *
+     * @param enrollment the current enrollment model
+     * @param request    the request
+     * @param status     the session status
+     * @return the destination page
+     * @throws PortalServiceException for any errors encountered
+     * @endpoint "provider/enrollment/steps/page"
+     * @verb POST
+     */
+    @RequestMapping(value = "/page", method = RequestMethod.POST)
+    public ModelAndView submitStepForm(
+            @ModelAttribute("enrollment") EnrollmentType enrollment,
+            HttpServletRequest request,
+            SessionStatus status
+    ) throws PortalServiceException {
+        if (null != request.getParameter("previous")) {
+            return previousPage(enrollment, request);
+        } else if (null != request.getParameter("next")) {
+            return nextPage(enrollment, request);
+        } else if (null != request.getParameter("submit")) {
+            return submit(enrollment, request, status);
+        } else if (null != request.getParameter("save")) {
+            return save(enrollment, request, status);
+        }
+        throw new PortalServiceException("Submit action not recognized");
     }
 
     /**
@@ -982,7 +1007,6 @@ public class EnrollmentPageFlowController extends BaseController {
      * @param enrollment the current enrollment model
      * @param request    the request
      * @param status     the session status
-     * @param model      the request model
      * @return the same page, with a success/error message
      * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/enrollment/save"
@@ -992,7 +1016,6 @@ public class EnrollmentPageFlowController extends BaseController {
     public ModelAndView save(
             @ModelAttribute("enrollment") EnrollmentType enrollment,
             HttpServletRequest request,
-            Model model,
             SessionStatus status
     ) throws PortalServiceException {
         String pageName = request.getParameter("pageName");
@@ -1039,7 +1062,6 @@ public class EnrollmentPageFlowController extends BaseController {
      *
      * @param enrollment the current enrollment model
      * @param request    the request
-     * @param model      the request model
      * @param status     the session status
      * @return the same page, with a success/error message
      * @throws PortalServiceException for any errors encountered
@@ -1050,7 +1072,6 @@ public class EnrollmentPageFlowController extends BaseController {
     public ModelAndView submit(
             @ModelAttribute("enrollment") EnrollmentType enrollment,
             HttpServletRequest request,
-            Model model,
             SessionStatus status
     ) throws PortalServiceException {
         String pageName = request.getParameter("pageName");

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -631,6 +631,10 @@ public class EnrollmentPageFlowController extends BaseController {
             return submit(enrollment, request, status);
         } else if (null != request.getParameter("save")) {
             return save(enrollment, request, status);
+        } else if (null != request.getParameter("saveNote")) {
+            return saveNote(enrollment, request, status);
+        } else if (null != request.getParameter("resubmitWithChanges")) {
+            return resubmitWithChanges(enrollment, request, status);
         }
         throw new PortalServiceException("Submit action not recognized");
     }
@@ -957,7 +961,6 @@ public class EnrollmentPageFlowController extends BaseController {
      * @param enrollment the current enrollment model
      * @param request    the request
      * @param status     the session status
-     * @param model      the request model
      * @return the same page, with a success/error message
      * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/enrollment/saveNote"
@@ -967,7 +970,6 @@ public class EnrollmentPageFlowController extends BaseController {
     public ModelAndView saveNote(
             @ModelAttribute("enrollment") EnrollmentType enrollment,
             HttpServletRequest request,
-            Model model,
             SessionStatus status
     ) throws PortalServiceException {
         CMSPrincipal principal = ControllerHelper.getPrincipal();
@@ -1125,7 +1127,6 @@ public class EnrollmentPageFlowController extends BaseController {
      *
      * @param enrollment the current enrollment model
      * @param request    the request
-     * @param model      the request model
      * @param status     the session status
      * @return the same page, with a success/error message
      * @throws PortalServiceException for any errors encountered
@@ -1136,7 +1137,6 @@ public class EnrollmentPageFlowController extends BaseController {
     public ModelAndView resubmitWithChanges(
             @ModelAttribute("enrollment") EnrollmentType enrollment,
             HttpServletRequest request,
-            Model model,
             SessionStatus status
     ) throws PortalServiceException {
         String pageName = request.getParameter("pageName");


### PR DESCRIPTION
Fixes the accessibility of submit buttons for forms with multiple submit buttons (and/or use the JS function `submitFormById` with two arguments).  These forms/buttons are found on these pages:
 -  the provider enrollment steps pages, e.g. the `Previous`, `Next`, `Save as Draft` buttons
 -  the `Edit Enrollment` page.  Log in as a service admin, click enrollments tab, click pending tab, click `edit` link for one of the items in the list.  The buttons are the navigation tabs `Personal Info`, `License Info` etc. and two at the bottom `Re-Submit Enrollment` and `Save Note`.   (This is the `edit_details.jsp` template.)

We stop using the JS function `submitFormById` and instead use parameters in the request that is sent when the buttons are clicked.  Then we use a new Java method to determine the destination page/url from the data in the parameters.

Tested by manually filling out a provider enrollment and editing an enrollment as a service admin, and confirming the buttons work as expected.  (Note that currently to test `Re-Submit Enrollment` you need to apply the changes described in the diff in the description of PR #560, as described there.)  The web UI tests also run successfully.

One similar form (in `provider/profile/list.jsp`) will be fixed separately, as suggested by @jasonaowen in Issue #553.  

Thanks @jasonaowen for helping with the fix for these.

Issue #553 Use accessible submit buttons on all forms