### PR TITLE
Fix JS click handlers for some former <a href="javascript:;"> buttons

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
@@ -68,7 +68,7 @@
                   </div>
                   <div class="buttons">
                     <a href="${ctx}/admin/viewAgreementDocuments" class="cancelAddAgreementBtn greyBtn"><span class="btR"><span class="btM">Cancel</span></span></a>
-                    <button class="saveAgreementDocumentBtn greyBtn" type="submit">Save</button>
+                    <button class="greyBtn" type="submit">Save</button>
                   </div>
                 </div>
               </form:form>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_help_item.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_help_item.jsp
@@ -71,7 +71,7 @@
                         <c:when test="${helpItem.id==0}"><a href="${ctx}/admin/searchHelp" class="greyBtn"><span class="btR"><span class="btM">Cancel</span></span></a></c:when>
                         <c:otherwise><a href="${ctx}/admin/getHelpItem?helpItemId=${helpItem.id}" class="greyBtn"><span class="btR"><span class="btM">Cancel</span></span></a></c:otherwise>
                         </c:choose>
-                        <button class="saveHelpTopicBtn greyBtn" type="submit">Save</button>
+                        <button class="greyBtn" type="submit">Save</button>
                       </div>
                   </div>
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
@@ -78,8 +78,8 @@
                     <div class="br"></div>
                   </div>
                   <div class="buttons">
-                    <a href="${ctx}/admin/getScreeningSchedule" class="greyBtn canceleScheduleBtn"><span class="btR"><span class="btM">Cancel</span></span></a>
-                    <button class="greyBtn saveScheduleBtn">Save</button>
+                    <a href="${ctx}/admin/getScreeningSchedule" class="greyBtn"><span class="btR"><span class="btM">Cancel</span></span></a>
+                    <button class="greyBtn saveScheduleBtn" type="submit">Save</button>
                   </div>
                 </div>
               </form:form>

--- a/psm-app/cms-web/WebContent/js/admin/script.js
+++ b/psm-app/cms-web/WebContent/js/admin/script.js
@@ -544,7 +544,8 @@ $(document).ready(function () {
         });
   });
 
-  $('.saveScheduleBtn').live('click', function () {
+  $('.saveScheduleBtn').click(function (event) {
+    event.preventDefault();
     var upcomingScreeningDateDatePart = $("#upcomingScreeningDateDatePart").val();
     var upcomingScreeningDateHourPart = $("#upcomingScreeningDateHourPart").val();
     var upcomingScreeningDateMinutePart = $("#upcomingScreeningDateMinutePart").val();

--- a/psm-app/cms-web/WebContent/js/admin/script.js
+++ b/psm-app/cms-web/WebContent/js/admin/script.js
@@ -355,7 +355,9 @@ $(document).ready(function () {
           }
         }
     });
-  $(".saveProviderTypeBtn").click(function () {
+  $(".saveProviderTypeBtn").click(function (event) {
+    event.preventDefault();
+
     if ($("#addTypeRadio1").is(":checked")) {
       $("#paymentRequiredField").val("true");
     } else {
@@ -1580,9 +1582,6 @@ $(document).ready(function () {
   }
 
   /* END OF SERVICE AGENT SCRIPT -------------------------------------------------- */
-  $('#saveUserBtn').click(function () {
-    $('#userForm').submit();
-  });
 
   $("#helpTopicForm").validate({
         rules: {
@@ -1597,9 +1596,6 @@ $(document).ready(function () {
 
         }
       });
-  $(".saveHelpTopicBtn").click(function () {
-    $("#helpTopicForm").submit();
-  });
 
   $("#agreementDocumentForm").validate({
         rules: {
@@ -1614,10 +1610,6 @@ $(document).ready(function () {
 
         }
       });
-
-  $(".saveAgreementDocumentBtn").click(function () {
-    $("#agreementDocumentForm").submit();
-  });
 
   $('.deleteHelpTopicBtn').live('click', function () {
     loadModal('#deleteHelpTopicModal');

--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -1427,11 +1427,6 @@ $(document).ready(function () {
     $('#changeScreenSchedulePanel').show();
   });
 
-  $('.canceleScheduleBtn,.saveScheduleBtn').live('click', function () {
-      $('#changeScreenSchedulePanel').hide();
-      $('#screenSchedulePanel').show();
-    });
-
   $('.addHelpTopicBtn').live('click', function () {
       $('#helpTopicsPanel').hide();
       $('#viewHelpTopicPanel').hide();

--- a/psm-app/cms-web/WebContent/js/system/script.js
+++ b/psm-app/cms-web/WebContent/js/system/script.js
@@ -1152,11 +1152,6 @@ $(document).ready(function () {
     $('#changeScreenSchedulePanel').show();
   });
 
-  $('.canceleScheduleBtn,.saveScheduleBtn').live('click', function () {
-    $('#changeScreenSchedulePanel').hide();
-    $('#screenSchedulePanel').show();
-  });
-
   $('.addHelpTopicBtn').live('click', function () {
     $('#helpTopicsPanel').hide();
     $('#viewHelpTopicPanel').hide();

--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
@@ -73,7 +73,7 @@
             </div>
             <div class="buttonBox">
               <a href="{{ctx}}/ops/getUser" class="greyBtn"><span class="btR"><span class="btM">Cancel</span></span></a>
-              <button id="saveUserBtn" class="purpleBtn" type="submit">Save</button>
+              <button class="purpleBtn" type="submit">Save</button>
             </div>
             <!-- /.buttonBox -->
           </form>


### PR DESCRIPTION
Following up PR#567, this PR removes JS click handlers when no longer needed, or adds `event.preventDefault()` to the click handlers to prevent duplicated submits.

Web UI tests pass and manually clicking some of the buttons works.

Issue #553 Use accessible submit buttons on all forms