### PR TITLE
Remove jasypt

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -30,7 +30,6 @@ ext.libs = [
     hapi_fhir_structures: "ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:${hapi_fhir_version}",
     handlebars: 'com.github.jknack:handlebars:4.0.6',
     handlebars_springmvc: 'com.github.jknack:handlebars-springmvc:4.0.6',
-    jasypt: 'org.jasypt:jasypt:1.9.0',
     jbpm_human_task_core: dependencies.create("org.jbpm:jbpm-human-task-core:${jbpm_version}") {
         exclude group: 'javax.transaction'
         exclude group: 'org.apache.cxf'
@@ -102,7 +101,6 @@ project(':services') {
         compile libs.commons_codec
         compile libs.commons_lang
         compile libs.commons_lang3
-        compile libs.jasypt
         compile libs.jbpm_human_task_core
         compile libs.openpdf
         compile libs.velocity
@@ -258,7 +256,6 @@ project(':cms-portal-services') {
         earlib libs.commons_lang3
         earlib libs.hapi_fhir
         earlib libs.hapi_fhir_structures
-        earlib libs.jasypt
         earlib libs.jbpm_human_task_core
         earlib libs.jbpm_persistence_jpa
         earlib libs.openpdf

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -78,7 +78,7 @@ public class CMSConfigurator {
 
         if (globalSettings == null) {
             synchronized (CMSConfigurator.class) {
-                globalSettings = Util.newEncryptionEnabledProps();
+                globalSettings = new Properties();
                 try {
                     globalSettings.load(stream);
                 } catch (IOException e) {

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
@@ -21,11 +21,8 @@ import gov.medicaid.services.PortalServiceConfigurationException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
-import java.util.Properties;
 
 import org.apache.commons.codec.binary.Base64;
-import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
-import org.jasypt.properties.EncryptableProperties;
 
 /**
  * Common utility methods.
@@ -44,11 +41,6 @@ public class Util {
      * Environment variable expected for the environment type.
      */
     public static final String CMS_ENV = "cms.env";
-
-    /**
-     * Environment variable expected for the encryption key.
-     */
-    public static final String CMS_CRYPT_PASSWORD = "cms.crypt.password";
 
     /**
      * Private constructor.
@@ -153,32 +145,6 @@ public class Util {
     @SuppressWarnings("rawtypes")
     public static boolean isNotEmpty(List values) {
         return !isEmpty(values);
-    }
-
-    /**
-     * Creates a new properties instance, it checks the environment if the app is running in production mode, if yes,
-     * then the properties file supports encrypted values.
-     *
-     * @return the properties implementation
-     */
-    public static Properties newEncryptionEnabledProps() {
-        Properties props;
-        // for production, we expect all sensitive properties to be encrypted
-        if (PRODUCTION.equals(System.getProperty(CMS_ENV))) {
-            String password = System.getProperty(CMS_CRYPT_PASSWORD);
-            if (isBlank(password)) {
-                throw new PortalServiceConfigurationException(CMS_CRYPT_PASSWORD
-                    + " is not found, please set the environment "
-                    + "variable before starting up the application in PROD mode.");
-            }
-
-            StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
-            encryptor.setPassword(password);
-            props = new EncryptableProperties(encryptor);
-        } else {
-            props = new Properties();
-        }
-        return props;
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
@@ -182,17 +182,6 @@ public class Util {
     }
 
     /**
-     * Left pads the given value with the given character to a specific width.
-     * @param value the value to be padded
-     * @param i the width expected
-     * @param c the padding character
-     * @return the padded string
-     */
-    public static String pad(String value, int i, char c) {
-        return String.format("%" + i + "s", value).replace(' ', c);
-    }
-
-    /**
      * Hashes the given string using the given salt value.
      * @param value the value to be hashed
      * @param salt the salt for the hash

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
@@ -87,20 +87,6 @@ public class Util {
     }
 
     /**
-     * Replace page and query string.
-     *
-     * @param original the original url
-     * @param lastPart the last part to use
-     * @return the original url up to the last / appended with the given last part
-     */
-    public static String replaceLastURLPart(String original, String lastPart) {
-        StringBuffer sb = new StringBuffer();
-        sb.append(original.substring(0, original.lastIndexOf("/") + 1));
-        sb.append(lastPart);
-        return sb.toString();
-    }
-
-    /**
      * Checks if the given value contains only digits.
      *
      * @param value the value to check

--- a/psm-app/services/src/main/resources/cms.properties
+++ b/psm-app/services/src/main/resources/cms.properties
@@ -1,7 +1,4 @@
-#
-# This file configures the CMS app, you can use encrypted values as this is read via JASYPT
-# please see http://www.jasypt.org/encrypting-configuration.html for additional information
-#
+# This file configures the Provider Screening Module
 
 email.NEW_REGISTRATION.subject=Successful registration to CMS.
 email.NEW_REGISTRATION.template=/emails/registration_success.txt


### PR DESCRIPTION
The PSM previously allowed for encrypting values in `cms.properties`, but this functionality was barely documented - only a single mention in the header with a link to [a page on the jasypt site](http://www.jasypt.org/encrypting-configuration.html).

The [jasypt library](http://www.jasypt.org/), itself, seems to be abandoned - the last release was in February 2014. It's also [not entirely clear that its encryption/decryption routines are robust](https://security.stackexchange.com/a/65240).

If this functionality turns out to be worthwhile, we should reimplement it using modern, maintained, secure alternatives to jasypt.

Along the way, remove some nearby unused utility methods.

---

To test this, I built, deployed, and ran the integration tests. I would expect a compilation failure if any of the deleted methods were referenced, and the integration tests would fail if the app were unable to load `cms.properties`.

---

Issue #16 Manage sets of dependencies via Gradle or another tool