### PR TITLE
System admin advanced search and filter buttons

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
@@ -94,7 +94,7 @@
               </div>
               <div class="clearFixed"></div>
               <div class="buttons">
-                  <a href="javascript:;" class="purpleBtn advancedSearchBtn"><span class="btR"><span class="btM"><span class="icon">Search</span><span class="arrow"></span></span></span></a>
+                <button class="purpleBtn" type="submit"><span class="icon">Search</span><span class="arrow"></span></button>
               </div>
           </form:form>
         <!-- /.tabSection -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/filter-panel.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/filter-panel.jsp
@@ -47,6 +47,6 @@
     <form:hidden id="searchBox" path="searchBox" />
     <input type="hidden" id="initSearchBox" name="initSearchBox" value="false" />
     <form:hidden id="roles" path="roles"/>
-    <button id="filterBtn" class="purpleBtn" type="submit">Filter</button>
+    <button class="purpleBtn" type="submit">Filter</button>
 </form:form>
 <!-- /.filterPanel -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_advanced.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_advanced.jsp
@@ -115,7 +115,7 @@
             </div>
             <div class="clearFixed"></div>
             <div class="buttons">
-              <a id="showSearchEnrollmentsResultBtn" href="javascript:;" class="purpleBtn advancedSearchBtn"><span class="btR"><span class="btM"><span class="icon">Search</span><span class="arrow"></span></span></span></a>
+              <a id="showSearchEnrollmentsResultBtn" href="javascript:;" class="purpleBtn"><span class="btR"><span class="btM"><span class="icon">Search</span><span class="arrow"></span></span></span></a>
             </div>
           </div>
           <!-- /.tabSection -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
@@ -95,7 +95,7 @@
               </div>
               <div class="clearFixed"></div>
               <div class="buttons">
-                <button class="purpleBtn advancedSearchBtn" type="submit"><span class="icon">Search</span><span class="arrow"></span></button>
+                <button class="purpleBtn" type="submit"><span class="icon">Search</span><span class="arrow"></span></button>
               </div>
             </form>
             <!-- /.tabSection -->

--- a/psm-app/cms-web/WebContent/js/admin/script.js
+++ b/psm-app/cms-web/WebContent/js/admin/script.js
@@ -1541,10 +1541,6 @@ $(document).ready(function () {
     window.location.href = 'enrollment-service-agent.html';
   });
 
-  $('.advancedSearchBtn').live('click', function () {
-    $('#searchResultsSection').show();
-  });
-
   if ($.browser.msie && ($.browser.version == "7.0")) {
     $('#createEnrollment input[type="radio"],#advancedSearch input[type="checkbox"]').css('margin', '5px 3px auto 3px');
     $('.helpSection .row li').css('width', $('.helpSection .row ul').width() / 3);

--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -1321,10 +1321,6 @@ $(document).ready(function () {
     window.location.href = 'enrollment-service-agent.html';
   });
 
-  $('.advancedSearchBtn').live('click', function () {
-    $('#searchResultsSection').show();
-  });
-
   if ($.browser.msie && ($.browser.version == "7.0")) {
     $('#createEnrollment input[type="radio"],#advancedSearch input[type="checkbox"]').css('margin', '5px 3px auto 3px');
     $('.helpSection .row li').css('width', $('.helpSection .row ul').width() / 3);

--- a/psm-app/cms-web/WebContent/js/system/script.js
+++ b/psm-app/cms-web/WebContent/js/system/script.js
@@ -1393,9 +1393,9 @@ $(document).ready(function () {
         $('#searchUserAccountsForm, #advancedSearch').submit();
         return false;
       });
-
-    $('#filterBtn, .advancedSearchBtn').live('click', function () {
-        $('#searchUserAccountsForm, #advancedSearch').submit();
+ 
+    $('.advancedSearchBtn').click(function () {
+        $('#advancedSearch').submit();
         return false;
       });
 

--- a/psm-app/cms-web/WebContent/js/system/script.js
+++ b/psm-app/cms-web/WebContent/js/system/script.js
@@ -1024,10 +1024,6 @@ $(document).ready(function () {
     window.location.href = 'enrollment-service-agent.html';
   });
 
-  $('.advancedSearchBtn').live('click', function () {
-    $('#searchResultsSection').show();
-  });
-
   if ($.browser.msie && ($.browser.version == "7.0")) {
     $('#createEnrollment input[type="radio"],#advancedSearch input[type="checkbox"]').css('margin', '5px 3px auto 3px');
     $('.helpSection .row li').css('width', $('.helpSection .row ul').width() / 3);
@@ -1391,11 +1387,6 @@ $(document).ready(function () {
         $("#sortColumn").val(newSortColumn);
         setSearchConditions();
         $('#searchUserAccountsForm, #advancedSearch').submit();
-        return false;
-      });
- 
-    $('.advancedSearchBtn').click(function () {
-        $('#advancedSearch').submit();
         return false;
       });
 


### PR DESCRIPTION
This is a follow-up to PR #567 and removes the now-unneeded JS click handler function for the system admin advanced search and filter buttons.  I have left the `advancedSearchBtn` css class on that button because it is used to attach a separate click handler function.

Tested by logging in as a system admin ('system') and confirming that the filter and advanced search features work as expected.

Issue #553 Use accessible submit buttons on all forms