### PR TITLE
Change license state in test: #571

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -39,8 +39,8 @@ public class EnrollmentSteps {
             LocalDate.now().minusWeeks(30);
     private static final LocalDate LICENSE_RENEWAL_DATE =
             LocalDate.now().plusWeeks(30);
-    private static final String LICENSE_ISSUING_STATE_FULL = "Alaska";
-    private static final String LICENSE_ISSUING_STATE_ABBR = "AK";
+    private static final String LICENSE_ISSUING_STATE_FULL = "Minnesota";
+    private static final String LICENSE_ISSUING_STATE_ABBR = "MN";
 
     private static final String PRIVATE_PRACTICE_NAME = "My Private Practice";
     private static final String PRACTICE_GROUP_NPI = "1111111112";


### PR DESCRIPTION
This is a temporary fix.  Because of a MN-specific rule, enrollments for
some provider types cannot be approved unless they have a license issued
by the state of Minnesota.  Eventually, we need to remove the rule.  For
now, this change will allow us to approve enrollment applications
generated by the integration tests.