### PR TITLE
Finish making the system admin edit user save button accessible

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
@@ -64,11 +64,19 @@
             <c:otherwise><c:url value='/system/user/new?roleName=${role }' var='updateURL' /></c:otherwise>
           </c:choose>
           <div class="tabSection">
-            <div class="detailPanel">
-              <form:form commandName="user">
-                <form:errors path="*" cssClass="error" ></form:errors>
-                </form:form>
-                <form:form cssClass="section" id="updateProfile" action="${updateURL }" modelAttribute="user">
+            <form:form commandName="user" action="${updateURL}" modelAttribute="user">
+              <spring:hasBindErrors name="user">
+                <div class="errorInfo" style="display: block;">
+                  <h3>Please correct the following errors:</h3>
+                  <form:errors path="*"></form:errors>
+                  <div class="tl"></div>
+                  <div class="tr"></div>
+                  <div class="bl"></div>
+                  <div class="br"></div>
+                </div>
+              </spring:hasBindErrors>
+              <div class="detailPanel">
+                <div class="section" id="updateProfile">
                   <input type="hidden" name="status" value="ACTIVE" />
                   <form:hidden path="userId"/>
                   <div class="wholeCol">
@@ -118,7 +126,7 @@
                       </form:select>
                     </div>
                   </div>
-                </form:form>
+                </div>
                 <!-- /.section -->
                 <div class="tl"></div>
                 <div class="tr"></div>
@@ -127,12 +135,12 @@
               </div>
               <div class="buttonBox">
                 <a href="<c:url value='/system/user/list' />" class="greyBtn"><span class="btR"><span   class="btM">Cancel</span></span></a>
-                <button class="purpleBtn editAccountSaveBtn" type="submit">Save</button>
+                <button class="purpleBtn" type="submit">Save</button>
               </div>
               <!-- /.buttonBox -->
-            </div>
-            <!-- /.tabSection -->
+            </form:form>
           </div>
+          <!-- /.tabSection -->
         </div>
       </div>
       <!-- /#mainContent -->

--- a/psm-app/cms-web/WebContent/js/system/script.js
+++ b/psm-app/cms-web/WebContent/js/system/script.js
@@ -1394,10 +1394,6 @@ $(document).ready(function () {
         return false;
       });
 
-    $('.editAccountSaveBtn').live('click', function () {
-        $('#updateProfile').submit();
-      });
-
     $('#filterBtn, .advancedSearchBtn').live('click', function () {
         $('#searchUserAccountsForm, #advancedSearch').submit();
         return false;


### PR DESCRIPTION
A follow-up to PR #567. Removes now-unnecessary JS click handler for the system admin create/edit user save button.  Also makes error handling on the system admin create/edit user page consistent with error handling elsewhere in the PSM (as part of moving the submit button inside the form).

Tested by logging in as a system admin ('system') and attempting to create and edit a user with required fields missing, then successfully creating and editing a new user.

Before:

![screenshot-2017-12-15-create-new-user-account-before](https://user-images.githubusercontent.com/1091693/34054579-a3f9d4f6-e199-11e7-8053-49bad0a36b86.png)

After:

![screenshot-2017-12-15-create-new-user-account-after](https://user-images.githubusercontent.com/1091693/34054586-a9fd8546-e199-11e7-9c78-85ca37c4b55c.png)


Issue #553 Use accessible submit buttons on all forms