### PR TITLE
Upgrade Groovy to 2.4.13

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -89,7 +89,7 @@ allprojects {
         }
 
         dependencies {
-            testCompile 'org.codehaus.groovy:groovy-all:2.4.10'
+            testCompile 'org.codehaus.groovy:groovy-all:2.4.13'
             testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
         }
     }


### PR DESCRIPTION
Use the [latest stable version of Groovy](http://groovy-lang.org/changelogs/changelog-2.4.13.html) in our unit tests.

I tested this by running

```
./gradlew cms-{business-model,business-process,portal-services,web}:test services:test
```

and seeing the tests pass.

Issue #16 Manage sets of dependencies via Gradle or another tool