### PR TITLE
Fix accessibility of submit buttons that call JS functions

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -116,11 +116,7 @@
                     <span class="btM">Cancel</span>
                   </span>
                 </a>
-                <a href="javascript:submitFormById('registrationform');" class="purpleBtn">
-                  <span class="btR">
-                    <span class="btM">Register</span>
-                  </span>
-                </a>
+                <button class="purpleBtn" type="submit">Register</button>
               </div>
               <!-- /.buttonBox -->
             </form:form>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
@@ -103,7 +103,7 @@
               </div>
               <div class="buttonBox">
                 <a href="${ctx}/provider/search/approved?statuses=Approved&showFilterPanel=true" class="greyBtn"><span class="btR"><span class="btM"><span class="text">Cancel</span></span></span></a>
-                <a href="javascript:;" onclick="submitCosForm();" class="greyBtn"><span class="btR"><span class="btM"><span class="text">Save</span></span></span></a>
+                <button class="greyBtn submitCosFormBtn" type="submit">Save</button>
               </div>
             </form>
           </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
@@ -103,7 +103,7 @@
               </div>
               <div class="buttonBox">
                 <a href="${ctx}/provider/search/approved?statuses=Approved&showFilterPanel=true" class="greyBtn"><span class="btR"><span class="btM"><span class="text">Cancel</span></span></span></a>
-                <a href="javascript:;" onclick="submitCosForm();" class="greyBtn"><span class="btR"><span class="btM"><span class="text">Save</span></span></span></a>
+                <button class="greyBtn submitCosFormBtn" type="submit">Save</button>
               </div>
             </form>
           </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -241,7 +241,7 @@
               </div>
               <div class="buttonBox">
                 <a href="${ctx}/provider/search/pending?statuses=Pending&showFilterPanel=true" class="greyBtn"><span class="btR"><span class="btM"><span class="text">Cancel</span></span></span></a>
-                <a href="javascript:;" onclick="submitFormById('approvalForm');" class="greyBtn"><span class="btR"><span class="btM"><span class="text">Approve</span></span></span></a>
+                <button class="greyBtn" type="submit">Approve</button>
                 <a href="${ctx}/agent/enrollment/rejectTicket?id=${id}" class="greyBtn"><span class="btR"><span class="btM"><span class="text">Reject</span></span></span></a>
                 <a href="${ctx}/provider/enrollment/reopen?id=${id}" class="greyBtn"><span class="btR"><span class="btM"><span class="text">Modify</span></span></span></a>
               </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
@@ -80,11 +80,7 @@
                     <span class="btM">Cancel</span>
                   </span>
                 </a>
-                <a href="javascript:submitFormById('passwordForm');" class="purpleBtn">
-                  <span class="btR">
-                    <span class="btM">Reset Password</span>
-                  </span>
-                </a>
+                <button class="purpleBtn" type="submit">Reset Password</button>
               </div>
               <!-- /.buttonBox -->
             </form:form>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
@@ -16,7 +16,7 @@
         <form:hidden path="pageNumber" />
         <form:hidden path="sortColumn" />
         <form:hidden path="ascending" />
-        
+
         <div class="leftCol">
             <div class="row">
                 <label>NPI/UMPI</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
@@ -82,6 +82,6 @@
             </div>
         </div>
     </div>
-    <a href="javascript:submitFormById('paginationForm');" class="purpleBtn"><span class="btR"><span class="btM">Filter</span></span></a>
+    <button class="purpleBtn" type="submit">Filter</button>
 </div>
 </form:form>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -145,11 +145,7 @@
                       </div>
                     </div>
                   </div>
-                  <a href="javascript:submitFormById('paginationForm');" class="purpleBtn">
-                    <span class="btR">
-                      <span class="btM">Filter</span>
-                    </span>
-                  </a>
+                  <button class="purpleBtn" type="submit">Filter</button>
                 </div>
               </form:form>
               <!-- /.filterPanel -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
@@ -24,10 +24,10 @@
     <div class="modal-content">
       <div class="right">
         <div class="middle">
-          <div class="searchRow">
-            <c:url var="lookupUrl" value="/provider/enrollment/lookup" />
-            <form action="${lookupUrl}" id="practiceLookupForm">
-              <sec:csrfInput />
+          <c:url var="lookupUrl" value="/provider/enrollment/lookup" />
+          <form action="${lookupUrl}" id="practiceLookupForm">
+            <sec:csrfInput />
+            <div class="searchRow">
               <span>
                 <label>Practice Name:</label>
                 <input type="hidden" name="agency" value="false"/>
@@ -50,11 +50,11 @@
                 <input type="text" class="normalInput inputS zipInputFor" name="zip"/>
               </span>
               <div class="clear"></div>
