### PR TITLE
Improve color contrast of text on light blue table rows

### DIFF
--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -506,8 +506,8 @@ input.date{
 .generalTable tr td.alignCenter{
   text-align:center;
 }
-.generalTable .sep{
-  color:#999999;
+.generalTable .sep {
+  color: #6e6e6e;
   margin:0 5px;
 }
 .red{

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -28,8 +28,8 @@ input,select,textarea{
   max-width: 960px;
   width: 99%;
 }
-.green{
-  color:#5bc217;
+.green {
+  color: #3a7b0f;
 }
 .functionTab select.timeSelect{
   width:85px;

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -5,9 +5,9 @@ body {
   font-size:12px;
 }
 
-a{
+a {
   text-decoration:underline;
-  color:#1AABFF;
+  color: #0071b3;
 }
 a:hover{
   text-decoration:none;
@@ -35,7 +35,7 @@ input,select,textarea{
   width:85px;
 }
 #header {
-  background: #033a6e;
+  background: #0d4478;
   border-bottom: 2px solid #d5e2e5;
   height: 33px;
   line-height: 33px;
@@ -53,8 +53,8 @@ input,select,textarea{
   text-align:right;
   float:right;
 }
-#header .userSection a{
-  color:#1aabff;
+#header .userSection a {
+  color: #43baff;
   font-weight:bold;
   margin:0 4px;
 }
@@ -64,7 +64,7 @@ input,select,textarea{
 .logoutButton {
   background: none!important;
   border: none;
-  color: #1aabff;
+  color: #43baff;
   cursor: pointer;
   font: inherit;
   padding: 0!important;
@@ -178,8 +178,7 @@ input,select,textarea{
   margin:8px 0;
   float:left;
 }
-.breadCrumb a{
-  color:#1aabff;
+.breadCrumb a {
   background: url("../i/crumbs-arrow.gif") no-repeat scroll right center transparent;
   display: inline-block;
   float: left;
@@ -506,9 +505,6 @@ input.date{
 }
 .generalTable tr td.alignCenter{
   text-align:center;
-}
-.generalTable tr td a{
-  color:#1aabff;
 }
 .generalTable .sep{
   color:#999999;
@@ -2840,8 +2836,7 @@ a.searchBtn span.btM{
   padding-top:25px;
 }
 .editInfo,
-.editInfo:visited{
-  color:#1aabff;
+.editInfo:visited {
   font-size:12px;
   float:right;
   display:inline-block;


### PR DESCRIPTION
Blue link text, green text, and grey `|` separators were all too light to provide sufficient contrast for accessibility on light blue table rows.  This PR darkens them to fix the problem.  (Also, the dark blue header strip is restored to its original color and the links in it are lightened, to fix the contrast issue there.)  See commit messages for details.

Tested by logging in as a provider and running the HTML_CodeSniffer bookmarklet to confirm that the color contrast errors no longer occur.  The error reads:

> This element has insufficient contrast at this conformance level. 

Before:

![screenshot-2017-12-18-dashboard-before](https://user-images.githubusercontent.com/1091693/34129118-efe64d58-e410-11e7-99c1-eab11deb06ef.png)

After:

![screenshot-2017-12-18-dashboard-after](https://user-images.githubusercontent.com/1091693/34129127-f79c8210-e410-11e7-94ae-9e4549db23ed.png)


Issue #467 Improve ADA compliance