### PR TITLE
Fix login on logged-out error page

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -90,7 +90,7 @@
                 <h:handlebars template="includes/logo" context="${pageContext}"/>
               </div>
               <!-- /.mainNav -->
-              <form id="loginForm" action="<c:url value='login'/>" method="post">
+              <form id="loginForm" action="<c:url value='/login'/>" method="post">
                 <sec:csrfInput />
                 <div class="loginPanel">
                   <h:handlebars template="includes/flash" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -20,7 +20,7 @@
             <h:handlebars template="includes/logo" context="${pageContext}"/>
           </div>
           <!-- /.mainNav -->
-          <form id="loginForm" action="<c:url value='login'/>" method="post">
+          <form id="loginForm" action="<c:url value='/login'/>" method="post">
             <sec:csrfInput />
             <div class="loginPanel">
               <h:handlebars template="includes/flash" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
@@ -20,7 +20,7 @@
             <h:handlebars template="includes/logo" context="${pageContext}"/>
           </div>
 
-          <form id="loginForm" action="<c:url value='login'/>" method="post">
+          <form id="loginForm" action="<c:url value='/login'/>" method="post">
             <sec:csrfInput />
             <div class="loginPanel">
               <p>


### PR DESCRIPTION
While reviewing #578, I came across a small bug. It was a quick fix:

---

The page shown when an error happens without a signed-in user (such as trying to self-register when the application server cannot reach the email server) contains a login form. However, the target of the form was a relative path, which meant that, in cases such as the self-registration error, where the URL has additional path components, the browser would try to send the form data to that relative URL - e.g., `/accounts/login`, which results in a 404.

Specify the full path of `/login` for all the instances of the login form, which matches the path set in [`spring-security.xml`](https://github.com/SolutionGuidance/psm/blob/54481cf94cdbf5aa3ff2b63c7d1c6a5257734231/psm-app/cms-web/WebContent/WEB-INF/spring-security.xml#L66-L68).

---

I tested this by self-registering when my dev email server was not running, and then logging in from the resulting error page.