### PR TITLE
Improve accessibility of empty anchor elements

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
@@ -18,7 +18,7 @@
             <div class="modal-title">
                 <div class="right">
                     <div class="middle">
-                        <a href="javascript:;" class="closeModal"></a>
+                        <button class="closeModal" title="Close" aria-label="Close"></button>
                         <h2>Delete User Account</h2>
                     </div>
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
@@ -20,7 +20,6 @@
                     <div class="middle">
                         <a href="javascript:;" class="closeModal"></a>
                         <h2>Delete User Account</h2>
-
                     </div>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
@@ -13,7 +13,7 @@
     <div class="modal-title">
       <div class="right">
         <div class="middle">
-          <a href="javascript:;" class="closeModal"></a>
+          <button class="closeModal" title="Close" aria-label="Close"></button>
           <h2>Find Practice Data in Existing Record</h2>
         </div>
       </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/save_as_draft.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/save_as_draft.jsp
@@ -6,26 +6,25 @@
  --%>
 <!-- /#saveAsDraftModal-->
 <div id="saveAsDraftModal" class="outLay">
-    <div class="inner"> 
+    <div class="inner">
         <!-- title -->
         <div class="modal-title">
             <div class="right">
                 <div class="middle">
                     <a href="javascript:;" class="closeModal"></a> 
                     <h2>Save as a Draft</h2>
-                    
                 </div>
             </div>
         </div>
-        <!-- End .modal-title --> 
+        <!-- End .modal-title -->
 
         <!-- content -->
         <div class="modal-content">
             <div class="right">
                 <div class="middle">
                     <p>The enrollment has been saved as Draft.</p>
-                    <div class="buttonArea"> 
-                        <a href="javascript:;" class="purpleBtn closeModal okBtn"><span class="btR"><span class="btM">OK</span></span></a> 
+                    <div class="buttonArea">
+                        <a href="javascript:;" class="purpleBtn closeModal okBtn"><span class="btR"><span class="btM">OK</span></span></a>
                     </div>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/save_as_draft.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/save_as_draft.jsp
@@ -11,7 +11,7 @@
         <div class="modal-title">
             <div class="right">
                 <div class="middle">
-                    <a href="javascript:;" class="closeModal"></a> 
+                    <button class="closeModal" title="Close" aria-label="Close"></button>
                     <h2>Save as a Draft</h2>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/stale_ticket.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/stale_ticket.jsp
@@ -11,7 +11,7 @@
         <div class="modal-title">
             <div class="right">
                 <div class="middle">
-                    <a href="javascript:;" class="closeModal"></a> 
+                    <button class="closeModal" title="Close" aria-label="Close"></button>
                     <h2>ERROR</h2>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/stale_ticket.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/stale_ticket.jsp
@@ -6,27 +6,26 @@
  --%>
 <!-- /#saveAsDraftModal-->
 <div id="staleTicket" class="outLay">
-    <div class="inner"> 
+    <div class="inner">
         <!-- title -->
         <div class="modal-title">
             <div class="right">
                 <div class="middle">
                     <a href="javascript:;" class="closeModal"></a> 
                     <h2>ERROR</h2>
-                    
                 </div>
             </div>
         </div>
-        <!-- End .modal-title --> 
+        <!-- End .modal-title -->
 
         <!-- content -->
         <div class="modal-content">
             <div class="right">
                 <div class="middle">
-                    <p>The referenced profile has been modified by another user or system and this may not be showing the latest data. 
+                    <p>The referenced profile has been modified by another user or system and this may not be showing the latest data.
                     Submission will not be allowed. Please create a new request using the latest profile information.</p>
-                    <div class="buttonArea"> 
-                        <a href="javascript:;" class="purpleBtn closeModal okBtn"><span class="btR"><span class="btM">OK</span></span></a> 
+                    <div class="buttonArea">
+                        <a href="javascript:;" class="purpleBtn closeModal okBtn"><span class="btR"><span class="btM">OK</span></span></a>
                     </div>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/submit_enrollment.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/submit_enrollment.jsp
