### PR TITLE
Bundle user help docs in web app

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -162,9 +162,15 @@ project(':cms-business-process') {
 
 project(':cms-web') {
     apply plugin: 'war'
+
+    configurations {
+        userdocs
+    }
+
     dependencies {
         providedCompile project(':services')
         providedCompile fileTree(dir: 'WebContent/WEB-INF/lib')
+        userdocs project(path: ':userhelp', configuration: 'html')
         compile libs.spring_beans
         compile libs.spring_ldap
         compile libs.spring_security_acl
@@ -186,6 +192,12 @@ project(':cms-web') {
         configure(options) {
             noTimestamp true
             tags = ['endpoint:a:Endpoint:', 'verb:a:HTTP Verbs Allowed:']
+        }
+    }
+
+    war {
+        from(configurations.userdocs) {
+            into 'help'
         }
     }
 }
@@ -321,6 +333,10 @@ project(':integration-tests') {
 project(':userhelp') {
     apply plugin: BasePlugin
 
+    configurations {
+        html
+    }
+
     ['epub', 'html', 'latex',].each { name ->
         task(
             name,
@@ -353,6 +369,12 @@ project(':userhelp') {
     ) {
         sourceDirectory = 'source'
         builder = 'linkcheck'
+    }
+
+    artifacts {
+        html(html.outputDirectory) {
+            builtBy html
+        }
     }
 
     check.dependsOn linkcheck

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -38,9 +38,9 @@ ext.libs = [
         exclude group: 'org.hibernate.javax.persistence'
     },
     jbpm_persistence_jpa: dependencies.create("org.jbpm:jbpm-persistence-jpa:${jbpm_version}") {
-       exclude group: 'javax.transaction'
-       exclude group: 'org.hibernate'
-       exclude group: 'org.hibernate.javax.persistence'
+        exclude group: 'javax.transaction'
+        exclude group: 'org.hibernate'
+        exclude group: 'org.hibernate.javax.persistence'
     },
     spring_beans: "org.springframework:spring-beans:${spring_core_version}",
     spring_context: "org.springframework:spring-context:${spring_core_version}",
@@ -180,13 +180,13 @@ project(':cms-web') {
     webAppDirName = 'WebContent'
 
     task apiDocs(type: Javadoc) {
-      source = sourceSets.main.allJava
-      classpath += configurations.compile
-      destinationDir = reporting.file('api-docs')
-      configure(options) {
-        noTimestamp true
-        tags = ['endpoint:a:Endpoint:', 'verb:a:HTTP Verbs Allowed:']
-      }
+        source = sourceSets.main.allJava
+        classpath += configurations.compile
+        destinationDir = reporting.file('api-docs')
+        configure(options) {
+            noTimestamp true
+            tags = ['endpoint:a:Endpoint:', 'verb:a:HTTP Verbs Allowed:']
+        }
     }
 }
 

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -14,6 +14,7 @@
 
   <mvc:resources location="/js/" mapping="/js/**"/>
   <mvc:resources location="/css/" mapping="/css/**"/>
+  <mvc:resources location="/help/" mapping="/help/**"/>
   <mvc:resources location="/i/" mapping="/i/**"/>
 
   <mvc:annotation-driven/>

--- a/psm-app/cms-web/WebContent/WEB-INF/spring-security.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/spring-security.xml
@@ -11,6 +11,7 @@
     http://www.springframework.org/schema/context/spring-context-4.3.xsd">
   <s:http pattern="/css/**" security="none"/>
   <s:http pattern="/js/**" security="none"/>
+  <s:http pattern="/help/**" security="none"/>
   <s:http pattern="/i/**" security="none"/>
 
   <s:http entry-point-ref="authenticationProcessingFilterEntryPoint"

--- a/psm-app/cms-web/WebContent/templates/includes/header.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/header.template.html
@@ -2,7 +2,7 @@
   <div class="contentWidth">
     <div class="userSection">
       Welcome, <strong>{{principalUser.username}}</strong>
-      | <a href="javascript:;">Help</a>
+      | <a href="{{ctx}}/help/index.html">Help</a>
       | <form action="{{ctx}}/logout" method="post" class="logoutForm">
           <input type="submit" class="logoutButton" value="Logout"/>
           <input type="hidden" name="{{csrf.parameterName}}" value="{{csrf.token}}"/>


### PR DESCRIPTION
Build and include the HTML user documentation in the built PSM web application, and link to it from the (previously non-functional) "Help" link at the top of every page.

In order for `cms-web` to know about the output of `:userdocs:html`, we need to declare a configuration, and then link the output of the task to the configuration. For now, as we only need the HTML output, I only declared that configuration and output; hopefully this will be a useful template in case we ever need to refer to the results of the other tasks.

---

To test this, I built and deployed the app, logged in, and clicked the "Help" button at the top of the page, then clicked around.

---

See also:
- https://docs.gradle.org/current/userguide/artifact_management.html
- https://mrhaki.blogspot.com/2016/02/gradle-goodness-inter-project-artifact.html
- https://discuss.gradle.org/t/how-to-copy-files-from-a-custom-configuration-into-a-particular-war-directory/6004

Resolves #154 "Help" link does not display help
Resolves #359 Make user help docs reliably user-visible