### PR TITLE
Allow system role full access for processing

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -77,7 +77,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -107,8 +106,9 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     /**
      * List of roles with full access to all profiles and tickets.
      */
-    private static final List<String> FULL_ACCESS = Collections.singletonList(
-            ViewStatics.ROLE_SERVICE_ADMINISTRATOR
+    private static final List<String> FULL_ACCESS = Arrays.asList(
+            ViewStatics.ROLE_SERVICE_ADMINISTRATOR,
+            ViewStatics.ROLE_SYSTEM_ADMINISTRATOR
     );
 
     /**


### PR DESCRIPTION
When I removed access from the system role in #524, we didn't understand how pervasive the PSM used the system role for internal processing. The first visible problem was that the post-processing of a submitted enrollment application failed, as the post-processing code no longer had permission to read or modify the application, but this was not the only problem.

We will continue to change internal processing code to no longer require the system user to have full access, but in the meantime, restore the functionality of the system to unblock development of other issues.

This partially reverts commit 83f2cbc22886e4c8ab856e0b6fc3ce42e800f1ce.

---

I tested this by submitted a new enrollment as a provider, verified it had a risk level assigned, then logged in as an admin and verified that the LEIE check was run and that I could approve the enrollment (and actually have it show up as approved).

Issue #10 Limit sys admins', service agents' ability to view, edit enrollments
Resolves #546 Post processing fails on submitted enrollment applications
PR #524 Restrict agents and system administrators