### PR TITLE
Reproducibly build API docs by omitting timestamp

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -184,6 +184,7 @@ project(':cms-web') {
       classpath += configurations.compile
       destinationDir = reporting.file('api-docs')
       configure(options) {
+        noTimestamp true
         tags = ['endpoint:a:Endpoint:', 'verb:a:HTTP Verbs Allowed:']
       }
     }

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -183,7 +183,9 @@ project(':cms-web') {
       source = sourceSets.main.allJava
       classpath += configurations.compile
       destinationDir = reporting.file('api-docs')
-      options.optionFiles << file('javadoc.options')
+      configure(options) {
+        tags = ['endpoint:a:Endpoint:', 'verb:a:HTTP Verbs Allowed:']
+      }
     }
 }
 

--- a/psm-app/cms-web/javadoc.options
+++ b/psm-app/cms-web/javadoc.options
@@ -1,1 +1,0 @@
--subpackages . -tag 'endpoint:a:Endpoint:' -tag 'verb:a:HTTP Verbs Allowed:'


### PR DESCRIPTION
Refactor the `cms-web:apiDocs` task to use the native gradle [Javadoc support](https://docs.gradle.org/3.5/dsl/org.gradle.api.tasks.javadoc.Javadoc.html) for setting [Javadoc options](https://docs.gradle.org/3.5/javadoc/org/gradle/external/javadoc/StandardJavadocDocletOptions.html), and then add the equivalent of the `-notimestamp` option to prevent needless diffs.

From the [Reproducible Builds project](https://reproducible-builds.org/docs/timestamps/):

> Often the time of the build was used as an approximate way to know which version of the source has been built, and which tools had been used to do it. With reproducible builds, recording the time of the build becomes meaningless: on one side, the source code needs to be tracked more accurately than just a timestamp, and on the other side, the build environment needs to be defined or extensively recorded.

We were recording the source commit the API docs were built from (and should again), which is much more useful information than the date and time when the docs were built.

---

To test this, I ran `./gradlew cms-web:apiDocs` on `master`, moved the built docs from `cms-web/build/reports/api-docs/` into a temporary location, and then built the docs on this branch and compared with `diff --recursive --ignore-space-change --report-identical-files cms-web/build/reports/api-docs/ /tmp/javadoc/` and saw only the "Generated by javadoc" comment changes.

---

This resolves a comment @brainwane [raised in #478](https://github.com/SolutionGuidance/psm/pull/478#discussion_r158565990).