### PR TITLE
Use action links in table rows on `My Profile` page

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -36,14 +36,10 @@
               <table cellpadding="0" cellspacing="0" class="generalTable">
                 <thead>
                   <tr>
-                    <th class="alignCenter">NPI / UMPI<span class="sep"></span>
-                    </th>
-                    <th class="alignCenter">Provider Type<span class="sep"></span>
-                    </th>
-                    <th class="alignCenter">Last Modified On<span class="sep"></span>
-                    </th>
-                    <th class="alignCenter">Action<span class="sep"></span>
-                    </th>
+                    <th>NPI / UMPI<span class="sep"></span></th>
+                    <th>Provider Type<span class="sep"></span></th>
+                    <th>Last Modified On<span class="sep"></span></th>
+                    <th class="alignCenter">Action<span class="sep"></span></th>
                   </tr>
                 </thead>
                 <tbody>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -30,54 +30,54 @@
 
           <div class="dashboardPanel">
             <div class="tableData">
-                <div class="tableTitle">
-                  <h2>Profiles</h2>
-                </div>
-                <table cellpadding="0" cellspacing="0" class="generalTable">
-                  <thead>
+              <div class="tableTitle">
+                <h2>Profiles</h2>
+              </div>
+              <table cellpadding="0" cellspacing="0" class="generalTable">
+                <thead>
+                  <tr>
+                    <th class="alignCenter">NPI / UMPI<span class="sep"></span>
+                    </th>
+                    <th class="alignCenter">Provider Type<span class="sep"></span>
+                    </th>
+                    <th class="alignCenter">Last Modified On<span class="sep"></span>
+                    </th>
+                    <th class="alignCenter">Action<span class="sep"></span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <c:forEach var="profile" items="${profiles}">
+                    <c:url var="viewProfileLink" value="/provider/enrollment/profile">
+                      <c:param name="id" value="${profile.profileId}"/>
+                    </c:url>
+                    <c:url var="editProfileLink" value="/provider/profile/edit">
+                      <c:param name="profileId" value="${profile.profileId}"/>
+                    </c:url>
+                    <c:url var="renewProfileLink" value="/provider/profile/renew">
+                      <c:param name="profileId" value="${profile.profileId}"/>
+                    </c:url>
                     <tr>
-                      <th class="alignCenter">NPI / UMPI<span class="sep"></span>
-                      </th>
-                      <th class="alignCenter">Provider Type<span class="sep"></span>
-                      </th>
-                      <th class="alignCenter">Last Modified On<span class="sep"></span>
-                      </th>
-                      <th class="alignCenter">Action<span class="sep"></span>
-                      </th>
+                      <td><c:out value="${profile.npi}"/></td>
+                      <td><c:out value="${profile.providerType}"/></td>
+                      <td><fmt:formatDate value="${profile.lastModifiedDate}" pattern="MM/dd/yyyy"/></td>
+                      <td class="alignCenter">
+                        <a href="${viewProfileLink}">View</a><span class="sep">|</span>
+                        <a href="${editProfileLink}">Edit</a><span class="sep">|</span>
+                        <a href="${renewProfileLink}">Renew</a>
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    <c:forEach var="profile" items="${profiles}">
-                      <c:url var="viewProfileLink" value="/provider/enrollment/profile">
-                        <c:param name="id" value="${profile.profileId}"/>
-                      </c:url>
-                      <c:url var="editProfileLink" value="/provider/profile/edit">
-                        <c:param name="profileId" value="${profile.profileId}"/>
-                      </c:url>
-                      <c:url var="renewProfileLink" value="/provider/profile/renew">
-                        <c:param name="profileId" value="${profile.profileId}"/>
-                      </c:url>
-                      <tr>
-                        <td><c:out value="${profile.npi}"/></td>
-                        <td><c:out value="${profile.providerType}"/></td>
-                        <td><fmt:formatDate value="${profile.lastModifiedDate}" pattern="MM/dd/yyyy"/></td>
-                        <td class="alignCenter">
-                          <a href="${viewProfileLink}">View</a><span class="sep">|</span>
-                          <a href="${editProfileLink}">Edit</a><span class="sep">|</span>
-                          <a href="${renewProfileLink}">Renew</a>
-                        </td>
-                      </tr>
-                    </c:forEach>
-                    <c:if test="${empty profiles}">
-                      <tr>
-                        <td colspan="4">No profiles found.</td>
-                      </tr>
-                    </c:if>
-                  </tbody>
-                </table>
-                <div class="clearFixed"></div>
-                <div class="tl"></div>
-                <div class="tr"></div>
+                  </c:forEach>
+                  <c:if test="${empty profiles}">
+                    <tr>
+                      <td colspan="4">No profiles found.</td>
+                    </tr>
+                  </c:if>
+                </tbody>
+              </table>
+              <div class="clearFixed"></div>
+              <div class="tl"></div>
+              <div class="tr"></div>
             </div>
             <!-- /.tableData -->
             <div class="sideBar">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -30,24 +30,19 @@
 
           <div class="dashboardPanel">
             <div class="tableData">
