### PR TITLE
Test that change password link exists: #568

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -39,6 +39,10 @@ buttons in the `ui` subdirectory.
 See [PR #348](https://github.com/SolutionGuidance/psm/pull/348) for an
 example of adding a new Selenium test.
 
+You can check the results of these tests by running:
+
+    $ chromium integration-tests/build/reports/tests/test/index.html
+
 ### Running Browser Tests
 
 #### With SauceLabs

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -93,7 +93,7 @@
                     <c:if test="${isInternalUser}">
                       <li>
                         <p>
-                          <a href="<c:url value="/provider/profile/reset" />">Change Password</a>
+                          <a href="<c:url value="/provider/profile/reset" />" id="change_password_link">Change Password</a>
                           <br/>
                           Set a new password for your online account
                         </p>

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -26,7 +26,7 @@
           {{/if}}
 
           <li class="last {{#if activeTab3 }} active {{/if}}">
-            <a href="{{ctx}}/myprofile">MY PROFILE</a>
+            <a href="{{ctx}}/myprofile" id="my_profile_tab">MY PROFILE</a>
             {{#if activeTab3 }} <span class="arrow"></span> {{/if}}
           </li>
         {{/if}}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
@@ -5,29 +5,23 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import net.thucydides.core.annotations.Steps;
 
-import gov.medicaid.features.general.ui.DashboardPage;
-import gov.medicaid.features.general.ui.MyProfilePage;
-
 @SuppressWarnings("unused")
 public class ChangePasswordStepDefinitions {
     @Steps
     GeneralSteps generalSteps;
 
-    private DashboardPage dashboardPage;
-    private MyProfilePage profilePage;
-
     @Given("^I am on the dashboard page$")
     public void check_dashboard_page() {
-        dashboardPage.checkOnDashboard();
+        generalSteps.checkOnDashboard();
     }
 
     @When("^I click on My Profile$")
     public void i_click_on_my_profile()  {
-        dashboardPage.clickMyProfile();
+        generalSteps.clickMyProfile();
     }
 
     @Then("^I should see the Change Password link$")
     public void i_should_see_change_password()  {
-        profilePage.checkChangePassword();
+        generalSteps.seeChangePassword();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
@@ -1,0 +1,33 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import net.thucydides.core.annotations.Steps;
+
+import gov.medicaid.features.general.ui.DashboardPage;
+import gov.medicaid.features.general.ui.MyProfilePage;
+
+@SuppressWarnings("unused")
+public class ChangePasswordStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    private DashboardPage dashboardPage;
+    private MyProfilePage profilePage;
+
+    @Given("^I am on the dashboard page$")
+    public void check_dashboard_page() {
+        dashboardPage.checkOnDashboard();
+    }
+
+    @When("^I click on My Profile$")
+    public void i_click_on_my_profile()  {
+        dashboardPage.clickMyProfile();
+    }
+
+    @Then("^I should see the Change Password link$")
+    public void i_should_see_change_password()  {
+        profilePage.checkChangePassword();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,12 +1,16 @@
 package gov.medicaid.features.general.steps;
 
+import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.LoginPage;
+import gov.medicaid.features.general.ui.MyProfilePage;
 import net.thucydides.core.annotations.Step;
 
 @SuppressWarnings("unused")
 public class GeneralSteps {
     
+    private DashboardPage dashboardPage;
     private LoginPage loginPage;
+    private MyProfilePage profilePage;
 
     @Step
     public void loginAsProvider() {
@@ -14,6 +18,21 @@ public class GeneralSteps {
         loginPage.enterProviderCredentials();
         loginPage.login();
         loginPage.checkUserLoggedIn("p1");
+    }
+    
+    @Step
+    public void checkOnDashboard() {
+        dashboardPage.checkOnDashboard();
+    }
+
+    @Step
+    public void clickMyProfile()  {
+        dashboardPage.clickMyProfile();
+    }
+
+    @Step
+    public void seeChangePassword()  {
+        profilePage.checkChangePassword();
     }
 
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
@@ -23,4 +23,12 @@ public class DashboardPage extends PageObject {
         click(this, $(".logoutButton"));
     }
 
+    public void clickMyProfile() {
+        click(this, $("#my_profile_tab"));
+    }
+
+    public void checkOnDashboard() {
+        assertThat(getTitle()).isEqualTo("Dashboard");
+    }
+    
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/MyProfilePage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/MyProfilePage.java
@@ -1,0 +1,13 @@
+package gov.medicaid.features.general.ui;
+
+import net.thucydides.core.pages.PageObject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MyProfilePage extends PageObject {
+    
+    public void checkChangePassword() {
+        String changeLinkText = $("#change_password_link").getText();
+        assertThat(changeLinkText).contains("Change Password");
+    }
+}

--- a/psm-app/integration-tests/src/test/resources/features/general/changepassword.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/changepassword.feature
@@ -1,0 +1,22 @@
+Feature: Provider changes their own Password
+  A provider wishes to change their password to prevent unauthorized access.
+
+@pull_568
+Scenario: Change Password Option
+  Given I am logged in
+  And I am on the dashboard page
+  When I click on My Profile
+  Then I should see the Change Password link
+
+@ignore
+Scenario: Visit Change Provider Page
+  Given I am on the My Profile page
+  When I click on Change Password
+  Then I should see the Update Password page
+
+@ignore 
+Scenario: Change Provider Password
+  Given I am on the Update Password page
+  When I enter a new password
+  And the correct old password
+  Then I should get a confirmation message


### PR DESCRIPTION
PR #568 fixed an issue where the change password link wasn't showing up
for providers.  This tests that, and will fail if the link disappears
again.  This also adds ignored features to be implemented later, testing
whether the change password link functions correctly.

@jasonaowen, I added ids to these elements even after our discussion in #585.  These links don't have existing classes, and finding them in the DOM was difficult.  Happy to discuss or remove if you think this isn't the right way to do it.  

Also, this should be merged after #585 so I can easily rebase/edit this to use the new step library introduced there.  Finally, if reviewers would rather not have `@ignore`'d features here then I can take them out or implement them as desired.

Thanks!  Testing this should just be running the integration tests, possibly editing/removing the change password link to see the test fail.