@@ -6,26 +6,25 @@
  --%>
 <!-- /#saveAsDraftModal-->
 <div id="submitEnrollmentModal" class="outLay">
-    <div class="inner"> 
+    <div class="inner">
         <!-- title -->
         <div class="modal-title">
             <div class="right">
                 <div class="middle">
                     <a href="javascript:;" class="closeModal"></a> 
                     <h2>Submit Enrollment</h2>
-                    
                 </div>
             </div>
         </div>
-        <!-- End .modal-title --> 
+        <!-- End .modal-title -->
 
         <!-- content -->
         <div class="modal-content">
             <div class="right">
                 <div class="middle">
                     <p>The enrollment has been successfully submitted</p>
-                    <div class="buttonArea"> 
-                        <a href="javascript:;" class="purpleBtn closeModal okBtn"><span class="btR"><span class="btM">OK</span></span></a> 
+                    <div class="buttonArea">
+                        <a href="javascript:;" class="purpleBtn closeModal okBtn"><span class="btR"><span class="btM">OK</span></span></a>
                     </div>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/submit_enrollment.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/submit_enrollment.jsp
@@ -11,7 +11,7 @@
         <div class="modal-title">
             <div class="right">
                 <div class="middle">
-                    <a href="javascript:;" class="closeModal"></a> 
+                    <button class="closeModal" title="Close" aria-label="Close"></button>
                     <h2>Submit Enrollment</h2>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/superseded_ticket.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/superseded_ticket.jsp
@@ -6,26 +6,25 @@
  --%>
 <!-- /#saveAsDraftModal-->
 <div id="supersededTicket" class="outLay">
-    <div class="inner"> 
+    <div class="inner">
         <!-- title -->
         <div class="modal-title">
             <div class="right">
                 <div class="middle">
-                    <a href="javascript:;" class="closeModal"></a> 
+                    <a href="javascript:;" class="closeModal"></a>
                     <h2>WARNING</h2>
-                    
                 </div>
             </div>
         </div>
-        <!-- End .modal-title --> 
+        <!-- End .modal-title -->
 
         <!-- content -->
         <div class="modal-content">
             <div class="right">
                 <div class="middle">
                     <p>There is a pending request for the same profile. Submission will not be allowed unless the other request is denied.</p>
-                    <div class="buttonArea"> 
-                        <a href="javascript:;" class="purpleBtn closeModal okBtn"><span class="btR"><span class="btM">OK</span></span></a> 
+                    <div class="buttonArea">
+                        <a href="javascript:;" class="purpleBtn closeModal okBtn"><span class="btR"><span class="btM">OK</span></span></a>
                     </div>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/superseded_ticket.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/superseded_ticket.jsp
@@ -11,7 +11,7 @@
         <div class="modal-title">
             <div class="right">
                 <div class="middle">
-                    <a href="javascript:;" class="closeModal"></a>
+                    <button class="closeModal" title="Close" aria-label="Close"></button>
                     <h2>WARNING</h2>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
@@ -47,5 +47,5 @@
     <div class="tr"></div>
     <div class="bl"></div>
     <div class="br"></div>
-    <a href="javascript:" class="closeSection"></a>
+    <button class="closeSection" title="Close" aria-label="Close" type="button"></button>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
@@ -21,13 +21,13 @@
             <input class="showHidePanel" ${formValue eq 'Y' ? 'checked' : ''} type="checkbox" name="${formName}" value="Y" />This clinic is a Community Health Board
         </span>
     </div>
-    
+
     <div class="section line hiddenSection" style="display: ${formValue eq 'Y' ? 'block' : 'none'};">
         <div class="">
             <div class="row requireField">
                 <label>Please upload a copy of contract with DHS<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-    