-              <form id="myProfilesForm" action="" method="get">
-                <sec:csrfInput />
                 <div class="tableTitle">
                   <h2>Profiles</h2>
                 </div>
                 <table cellpadding="0" cellspacing="0" class="generalTable">
                   <thead>
                     <tr>
-                      <c:if test="${not empty profiles}">
-                        <th class="alignCenter">
-                          <span class="sep"></span>
-                        </th>
-                      </c:if>
                       <th class="alignCenter">NPI / UMPI<span class="sep"></span>
                       </th>
                       <th class="alignCenter">Provider Type<span class="sep"></span>
                       </th>
                       <th class="alignCenter">Last Modified On<span class="sep"></span>
+                      </th>
+                      <th class="alignCenter">Action<span class="sep"></span>
                       </th>
                     </tr>
                   </thead>
@@ -56,20 +51,26 @@
                       <c:url var="viewProfileLink" value="/provider/enrollment/profile">
                         <c:param name="id" value="${profile.profileId}"/>
                       </c:url>
+                      <c:url var="editProfileLink" value="/provider/profile/edit">
+                        <c:param name="profileId" value="${profile.profileId}"/>
+                      </c:url>
+                      <c:url var="renewProfileLink" value="/provider/profile/renew">
+                        <c:param name="profileId" value="${profile.profileId}"/>
+                      </c:url>
                       <tr>
-                        <td class="alignCenter">
-                          <input type="radio" name="profileId" value="${profile.profileId}"/>
-                        </td>
-                        <td>
-                          <a href="${viewProfileLink}"><c:out value="${profile.npi}"/></a>
-                        </td>
+                        <td><c:out value="${profile.npi}"/></td>
                         <td><c:out value="${profile.providerType}"/></td>
                         <td><fmt:formatDate value="${profile.lastModifiedDate}" pattern="MM/dd/yyyy"/></td>
+                        <td class="alignCenter">
+                          <a href="${viewProfileLink}">View</a><span class="sep">|</span>
+                          <a href="${editProfileLink}">Edit</a><span class="sep">|</span>
+                          <a href="${renewProfileLink}">Renew</a>
+                        </td>
                       </tr>
                     </c:forEach>
                     <c:if test="${empty profiles}">
                       <tr>
-                        <td colspan="3">No profiles found.</td>
+                        <td colspan="4">No profiles found.</td>
                       </tr>
                     </c:if>
                   </tbody>
@@ -77,7 +78,6 @@
                 <div class="clearFixed"></div>
                 <div class="tl"></div>
                 <div class="tr"></div>
-              </form>
             </div>
             <!-- /.tableData -->
             <div class="sideBar">
@@ -110,22 +110,6 @@
               </div>
             </div>
             <!-- /.sideBar -->
-
-            <div class="tableDataButtons buttonBox">
-              <c:url var="editProfileLink" value="/provider/profile/edit"></c:url>
-              <c:url var="renewProfileLink" value="/provider/profile/renew"></c:url>
-              <a href="javascript:submitFormById('myProfilesForm', '${renewProfileLink}');" class="purpleBtn">
-                <span class="btR">
-                  <span class="btM">Renew Enrollment</span>
-                </span>
-              </a>
-              <a href="javascript:submitFormById('myProfilesForm', '${editProfileLink}');" class="purpleBtn">
-                <span class="btR">
-                  <span class="btM">Edit Profile</span>
-                </span>
-              </a>
-            </div>
-            <!-- /.tableDataButtons -->
           </div>
           <!-- /.dashboardPanel -->
         </div>


### PR DESCRIPTION
As described in @jasonaowen 's comment in issue #553 , on the `My Profile` page, this PR adds `View | Edit | Renew` links to a new column in the table and removes the radio buttons column, the form, and the submit buttons at the bottom of the page.  This better approach follows similar tables in the PSM and solves the issue with needing accessible submit buttons on the page.

Tested by logging in as a provider, clicking on the My Profile tab, and testing that the new links in the table work as expected.  (If you need to add profiles to that table for testing, submit an enrollment and then approve the enrollment.)

Screenshots before:

![my-profile-radio-buttons](https://user-images.githubusercontent.com/1091693/33957327-538bf3f4-e00f-11e7-8348-c315082568a6.png)

and after (with different profiles in the list):

![screenshot-2017-12-13 import profiles](https://user-images.githubusercontent.com/1091693/33957350-5e8e549a-e00f-11e7-88cb-02ed5d102245.png)

Issue #553 Use accessible submit buttons on all forms