### PR TITLE
Upgrade Serenity

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -16,7 +16,7 @@ def jbpm_version = '5.4.0.Final'
 def hapi_fhir_version = '3.1.0'
 def spring_core_version = '4.3.12.RELEASE'
 def spring_security_version = '4.2.3.RELEASE'
-def serenity_version = '1.5.5'
+def serenity_version = '1.8.20'
 
 // These libraries are known to be used, since they are required during compile
 // or on immediate deployment
@@ -278,7 +278,7 @@ project(':integration-tests') {
     dependencies {
         testCompile "net.serenity-bdd:serenity-core:${serenity_version}"
         testCompile "net.serenity-bdd:serenity-junit:${serenity_version}"
-        testCompile 'net.serenity-bdd:serenity-cucumber:1.1.35'
+        testCompile 'net.serenity-bdd:serenity-cucumber:1.6.9'
         testCompile 'junit:junit:4.12'
         testCompile 'org.assertj:assertj-core:3.8.0'
     }


### PR DESCRIPTION
Use [1.8.20 of serenity-core and serenity-junit](https://github.com/serenity-bdd/serenity-core/releases/tag/v1.8.20), and version [1.6.9 of serenity-cucumber](https://github.com/serenity-bdd/serenity-cucumber/releases/tag/v1.6.9).

Stay on 1.4.0 of serenity-gradle-plugin, as newer versions seem to be incompatible with the apparently no-longer-maintained [gradle-jaxb-plugin 1.3.6](https://github.com/jacobono/gradle-jaxb-plugin/releases/tag/1.3.6).

---

I tested this by running the integration tests.

---

Issue #16 Manage sets of dependencies via Gradle or another tool