+
                 <c:set var="formName" value="_30_dhsContract"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <c:if test="${not empty formValue}">
@@ -41,7 +41,7 @@
         </div>
         <div class="clearFixed"></div>
     </div>
-    
+
     <!-- /.section -->
     <div class="tl"></div>
     <div class="tr"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
@@ -21,12 +21,12 @@
         <c:set var="formName" value="_16_objectId_${status.index - 1}"></c:set>
         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
         <input type="hidden" name="${formName}" value="${formValue}"/>
-    
+
         <div class="">
             <div class="row requireField">
                 <label>NPI/UMPI<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_16_npi_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="umpiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
@@ -47,7 +47,7 @@
             <div class="row requireField">
                 <label>Individual Provider Type<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_16_providerType_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <select name="${formName}">
@@ -70,7 +70,7 @@
                 </label>
                 <span class="floatL"><b>:</b></span>
                             <span class="dateWrapper floatL">
-                            
+
                     <c:set var="formName" value="_16_dob_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input class="date" type="text" name="${formName}" value="${formValue}"/>
@@ -147,12 +147,12 @@
         <c:set var="formName" value="_16_objectId"></c:set>
         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
         <input type="hidden" name="${formName}" value="${formValue}"/>
-    
+
         <div class="">
             <div class="row requireField">
                 <label>NPI/UMPI<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_16_npi"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="umpiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
@@ -173,7 +173,7 @@
             <div class="row requireField">
                 <label>Individual Provider Type<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_16_providerType"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <select name="${formName}">
@@ -196,7 +196,7 @@
                 </label>
                 <span class="floatL"><b>:</b></span>
                             <span class="dateWrapper floatL">
-                            
+
                     <c:set var="formName" value="_16_dob"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input class="date" type="text" name="${formName}" value="${formValue}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
@@ -136,7 +136,7 @@
     <div class="tr"></div>
     <div class="bl"></div>
     <div class="br"></div>
-    <a href="javascript:" class="closeSection"></a>
+    <button class="closeSection" title="Close" aria-label="Close" type="button"></button>
 </div>
 </c:forEach>
 </div>
@@ -262,7 +262,7 @@
     <div class="tr"></div>
     <div class="bl"></div>
     <div class="br"></div>
-    <a href="javascript:" class="closeSection"></a>
+    <button class="closeSection" title="Close" aria-label="Close" type="button"></button>
 </div>
 
 <c:url var="lookupUrl" value="/provider/enrollment/lookupProvider" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
@@ -19,12 +19,12 @@
         <c:set var="formName" value="_20_objectId_${status.index - 1}"></c:set>
         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
         <input type="hidden" class="objectIdInput" name="${formName}" value="${formValue}"/>
-    
+
         <div class="">
             <div class="row requireField">
                 <label>NPI<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_20_npi_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="npiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
@@ -36,7 +36,7 @@
             <div class="row requireField">
                 <label>Pay-to Provider Name<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_20_name_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
@@ -44,7 +44,7 @@
             <div class="row requireField">
                 <label>Contact Name<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_20_contactName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="contactNameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
@@ -112,12 +112,12 @@
         <c:set var="formName" value="_20_objectId_${status.index - 1}"></c:set>
         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
         <input type="hidden" class="objectIdInput" name="${formName}" value="${formValue}"/>
-    
+
         <div class="">
             <div class="row requireField">
                 <label>NPI<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_20_npi_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="npiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
@@ -129,7 +129,7 @@
             <div class="row requireField">
                 <label>Pay-to Provider Name<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_20_name_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
@@ -137,7 +137,7 @@
             <div class="row requireField">
                 <label>Contact Name<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_20_contactName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="contactNameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
@@ -101,7 +101,7 @@
     <div class="tr"></div>
     <div class="bl"></div>
     <div class="br"></div>
-    <a href="javascript:" class="closeSection"></a>
+    <button class="closeSection" title="Close" aria-label="Close" type="button"></button>
 </div>
 </c:forEach>
 </div>
