### PR TITLE
Add checkstyle rules

### DIFF
--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -22,6 +22,7 @@
       <property name="tokens" value="PACKAGE_DEF, IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF"/>
     </module>
     <module name="LeftCurly"/>
+    <module name="NeedBraces"/>
     <module name="RightCurly">
       <property name="id" value="RightCurlySame"/>
       <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
@@ -34,5 +35,8 @@
     <module name="AvoidStarImport"/>
     <module name="IllegalImport"/>
     <module name="UnusedImports"/>
+    <module name="OneStatementPerLine"/>
+    <module name="PackageDeclaration"/>
+    <module name="StringLiteralEquality"/>
   </module>
 </module>


### PR DESCRIPTION
Enforce some rules that our codebase is already following:

- Check that there is only [one statement per line](http://checkstyle.sourceforge.net/config_coding.html#OneStatementPerLine)
- Ensure that each class has a [package declaration](http://checkstyle.sourceforge.net/config_coding.html#PackageDeclaration), which matches its filename
- Check that [string literals are not used with `==` or `!=`](http://checkstyle.sourceforge.net/config_coding.html#StringLiteralEquality), which measures object equality
- Checks for [braces around code blocks](http://checkstyle.sourceforge.net/config_blocks.html#NeedBraces) (aka no inline `if` statements)

Issue #456 Use consistent code style