### PR TITLE
Fix check for pending enrollments

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -2194,12 +2194,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
                 throw new PortalServiceException("No such profile.");
             }
 
-            // check if anyone has a pending submission for the same profile
-            ProviderSearchCriteria criteria = new ProviderSearchCriteria();
-            criteria.setProfileId(profileId);
-            criteria.setStatuses(Arrays.asList(ViewStatics.PENDING_STATUS));
-            SearchResult<UserRequest> results = searchTickets(getSystemUser(), criteria);
-            if (results.getTotal() > 0) {
+            if (profileHasPendingSubmission(profileId)) {
                 return Validity.SUPERSEDED;
             }
 
@@ -2212,6 +2207,14 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         }
         // new enrollments are always valid for submission
         return Validity.VALID;
+    }
+
+    private boolean profileHasPendingSubmission(long profileId) throws PortalServiceException {
+        ProviderSearchCriteria criteria = new ProviderSearchCriteria();
+        criteria.setProfileId(profileId);
+        criteria.setStatuses(Arrays.asList(ViewStatics.PENDING_STATUS));
+        SearchResult<UserRequest> results = searchTickets(getSystemUser(), criteria);
+        return results.getTotal() > 0;
     }
 
     @Override


### PR DESCRIPTION
After an enrollment has been approved, either the provider or an admin can edit or renew it. Providers can do this from the My Profile page; admins can do this from the approved enrollments tab.

The PSM does not allow a provider or an admin to submit a new enrollment based on an existing profile (read: approved enrollment) if there is already such a pending enrollment. In particular, if an admin renews or updates an enrollment, but does not review and approve or deny it, the provider cannot then go and also submit a renewal or update.

Or at least, this worked until #524. When we removed the `SYSTEM` role from the list of roles that have full access, we broke the pending enrollment check, because it searches using the system user - which no longer has access.

Fix the pending enrollment check.

---

I tested this by renewing a profile as an admin, logging is as a provider, and trying to update it. Upon submission, I got the desired error message of

>    There is a pending request for the same profile. Submission will not be allowed unless the other request is denied.

---

Issue #546 Post processing fails on submitted enrollment applications