### PR TITLE
Remove Save Ticket JAXB types

### DIFF
--- a/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
@@ -97,15 +97,7 @@
             </sequence>
         </complexType>
     </element>
-    
-    <element name="SaveTicketResponse">
-        <complexType>
-            <sequence>
-                <element name="ticketNumber" maxOccurs="1" minOccurs="1" type="long" />
-            </sequence>
-        </complexType>
-    </element>
-    
+
     <element name="GetLookupGroupsRequest">
         <complexType>
             <sequence>

--- a/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
@@ -97,18 +97,6 @@
             </sequence>
         </complexType>
     </element>
-
-
-    <element name="SaveTicketRequest">
-        <complexType>
-            <sequence>
-                <element name="username" maxOccurs="1" minOccurs="1" type="string" />
-                <element name="systemId" maxOccurs="1" minOccurs="1" type="string" />
-                <element name="npi" maxOccurs="1" minOccurs="0" type="string" />
-                <element name="Enrollment" type="Q1:EnrollmentType" maxOccurs="1" minOccurs="1"></element>
-            </sequence>
-        </complexType>
-    </element>
     
     <element name="SaveTicketResponse">
         <complexType>

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -31,7 +31,6 @@ import gov.medicaid.domain.model.LookupGroupNames;
 import gov.medicaid.domain.model.LookupTableEntry;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
-import gov.medicaid.domain.model.SaveTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
 import gov.medicaid.entities.CMSUser;
@@ -214,20 +213,17 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
      * @param systemId   the system that authenticated the requesting user
      * @param npi        the NPI for which this user is a proxy, if any
      * @param enrollment the enrollment to save
-     * @return the service response
+     * @return the enrollment (ticket) ID
      * @throws PortalServiceException for any errors encountered
      */
