### PR TITLE
Remove unused "export PDF folder" property

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -354,15 +354,6 @@ public class CMSConfigurator {
     }
 
     /**
-     * Gets the configured pdf files folder
-     *
-     * @return the pdf files folder
-     */
-    public String getExportPDFFolder() {
-        return globalSettings.getProperty("export.pdf.folder");
-    }
-
-    /**
      * The allowed referrer domain for MN logins.
      * @return the configured domain
      */

--- a/psm-app/services/src/main/resources/cms.properties
+++ b/psm-app/services/src/main/resources/cms.properties
@@ -247,7 +247,6 @@ extsources.PROD.base=http://prod.example.com
 
 # use guvnor or embedded rules (no spaces please) Y/N
 rules.embedded=Y
-export.pdf.folder=C:/Export/PDF
 
 # allowed internal domain for MN portal
 internalSecurityDomain=localhost


### PR DESCRIPTION
This property was only used by the FileNet service, which we removed in PR #220. Delete the property and the helper method used to access it.

Found while researching what options in `cms.properties` might need to be encrypted.

Issue #215 Add extension points to allow per-state integration
PR #220 Remove legacy integrations
Issue #614 Encrypt secret configuration options at rest