@@ -194,7 +194,7 @@
     <div class="tr"></div>
     <div class="bl"></div>
     <div class="br"></div>
-    <a href="javascript:" class="closeSection"></a>
+    <button class="closeSection" title="Close" aria-label="Close"  type="button"></button>
 </div>
 
 <c:url var="lookupUrl" value="/provider/enrollment/lookupProvider" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
@@ -356,7 +356,7 @@
     <div class="tr"></div>
     <div class="bl"></div>
     <div class="br"></div>
-    <a href="javascript:" class="closeSection"></a>
+    <button class="closeSection" title="Close" aria-label="Close" type="button"></button>
 </div>
 </c:forEach>
 </div>
@@ -677,7 +677,7 @@
     <div class="tr"></div>
     <div class="bl"></div>
     <div class="br"></div>
-    <a href="javascript:" class="closeSection"></a>
+    <button class="closeSection" title="Close" aria-label="Close" type="button"></button>
 </div>
 </div>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
@@ -7,7 +7,7 @@
 
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<%@taglib prefix="cms" uri="CMSTags"  %> 
+<%@taglib prefix="cms" uri="CMSTags"  %>
 
 <input type="hidden" name="formNames" value="<%= ViewStatics.QUALIFIED_PROFESSIONAL_FORM %>">
 <c:set var="selectedMarkup" value='selected="selected"' />
@@ -22,7 +22,7 @@
             <div class="row requireField">
                 <label>QP Type<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_29_qpType_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <select name="${formName}">
@@ -35,7 +35,7 @@
             <div class="row requireField">
                 <label>Name<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_29_name_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
@@ -43,7 +43,7 @@
             <div class="row requireField">
                 <label>NPI</label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_29_npi_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
@@ -54,7 +54,7 @@
                 </label>
                 <span class="floatL"><b>:</b></span>
                             <span class="dateWrapper floatL">
-                            
+
                     <c:set var="formName" value="_29_startDate_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input class="date" type="text" name="${formName}" value="${formValue}"/>
@@ -87,7 +87,7 @@
                 </label>
                 <span class="floatL"><b>:</b></span>
                             <span class="dateWrapper floatL">
-                            
+
                     <c:set var="formName" value="_29_dob_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input class="date" type="text" name="${formName}" value="${formValue}"/>
@@ -118,7 +118,7 @@
             <div class="clearFixed"></div>
         </div>
         <div class="clear"></div>
-        
+
         <div class="">
             <div class="row addressline1">
                 <label>Residence Address</label>
@@ -128,7 +128,7 @@
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
-            
+
             <div class="row inlineBox addressline2">
                 <span class="label">&nbsp;</span>
                 <span class="floatL"><b>&nbsp;</b></span>
@@ -137,7 +137,7 @@
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
-            
+
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
                 <span class="floatL"><b>&nbsp;</b></span>
@@ -170,12 +170,12 @@
                 </select>
             </div>
         </div>
-        
+
         <div class="leftCol">
             <div class="row requireField">
                 <label>BGS ID NUMBER<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_29_bgsNumber_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
@@ -190,7 +190,7 @@
                 </label>
                 <span class="floatL"><b>:</b></span>
                             <span class="dateWrapper floatL">
-                            
+
                     <c:set var="formName" value="_29_bgsClearanceDate_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input class="date" type="text" name="${formName}" value="${formValue}"/>
@@ -200,7 +200,7 @@
         </div>
         <div class="clearFixed"></div>
     </div>
-    
+
     <div class="tableData">
     <table cellpadding="0" cellspacing="0" class="generalTable fixedWidthTable">
         <colgroup>
@@ -248,7 +248,7 @@
                 <td class="licenseCopyInput">
                     <c:set var="formName" value="_29_attachment_${status.index - 1}_${licenseRow.index - 1}"></c:set>
                     <input type="file" class="fileUpload" size="10" name="${formName}" />