-            </form>
-          </div>
-          <div class="buttonArea">
-            <a href="javascript:performPracticeLookup();" class="purpleBtn searchBtn"><span class="btR"><span class="btM"><span class="icon">Search</span></span></span></a>
-          </div>
+            </div>
+            <div class="buttonArea">
+              <button class="purpleBtn searchBtn performPracticeLookupBtn" type="submit"><span class="icon">Search</span></button>
+            </div>
+          </form>
           <div class="tableContainer hide">
             <p><strong id="practiceLookupMatches">5 matching practices found:</strong></p>
             <table cellpadding="0" cellspacing="0" class="generalTable tablesorter" id="draftTable">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
@@ -86,11 +86,7 @@
                         <span class="btM">Cancel</span>
                       </span>
                     </a>
-                    <a href="javascript:submitFormById('accountLinkForm');" class="purpleBtn">
-                      <span class="btR">
-                        <span class="btM">Get Profiles</span>
-                      </span>
-                    </a>
+                    <button class="purpleBtn" type="submit">Get Profiles</button>
                   </div>
                 </div>
                 <!-- /.section -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -79,42 +79,42 @@
                 <div class="tl"></div>
                 <div class="tr"></div>
               </div>
-            <!-- /.tableData -->
-            <div class="sideBar">
-              <div class="notificationsPanel panel">
-                <div class="panelHeader">
-                  <h2>Help</h2>
+              <!-- /.tableData -->
+              <div class="sideBar">
+                <div class="notificationsPanel panel">
+                  <div class="panelHeader">
+                    <h2>Help</h2>
+                  </div>
+                  <div class="panelSection">
+                    <ul>
+                      <li>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+                          dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                        </p>
+                      </li>
+                    </ul>
+                  </div>
+                  <div class="tl"></div>
+                  <div class="tr"></div>
                 </div>
-                <div class="panelSection">
-                  <ul>
-                    <li>
-                      <p>
-                        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-                        dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-                      </p>
-                    </li>
-                  </ul>
-                </div>
-                <div class="tl"></div>
-                <div class="tr"></div>
               </div>
-            </div>
-            <!-- /.sideBar -->
+              <!-- /.sideBar -->
 
-            <div class="tableDataButtons buttonBox">
-              <a href="<c:url value="/provider/dashboard/setup" />" class="greyBtn">
-                <span class="btR">
-                  <span class="btM">Cancel</span>
-                </span>
-              </a>
-              <c:if test="${not empty profiles}">
-                <button class="purpleBtn" type="submit">Import Selected</button>
-              </c:if>
-              <c:if test="${empty profiles}">
-                <h:create-enrollment-button cssClass="purpleBtn"/>
-              </c:if>
-            </div>
-            <!-- /.tableDataButtons -->
+              <div class="tableDataButtons buttonBox">
+                <a href="<c:url value="/provider/dashboard/setup" />" class="greyBtn">
+                  <span class="btR">
+                    <span class="btM">Cancel</span>
+                  </span>
+                </a>
+                <c:if test="${not empty profiles}">
+                  <button class="purpleBtn" type="submit">Import Selected</button>
+                </c:if>
+                <c:if test="${empty profiles}">
+                  <h:create-enrollment-button cssClass="purpleBtn"/>
+                </c:if>
+              </div>
+              <!-- /.tableDataButtons -->
             </form>
           </div>
           <!-- /.dashboardPanel -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -30,9 +30,9 @@
           <h:handlebars template="includes/flash" context="${pageContext}"/>
 
           <div class="dashboardPanel">
-            <div class="tableData">
-              <form id="importProfilesForm" action="<c:url value="/provider/onboarding/list" />" method="post">
-                <sec:csrfInput />
+            <form id="importProfilesForm" action="<c:url value="/provider/onboarding/list" />" method="post">
+              <sec:csrfInput />
+              <div class="tableData">
                 <div class="tableTitle">
                   <h2>Profiles</h2>
                 </div>
@@ -78,8 +78,7 @@
                 <div class="clearFixed"></div>
                 <div class="tl"></div>
                 <div class="tr"></div>
-              </form>
-            </div>
+              </div>
             <!-- /.tableData -->
             <div class="sideBar">
               <div class="notificationsPanel panel">
@@ -109,17 +108,14 @@
                 </span>
               </a>
               <c:if test="${not empty profiles}">
-                <a href="javascript:submitFormById('importProfilesForm');" class="purpleBtn">
-                  <span class="btR">
-                    <span class="btM">Import Selected</span>
-                  </span>
-                </a>
+                <button class="purpleBtn" type="submit">Import Selected</button>
               </c:if>
               <c:if test="${empty profiles}">
                 <h:create-enrollment-button cssClass="purpleBtn"/>
               </c:if>
             </div>
             <!-- /.tableDataButtons -->
