### PR TITLE
Add Checkstyle rules for unused, star, and illegal imports

### DIFF
--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -32,6 +32,7 @@
       <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
     </module>
     <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/>
     <module name="UnusedImports"/>
   </module>
 </module>

--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -31,5 +31,6 @@
       <property name="option" value="alone"/>
       <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
     </module>
+    <module name="UnusedImports"/>
   </module>
 </module>

--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -31,6 +31,7 @@
       <property name="option" value="alone"/>
       <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
     </module>
+    <module name="AvoidStarImport"/>
     <module name="UnusedImports"/>
   </module>
 </module>

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -17,7 +17,6 @@
 package gov.medicaid.services.impl;
 
 import gov.medicaid.binders.BinderUtils;
-import gov.medicaid.binders.XMLUtility;
 import gov.medicaid.domain.model.ApplicantType;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetLookupGroupsRequest;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
@@ -19,7 +19,6 @@ package gov.medicaid.controllers;
 import java.util.logging.Logger;
 import gov.medicaid.controllers.validators.StrictCustomDateEditor;
 import gov.medicaid.interceptors.HandlebarsInterceptor;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
@@ -16,16 +16,11 @@
 
 package gov.medicaid.controllers;
 
-import java.text.SimpleDateFormat;
-import java.util.Locale;
-
 import javax.servlet.http.HttpSession;
 
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.interceptors.FlashMessageInterceptor;
 import gov.medicaid.security.CMSPrincipal;
-
-import org.springframework.web.servlet.ModelAndView;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseServiceAdminController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseServiceAdminController.java
@@ -18,9 +18,7 @@ package gov.medicaid.controllers.admin;
 
 import gov.medicaid.controllers.ControllerHelper;
 import gov.medicaid.entities.CMSUser;
-import gov.medicaid.services.PortalServiceConfigurationException;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.stereotype.Controller;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/BaseSystemAdminController.java
@@ -19,7 +19,6 @@ package gov.medicaid.controllers.admin;
 import java.util.logging.Logger;
 import gov.medicaid.interceptors.HandlebarsInterceptor;
 import gov.medicaid.services.LookupService;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.RegistrationService;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
@@ -49,7 +49,6 @@ import gov.medicaid.domain.model.SpecialtiesType;
 import gov.medicaid.domain.model.ValidationResultType;
 import gov.medicaid.domain.model.VerificationStatusType;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
@@ -16,7 +16,11 @@
 
 package gov.medicaid.entities;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.io.Serializable;
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
@@ -16,10 +16,19 @@
 
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import java.io.Serializable;
 import java.math.BigDecimal;
-import javax.persistence.*;
-
 
 /**
  * Base class for beneficial owners of organizations.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -23,7 +23,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.Transient;
 import java.io.Serializable;
 import java.util.Date;
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
@@ -16,10 +16,13 @@
 
 package gov.medicaid.entities;
 
-import java.util.Date;
-
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.io.Serializable;
+import java.util.Date;
 
 @javax.persistence.Entity
 @Table(name = "notes")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
@@ -20,7 +20,6 @@ import java.util.Date;
 
 import javax.persistence.*;
 import java.io.Serializable;
-import java.util.List;
 
 @javax.persistence.Entity
 @Table(name = "notes")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
@@ -16,14 +16,19 @@
 
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
 /**
  * A corporate beneficial owner.
  *
  * @author TCSASSEMBLER
  * @version 1.0
  */
-import javax.persistence.*;
-
 @javax.persistence.Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(discriminatorType = DiscriminatorType.STRING)

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
@@ -16,7 +16,15 @@
 
 package gov.medicaid.entities;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.List;
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
@@ -16,6 +16,14 @@
 
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.io.Serializable;
 import java.util.Date;
 
 /**
@@ -24,9 +32,6 @@ import java.util.Date;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-import javax.persistence.*;
-import java.io.Serializable;
-
 @javax.persistence.Entity
 @Table(name = "pay_to_providers")
 public class PayToProvider implements Serializable {

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
@@ -16,8 +16,15 @@
 
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import java.util.Date;
-import javax.persistence.*;
 
 /**
  * A person beneficial owner.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderService.java
@@ -1,14 +1,20 @@
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.io.Serializable;
+
 /**
  * Represents services allowed for the given provider.
  *
  * @author TCSASSEMBLER
  * @version 1.0
  */
-
-import javax.persistence.*;
-import java.io.Serializable;
 
 @javax.persistence.Entity
 @Table(name = "provider_services")


### PR DESCRIPTION
Fix some of the warnings that IntelliJ keeps giving me by cleaning up a few `import` anti-patterns, and prevent some classes of comments on pull requests by adding Checkstyle rules.

I tested this by doing a clean build and running Checkstyle locally; any errors from these changes should result in at least one of those failing.

Issue #456 Use consistent code style