-                    
+
                     <c:set var="formName" value="_29_filename_${status.index - 1}_${licenseRow.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <c:if test="${not empty formValue}">
@@ -350,7 +350,7 @@
         </table>
         </div>
     <div class="clearFixed"></div>
-    
+
     <!-- /.section -->
     <div class="tl"></div>
     <div class="tr"></div>
@@ -373,7 +373,7 @@
             <div class="row requireField">
                 <label>QP Type<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_29_qpType"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <select name="${formName}" class="qpTypeSelect">
@@ -386,7 +386,7 @@
             <div class="row requireField">
                 <label>Name<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_29_name"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
@@ -394,7 +394,7 @@
             <div class="row requireField">
                 <label>NPI</label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_29_npi"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
@@ -405,7 +405,7 @@
                 </label>
                 <span class="floatL"><b>:</b></span>
                             <span class="dateWrapper floatL">
-                            
+
                     <c:set var="formName" value="_29_startDate"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input class="date" type="text" name="${formName}" value="${formValue}"/>
@@ -429,7 +429,7 @@
                 </label>
                 <span class="floatL"><b>:</b></span>
                             <span class="dateWrapper floatL">
-                            
+
                     <c:set var="formName" value="_29_dob"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input class="date" type="text" name="${formName}" value="${formValue}"/>
@@ -460,7 +460,7 @@
             <div class="clearFixed"></div>
         </div>
         <div class="clear"></div>
-        
+
         <div class="">
             <div class="row addressline1">
                 <label>Residence Address</label>
@@ -470,7 +470,7 @@
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
-            
+
             <div class="row inlineBox addressline2">
                 <span class="label">&nbsp;</span>
                 <span class="floatL"><b>&nbsp;</b></span>
@@ -479,7 +479,7 @@
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
-            
+
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
                 <span class="floatL"><b>&nbsp;</b></span>
@@ -512,12 +512,12 @@
                 </select>
             </div>
         </div>
-        
+
         <div class="leftCol">
             <div class="row requireField">
                 <label>BGS ID NUMBER<span class="required">*</span></label>
                 <span class="floatL"><b>:</b></span>
-                
+
                 <c:set var="formName" value="_29_bgsNumber"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
@@ -532,7 +532,7 @@
                 </label>
                 <span class="floatL"><b>:</b></span>
                             <span class="dateWrapper floatL">
-                            
+
                     <c:set var="formName" value="_29_bgsClearanceDate"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input class="date" type="text" name="${formName}" value="${formValue}"/>
@@ -542,7 +542,7 @@
         </div>
         <div class="clearFixed"></div>
     </div>
-    
+
     <div class="tableData">
     <table cellpadding="0" cellspacing="0" class="generalTable">
         <thead>
@@ -572,7 +572,7 @@
                 <td class="licenseCopyInput">
                     <c:set var="formName" value="_29_attachment"></c:set>
                     <input type="file" class="fileUpload" size="10" name="${formName}" />
-                    
+
                     <c:set var="formName" value="_29_filename"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <c:if test="${not empty formValue}">
@@ -623,7 +623,7 @@
                 <td class="licenseCopyInput">
                     <c:set var="formName" value="_29_attachment"></c:set>
                     <input type="file" class="fileUpload" size="10" name="${formName}" />
-                    
+
                     <c:set var="formName" value="_29_filename"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <c:if test="${not empty formValue}">
@@ -671,7 +671,7 @@
         </table>
         </div>
     <div class="clearFixed"></div>
