### PR TITLE
540 logout test

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
@@ -4,6 +4,7 @@ import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
+import gov.medicaid.features.general.steps.GeneralSteps;
 import net.thucydides.core.annotations.Steps;
 
 import java.io.IOException;
@@ -12,6 +13,9 @@ import java.io.IOException;
 public class DataCoverageStepDefinitions {
     @Steps
     EnrollmentSteps enrollmentSteps;
+    
+    @Steps
+    GeneralSteps generalSteps;
 
     private OrganizationInfoPage organizationInfoPage;
 
@@ -21,7 +25,7 @@ public class DataCoverageStepDefinitions {
     }
 
     private void navigateToLicensePage() {
-        enrollmentSteps.loginAsProvider();
+        generalSteps.loginAsProvider();
         enrollmentSteps.createEnrollment();
         enrollmentSteps.selectIndividualProviderType();
         enrollmentSteps.enterIndividualPersonalInfo();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -71,14 +71,6 @@ public class EnrollmentSteps {
 
     private SimpleDateFormat formFieldDateFormat = new SimpleDateFormat("MMddyyyy");
 
-    @Step
-    public void loginAsProvider() {
-        loginPage.open();
-        loginPage.enterProviderCredentials();
-        loginPage.login();
-        loginPage.checkUserLoggedIn("p1");
-    }
-
     public void createEnrollment() {
         dashboardPage.clickOnNewEnrollment();
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
@@ -3,6 +3,7 @@ package gov.medicaid.features.enrollment.steps;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
+import gov.medicaid.features.general.steps.GeneralSteps;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
 import gov.medicaid.features.enrollment.ui.PersonalInfoPage;
 import net.thucydides.core.annotations.Steps;
@@ -16,13 +17,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ValidationStepDefinitions {
     @Steps
     EnrollmentSteps enrollmentSteps;
+    
+    @Steps
+    GeneralSteps generalSteps;
 
     private OrganizationInfoPage organizationInfoPage;
     private PersonalInfoPage personalInfoPage;
 
     @Given("^I have started an enrollment$")
     public void i_have_started_an_enrollment() {
-        enrollmentSteps.loginAsProvider();
+        generalSteps.loginAsProvider();
         enrollmentSteps.createEnrollment();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,0 +1,20 @@
+package gov.medicaid.features.general.steps;
+
+import gov.medicaid.features.general.ui.LoginPage;
+import net.thucydides.core.annotations.Step;
+
+@SuppressWarnings("unused")
+public class GeneralSteps {
+    
+    private LoginPage loginPage;
+
+    @Step
+    public void loginAsProvider() {
+        loginPage.open();
+        loginPage.enterProviderCredentials();
+        loginPage.login();
+        loginPage.checkUserLoggedIn("p1");
+    }
+
+}
+

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LogoutStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LogoutStepDefinitions.java
@@ -1,0 +1,38 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import gov.medicaid.features.general.ui.DashboardPage;
+import gov.medicaid.features.general.ui.LoginPage;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class LogoutStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    // This property is set by serenity at test time.
+    private LoginPage loginPage;
+    private DashboardPage dashboardPage;
+
+    @Given("I am logged in$")
+    public void enter_dashboard_page() {
+        loginAsProvider();
+    }
+
+    private void loginAsProvider() {
+        generalSteps.loginAsProvider();
+    }
+
+    @When("^I click on Logout$")
+    public void clickLogout()  {
+        dashboardPage.logout();
+    }
+
+    @Then("^I should see the login page$")
+    public void checkLogout() {
+        loginPage.checkUserLoggedOut();
+    }
+
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
@@ -19,4 +19,8 @@ public class DashboardPage extends PageObject {
         click(this, $(".nextBtn"));
     }
 
+    public void logout() {
+        click(this, $(".logoutButton"));
+    }
+
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
@@ -22,4 +22,8 @@ public class LoginPage extends PageObject {
         String welcomeText = $("#header > div > div.userSection").getText();
         assertThat(welcomeText).contains("Welcome, " + username);
     }
+
+    public void checkUserLoggedOut() {
+        assertThat(getTitle()).contains("Login");
+    }
 }

--- a/psm-app/integration-tests/src/test/resources/features/general/logout.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/logout.feature
@@ -1,0 +1,7 @@
+Feature: Log out of the Application as Provider
+  A provider wishes to close the application to preserve their privacy.
+
+  Scenario: Should Log out
+    Given I am logged in
+    When I click on Logout
+    Then I should see the login page


### PR DESCRIPTION
Add a regression test, following up to PR #540, that tests that logout works correctly.

Note that I used the `enrollment` package in `LogoutStepDefinitions.java`, so that I could refer to `enrollmentSteps`, but this file appears under `general`.  Can someone advise me about whether that was the right way to do it?

Test this by running the integration tests.  It should pass.  (Optionally, break the logout button somehow and it should fail.)