### PR TITLE
Upgrade Apache Velocity to version 2.0

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -52,7 +52,7 @@ ext.libs = [
     spring_security_ldap: "org.springframework.security:spring-security-ldap:${spring_security_version}",
     spring_security_taglibs: "org.springframework.security:spring-security-taglibs:${spring_security_version}",
     spring_webmvc: "org.springframework:spring-webmvc:${spring_core_version}",
-    velocity: 'org.apache.velocity:velocity:1.7',
+    velocity: 'org.apache.velocity:velocity-engine-core:2.0',
 ]
 
 allprojects {


### PR DESCRIPTION
After nearly seven years, Apache released a new version of the Velocity template engine! We use Velocity to handle email templates around registration, and (thankfully!) for our use case, the upgrade seems to be a drop-in replacement.

- https://velocity.apache.org/news.html#engine20
- https://velocity.apache.org/engine/2.0/
- https://velocity.apache.org/engine/2.0/changes.html
- https://velocity.apache.org/engine/2.0/upgrading.html

---

I tested this by causing each of the [4 email templates](https://github.com/SolutionGuidance/psm/blob/bcab22c4ec8ccc5f7b2c7b2a9519a5c1b09d032f/psm-app/services/src/main/java/gov/medicaid/entities/EmailTemplate.java#L27-L45) to be sent:
- new registration by user (self sign up)
- new registration by admin
- password change by user
- password change by admin (same template as previous)
- forgot password

In each case, I saw the expected email in the [debug smtpd](https://github.com/SolutionGuidance/psm/blob/16-upgrade-velocity/INSTALL.md#install-prerequisites).

---

Issue #16 Manage sets of dependencies via Gradle or another tool