-    
+
     <!-- /.section -->
     <div class="tl"></div>
     <div class="tr"></div>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4305,7 +4305,8 @@ input.passwordNormalInput{
   position: absolute;
   top: 0;
   right: 0;
-
+  border: none;
+  cursor: pointer;
 }
 .memberInfoPanel .section .leftCol, .memberInfoPanel .section .rightCol{
   display: inline;

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -155,10 +155,14 @@ input,select,textarea{
   background:url(../i/input-container-bg.png) no-repeat right center;
   margin:8px;
 }
-.mainNav .searchWidget .inputContainer a{
-  background:url(../i/icon-search.png) no-repeat right center;
+.mainNav .searchWidget .inputContainer .search {
+  background: url("../i/icon-search.png") no-repeat right center;
+  float: right;
+  margin-right: 5px;
   width:15px;
   height:26px;
+  border: none;
+  cursor: pointer;
 }
 .mainNav .searchWidget .inputContainer input{
   width:185px;

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -3308,6 +3308,8 @@ a.searchBtn span.btM{
   overflow:hidden;
   margin-top:15px;
   background:url(../i/modal-close.png) no-repeat 0 0;
+  border: none;
+  cursor: pointer;
 }
 
 #new-modal .inner .modal-title .closeModal:hover{

--- a/psm-app/cms-web/WebContent/js/admin/script.js
+++ b/psm-app/cms-web/WebContent/js/admin/script.js
@@ -111,7 +111,7 @@ $(document).ready(function () {
       quickSearchInput = '';
     }
 
-    window.location.href = $(this).attr("href") + "?npi=" + quickSearchInput;
+    window.location.href = ctx + "/provider/search/quick?npi=" + quickSearchInput;
     return false;
   });
 

--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -5,7 +5,7 @@ $(document).ready(function () {
       quickSearchInput = '';
     }
 
-    window.location.href = $(this).attr("href") + "?npi=" + quickSearchInput;
+    window.location.href = ctx + "/provider/search/quick?npi=" + quickSearchInput;
     return false;
   });
 

--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -90,7 +90,7 @@ $(document).ready(function () {
   //			$('#practiceLookupModal .tableContainer').show();
   //			addressPositionModal();
   //		});
-  $('#practiceLookupModal a.closeModal').click(function () {
+  $('#practiceLookupModal .closeModal').click(function () {
     $('#practiceLookupModal .tableContainer').hide();
   });
 

--- a/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
@@ -11,9 +11,6 @@
   {{#if adminPage}}
     <link rel="stylesheet" href="{{ctx}}/js/chosen/chosen.css" type="text/css" media="all"/>
     <link rel="stylesheet" href="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.css" type="text/css"/>
-    <script type="text/javascript">
-      var ctx = "{{ctx}}";
-    </script>
   {{else if systemPage}}
     <link rel="stylesheet" href="{{ctx}}/js/chosen/chosen.css" type="text/css" media="all"/>
   {{/if}}
@@ -27,27 +24,34 @@
     <script src="{{ctx}}/js/jquery.tinyscrollbar.min.js" type="text/javascript"></script>
     <script src="{{ctx}}/js/jquery.validate.min.js" type="text/javascript"></script>
     <script src="{{ctx}}/js/chosen/chosen.jquery.min.js" type="text/javascript"></script>
-  {{else if systemPage}}
-    <script src="{{ctx}}/js/chosen/chosen.jquery.min.js" type="text/javascript"></script>
-  {{/if}}
-  <script src="{{ctx}}/js/jquery.maskedinput.min.js" type="text/javascript"></script>
-  {{#if adminPage}}
+    <script src="{{ctx}}/js/jquery.maskedinput.min.js" type="text/javascript"></script>
     <script src="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.js" type="text/javascript"></script>
     <script src="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.js" type="text/javascript"></script>
     <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.image.js" type="text/javascript"></script>
     <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.link.js" type="text/javascript" ></script>
     <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.table.js" type="text/javascript" ></script>
-    <script src="{{ctx}}/js/admin/script.js" type="text/javascript"></script>
   {{else if systemPage}}
-    <script src="{{ctx}}/js/system/script.js" type="text/javascript"></script>
-    <script type="text/javascript">
-      var ctx = "{{ctx}}";
+    <script src="{{ctx}}/js/chosen/chosen.jquery.min.js" type="text/javascript"></script>
+    <script src="{{ctx}}/js/jquery.maskedinput.min.js" type="text/javascript"></script>
+  {{else}}
+    <script src="{{ctx}}/js/jquery.maskedinput.min.js" type="text/javascript"></script>
+    <script src="{{ctx}}/js/jquery.compare.js" type="text/javascript"></script>
+  {{/if}}
+
+  <script type="text/javascript">
+    var ctx = "{{ctx}}";
+    {{#if systemPage}}
       var roles = "{{role}}";
       var searchedResult = "{{searchedResult}}";
       var searchFirstName = "{{searchFirstName}}";
-    </script>
+    {{/if}}
+  </script>
+
+  {{#if adminPage}}
+    <script src="{{ctx}}/js/admin/script.js" type="text/javascript"></script>
+  {{else if systemPage}}
+    <script src="{{ctx}}/js/system/script.js" type="text/javascript"></script>
   {{else}}
-    <script src="{{ctx}}/js/jquery.compare.js" type="text/javascript"></script>
     <script src="{{ctx}}/js/script.js" type="text/javascript"></script>
   {{/if}}
 </head>

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -37,7 +37,7 @@
           <a href="{{ctx}}/system/advanced-search-system-admin">Advanced Search</a>
           <form id="searchBoxForm" class="inputContainer" action="{{ctx}}/system/user/search?role=Provider"  method="post">
             <input type="hidden" name="{{csrf.parameterName}}" value="{{csrf.token}}"/>
-            <a href="javascript:;" class="search searchBox"></a>
+            <button class="search searchBox" title="Search" aria-label="Search" type="submit"></button>
             <input type="text" class="hint" value="Search Keyword" title="Search Keyword" name="firstName" id="searchBoxFirstName"/>
             <input type="hidden" name="lastName" id="searchBoxLastName" />
             <input type="hidden" name="and" value="false" />
@@ -53,7 +53,8 @@
         <div class="searchWidget">
           <a href="{{ctx}}/provider/search/advanced">Advanced Search</a>
           <div class="inputContainer">
-            <a id="enrollmentQuickSearch" href="{{ctx}}/provider/search/quick" class="search"></a> <input id="quickSearchInput" type="text" class="hint" value="{{#if param.npi }} {{param.npi}} {{else}} Search Keyword {{/if}}" title="Search Keyword" />
+            <button id="enrollmentQuickSearch" class="search" title="Search" aria-label="Search"></button>
+            <input id="quickSearchInput" type="text" class="hint" value="{{#if param.npi }} {{param.npi}} {{else}} Search Keyword {{/if}}" title="Search Keyword" />
           </div>
         </div>
       {{/if}}


### PR DESCRIPTION
Anchor elements with no inner HTML content are an accessibility problem.  This PR fixes cases of this by replacing the anchors with `<button>` elements where possible or else by moving background images into the anchor tags where that is a more straightforward solution (as with the search buttons).  Title, aria-label, and role="button" attributes are added as appropriate to improve accessibility.

Search buttons tested by:
- log in as p1, do a search from the quick search field in the main navigation bar
- log in as system, do a search from the quick search field in the main navigation bar

The search should happen as expected (search results may vary).

Close buttons `[X]` on modal dialogs tested by:
- log in as p1, click 'Save as Draft' from an enrollment step page, click the `[X]` at top right of modal
- log in as p1, click 'Provider Lookup' from enrollment step page, click the `[X]` at top right of modal
- log in as p1, click 'Submit Enrollment' from enrollment step page, click the `[X]` at top right of modal
- log in as system, click `Delete` for a user in the list, click the `[X]` at top right of modal

The modal should close as expected.

The close buttons in the enrollment steps are not currently exposed in the UI, so cannot be tested at this point.

Resolves #507 Fix anchors that have no link content