-    public SaveTicketResponse saveTicket(
+    public long saveTicket(
             String username,
             String systemId,
             String npi,
             EnrollmentType enrollment
     ) throws PortalServiceException {
         CMSUser user = findUser(username, systemId, npi);
-        long ticketId = saveTicket(user, enrollment, true);
-        SaveTicketResponse response = new SaveTicketResponse();
-        response.setTicketNumber(ticketId);
-        return response;
+        return saveTicket(user, enrollment, true);
     }
 
     /**

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -31,7 +31,6 @@ import gov.medicaid.domain.model.LookupGroupNames;
 import gov.medicaid.domain.model.LookupTableEntry;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
-import gov.medicaid.domain.model.SaveTicketRequest;
 import gov.medicaid.domain.model.SaveTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
@@ -211,13 +210,20 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
     /**
      * Saves the ticket details.
      *
-     * @param request the service request
+     * @param username   the username of the requesting user
+     * @param systemId   the system that authenticated the requesting user
+     * @param npi        the NPI for which this user is a proxy, if any
+     * @param enrollment the enrollment to save
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
-    public SaveTicketResponse saveTicket(SaveTicketRequest request) throws PortalServiceException {
-        EnrollmentType enrollment = request.getEnrollment();
-        CMSUser user = findUser(request.getUsername(), request.getSystemId(), request.getNpi());
+    public SaveTicketResponse saveTicket(
+            String username,
+            String systemId,
+            String npi,
+            EnrollmentType enrollment
+    ) throws PortalServiceException {
+        CMSUser user = findUser(username, systemId, npi);
         long ticketId = saveTicket(user, enrollment, true);
         SaveTicketResponse response = new SaveTicketResponse();
         response.setTicketNumber(ticketId);

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -37,7 +37,6 @@ import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.domain.model.RequestType;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
-import gov.medicaid.domain.model.SaveTicketRequest;
 import gov.medicaid.domain.model.SaveTicketResponse;
 import gov.medicaid.domain.model.StatusMessageType;
 import gov.medicaid.domain.model.StatusMessagesType;
@@ -1040,13 +1039,13 @@ public class EnrollmentPageFlowController extends BaseController {
         }
 
         if (errors.isEmpty()) {
-            SaveTicketRequest serviceRequest = new SaveTicketRequest();
             CMSPrincipal principal = ControllerHelper.getPrincipal();
-            serviceRequest.setSystemId(principal.getAuthenticatedBySystem().name());
-            serviceRequest.setUsername(principal.getUsername());
-            serviceRequest.setNpi(principal.getUser().getProxyForNPI());
-            serviceRequest.setEnrollment(enrollment);
-            SaveTicketResponse serviceResponse = enrollmentWebService.saveTicket(serviceRequest);
+            SaveTicketResponse serviceResponse = enrollmentWebService.saveTicket(
+                    principal.getUsername(),
+                    principal.getAuthenticatedBySystem().name(),
+                    principal.getUser().getProxyForNPI(),
+                    enrollment
+            );
 
             ControllerHelper.flashPopup("saveAsDraftModal");
             ModelAndView mv = new ModelAndView("redirect:/provider/enrollment/view");

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -37,7 +37,6 @@ import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.domain.model.RequestType;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
-import gov.medicaid.domain.model.SaveTicketResponse;
 import gov.medicaid.domain.model.StatusMessageType;
 import gov.medicaid.domain.model.StatusMessagesType;
 import gov.medicaid.domain.model.SubmitTicketRequest;
@@ -1040,7 +1039,7 @@ public class EnrollmentPageFlowController extends BaseController {
 
         if (errors.isEmpty()) {
             CMSPrincipal principal = ControllerHelper.getPrincipal();
-            SaveTicketResponse serviceResponse = enrollmentWebService.saveTicket(
+            long enrollmentId = enrollmentWebService.saveTicket(
                     principal.getUsername(),
                     principal.getAuthenticatedBySystem().name(),
                     principal.getUser().getProxyForNPI(),
@@ -1049,7 +1048,7 @@ public class EnrollmentPageFlowController extends BaseController {
 
             ControllerHelper.flashPopup("saveAsDraftModal");
             ModelAndView mv = new ModelAndView("redirect:/provider/enrollment/view");
-            mv.addObject("id", serviceResponse.getTicketNumber());
+            mv.addObject("id", enrollmentId);
             status.setComplete();
             return mv;
         } else {

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -16,6 +16,7 @@
 
 package gov.medicaid.services;
 
+import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetLookupGroupsRequest;
 import gov.medicaid.domain.model.GetLookupGroupsResponse;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
@@ -24,7 +25,6 @@ import gov.medicaid.domain.model.GetTicketDetailsRequest;
 import gov.medicaid.domain.model.GetTicketDetailsResponse;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
-import gov.medicaid.domain.model.SaveTicketRequest;
 import gov.medicaid.domain.model.SaveTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
@@ -57,11 +57,19 @@ public interface EnrollmentWebService {
     /**
      * Saves the ticket details.
      *
-     * @param request the service request
+     * @param username   the username of the requesting user
+     * @param systemId   the system that authenticated the requesting user
+     * @param npi        the NPI for which this user is a proxy, if any
+     * @param enrollment the enrollment to save
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
-    public SaveTicketResponse saveTicket(SaveTicketRequest request) throws PortalServiceException;
+    public SaveTicketResponse saveTicket(
+            String username,
+            String systemId,
+            String npi,
+            EnrollmentType enrollment
+    ) throws PortalServiceException;
 
     /**
      * Submits the given enrollment request.

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -25,7 +25,6 @@ import gov.medicaid.domain.model.GetTicketDetailsRequest;
 import gov.medicaid.domain.model.GetTicketDetailsResponse;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
-import gov.medicaid.domain.model.SaveTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
 
@@ -61,10 +60,10 @@ public interface EnrollmentWebService {
      * @param systemId   the system that authenticated the requesting user
      * @param npi        the NPI for which this user is a proxy, if any
      * @param enrollment the enrollment to save
-     * @return the service response
+     * @return the enrollment (ticket) ID
      * @throws PortalServiceException for any errors encountered
      */
-    public SaveTicketResponse saveTicket(
+    public long saveTicket(
             String username,
             String systemId,
             String npi,


### PR DESCRIPTION
As I was tracing through the permissions checks for #546, I came across the `saveTicket` method, which had a parameter type and return type I hadn't encountered before. It turns out that each are JAXB-generated classes, and that the method and its single caller are the only places these two types are used. Remove both, so as to make it easier to read both the method and its caller, and to make it easier to change either.

To test this, I did a clean build (cleaning is necessary to regenerate the JAXB classes), deployed, logged in as a provider, started an enrollment, and then saved it as a draft.

Issue #596 Reduce use of JAXB class generation