+            </form>
           </div>
           <!-- /.dashboardPanel -->
         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
@@ -86,11 +86,7 @@
                         <span class="btM">Cancel</span>
                       </span>
                     </a>
-                    <a href="javascript:submitFormById('passwordForm');" class="purpleBtn">
-                      <span class="btR">
-                        <span class="btM">Update</span>
-                      </span>
-                    </a>
+                    <button class="purpleBtn" type="submit">Update</button>
                   </div>
                 </div>
                 <!-- /.section -->

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -3372,7 +3372,8 @@ a.searchBtn span.btM{
   padding-bottom:15px;
   text-align:center;
 }
-#new-modal .inner .buttonArea a{
+#new-modal .inner .buttonArea a,
+#new-modal .inner .buttonArea button {
   float:none;
   display:inline-block;
 }

--- a/psm-app/cms-web/WebContent/js/admin/script.js
+++ b/psm-app/cms-web/WebContent/js/admin/script.js
@@ -1096,6 +1096,22 @@ $(document).ready(function () {
     }
   });
 
+  // Submit COS Form
+  $('.submitCosFormBtn').click(function submitCosForm (event) {
+    event.preventDefault();
+    // validate
+    if ($('#startDate').val().trim().length == 0) {
+      $('#startDate').addClass('errorInput');
+      alert('Start Date is required');
+      return false;
+    }
+    if ($('#cosSelect').val() == null || $('#cosSelect').val().length == 0) {
+      alert('Please select at least one COS');
+      return false;
+    }
+    submitFormById('cosForm');
+  });
+
   /* START OF SERVICE AGENT SCRIPT ------------------------------------------------ */
 
   /*
@@ -1685,22 +1701,6 @@ function renewSelections(url) {
       }
     });
   }
-}
-
-function submitCosForm() {
-  // validate
-  if ($('#startDate').val().trim().length == 0) {
-    $('#startDate').addClass('errorInput');
-    alert('Start Date is required');
-    return false;
-  }
-
-  if ($('#cosSelect').val() == null || $('#cosSelect').val().length == 0) {
-    alert('Please select at least one COS');
-    return false;
-  }
-
-  submitFormById('cosForm');
 }
 
 function copyCOS(id) {

--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -932,6 +932,33 @@ $(document).ready(function () {
       }
     });
 
+  // Practice Lookup
+  $('.performPracticeLookupBtn').click(function performPracticeLookup (event) {
+    event.preventDefault();
+
+    var $form = $("#practiceLookupForm");
+    $('#practiceLookupForm input[name="agency"]').val(isAgencyLookup);
+
+    postJson({
+      url: $form.attr("action"),
+      async: false, // we are in modal anyway
+      data: $form.serialize(),
+      success: function (response, textStatus, jqXHR) {
+        practiceLookupResults = response;
+      },
+
+      error: function (jqXHR, textStatus, errorThrown) {
+        alert("There was an error encountered while performing lookup.");
+      }
+    });
+
+    populatePracticeLookupResults();
+
+    $('#practiceLookupModal .tableContainer').show();
+    repositionModal();
+  });
+
+
   /* START OF SERVICE AGENT SCRIPT ------------------------------------------------ */
 
   $('#draftEnrollmentTable').tablesorter({
@@ -2161,29 +2188,6 @@ function postJson(settings) {
     },
   })
   $.ajax(settings);
-}
-
-function performPracticeLookup() {
-  var $form = $("#practiceLookupForm");
-  $('#practiceLookupForm input[name="agency"]').val(isAgencyLookup);
-
-  postJson({
-    url: $form.attr("action"),
-    async: false, // we are in modal anyway
-    data: $form.serialize(),
-    success: function (response, textStatus, jqXHR) {
-      practiceLookupResults = response;
-    },
-
-    error: function (jqXHR, textStatus, errorThrown) {
-      alert("There was an error encountered while performing lookup.");
-    }
-  });
-
-  populatePracticeLookupResults();
-
-  $('#practiceLookupModal .tableContainer').show();
-  repositionModal();
 }
 
 function populatePracticeLookupResults() {


### PR DESCRIPTION
Fixes accessibility of submit buttons for forms where the buttons were directly making JS function calls such as `submitFormById` from their `href` or `onclick` attributes.  (As opposed to calling JS functions that were attached as a click handler to the `click` event.)

Tested by logging in as admin, navigating to the Category of Service page and confirming that the `Save` button on that page works.  The Web UI tests also pass.

Issue #553 Use accessible submit buttons on all forms