### PR TITLE
Migrate from commons-lang to commons-lang3

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -24,7 +24,6 @@ ext.libs = [
     commons_codec: 'commons-codec:commons-codec:1.11',
     commons_fileupload: 'commons-fileupload:commons-fileupload:1.3.3',
     commons_io: 'commons-io:commons-io:2.6',
-    commons_lang: 'commons-lang:commons-lang:2.6',
     commons_lang3: 'org.apache.commons:commons-lang3:3.7',
     hapi_fhir: "ca.uhn.hapi.fhir:hapi-fhir-client-okhttp:${hapi_fhir_version}",
     hapi_fhir_structures: "ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:${hapi_fhir_version}",
@@ -51,6 +50,7 @@ ext.libs = [
     spring_security_core: "org.springframework.security:spring-security-core:${spring_security_version}",
     spring_security_ldap: "org.springframework.security:spring-security-ldap:${spring_security_version}",
     spring_security_taglibs: "org.springframework.security:spring-security-taglibs:${spring_security_version}",
+    spring_web: "org.springframework:spring-web:${spring_core_version}",
     spring_webmvc: "org.springframework:spring-webmvc:${spring_core_version}",
     velocity: 'org.apache.velocity:velocity:1.7',
 ]
@@ -90,10 +90,10 @@ project(':services') {
 
     dependencies {
         compile libs.commons_codec
-        compile libs.commons_lang
         compile libs.commons_lang3
         compile libs.jbpm_human_task_core
         compile libs.openpdf
+        compile libs.spring_web
         compile libs.velocity
         compile fileTree(dir: '../cms-portal-services/lib', include: '*.jar')
         compile project(path: ':cms-business-model', configuration: 'archives')
@@ -120,7 +120,6 @@ project(':cms-business-process') {
         compile project(path: ':cms-business-model', configuration: 'archives')
         compile libs.commons_codec
         compile libs.commons_io
-        compile libs.commons_lang
         compile libs.commons_lang3
         compile libs.hapi_fhir
         compile libs.hapi_fhir_structures
@@ -164,6 +163,7 @@ project(':cms-web') {
         compile libs.spring_security_config
         compile libs.spring_security_ldap
         compile libs.spring_security_taglibs
+        compile libs.spring_web
         compile libs.spring_webmvc
         runtime libs.handlebars
         runtime libs.handlebars_springmvc
@@ -239,7 +239,6 @@ project(':cms-portal-services') {
         earlib libs.commons_codec
         earlib libs.commons_fileupload
         earlib libs.commons_io
-        earlib libs.commons_lang
         earlib libs.commons_lang3
         earlib libs.hapi_fhir
         earlib libs.hapi_fhir_structures

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -57,7 +57,7 @@ import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 import gov.medicaid.services.util.Util;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 
 import javax.ejb.Local;
 import javax.ejb.Stateless;
@@ -839,7 +839,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             SystemId sourceSystem,
             ProviderProfile profile
     ) throws PortalServiceException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("Profile import is not yet supported.");
     }
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
@@ -7,7 +7,7 @@ package gov.medicaid.controllers;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.util.Util;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.springframework.web.util.HtmlUtils;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -57,7 +57,7 @@ public class FullnameTag extends SimpleTagSupport {
             JspWriter out = pageContext.getOut();
             try {
                 if (Util.isNotBlank(user.getFirstName())) {
-                    out.println(StringEscapeUtils.escapeHtml(
+                    out.println(HtmlUtils.htmlEscape(
                             user.getFirstName() + " " + user.getLastName())
                     );
                 } else {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
@@ -7,8 +7,7 @@ package gov.medicaid.controllers;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.util.Util;
-
-import java.io.IOException;
+import org.apache.commons.lang.StringEscapeUtils;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -16,8 +15,7 @@ import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.SimpleTagSupport;
-
-import org.apache.commons.lang.StringEscapeUtils;
+import java.io.IOException;
 
 /**
  * This tag library will print the full name of the user given the id.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
@@ -31,7 +31,7 @@ public class FullnameTag extends SimpleTagSupport {
      * The entity manager to use when getting the user information.
      */
     private final EntityManager em;
-    
+
     /**
      * Creates a new instance.
      */
@@ -39,12 +39,12 @@ public class FullnameTag extends SimpleTagSupport {
         CMSConfigurator config = new CMSConfigurator();
         em = config.getPortalEntityManager();
     }
-    
+
     /**
      * The user id to be retrieved.
      */
     private String userId;
-    
+
     /**
      * Prints the full name of the user with the provided id.
      */
@@ -55,22 +55,25 @@ public class FullnameTag extends SimpleTagSupport {
             query.setParameter("userId", userId);
             CMSUser user = (CMSUser) query.getSingleResult();
 
-            PageContext pageContext = (PageContext) getJspContext(); 
-            JspWriter out = pageContext.getOut(); 
+            PageContext pageContext = (PageContext) getJspContext();
+            JspWriter out = pageContext.getOut();
             try {
                 if (Util.isNotBlank(user.getFirstName())) {
-                    out.println(StringEscapeUtils.escapeHtml(user.getFirstName() + " " + user.getLastName()));
+                    out.println(StringEscapeUtils.escapeHtml(
+                            user.getFirstName() + " " + user.getLastName())
+                    );
                 } else {
                     out.println(userId);
                 }
-            } catch (Exception e) { 
-                // Ignore. 
-            } 
+            } catch (Exception e) {
+                // Ignore.
+            }
         }
     }
 
     /**
      * Gets the value of the field <code>userId</code>.
+     *
      * @return the userId
      */
     public String getUserId() {
@@ -79,6 +82,7 @@ public class FullnameTag extends SimpleTagSupport {
 
     /**
      * Sets the value of the field <code>userId</code>.
+     *
      * @param userId the userId to set
      */
     public void setUserId(String userId) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -164,8 +164,8 @@ public abstract class BaseFormBinder implements FormBinder {
 
     /**
      * Retrieves the indexed name of the parameter.
+     *
      * @param key the base name
-     * @param idx the parameter index
      * @return the generated key
      */
     protected String name(String key) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -16,6 +16,8 @@
 
 package gov.medicaid.binders;
 
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
 import gov.medicaid.domain.model.AddressType;
 import gov.medicaid.domain.model.ApplicantType;
 import gov.medicaid.domain.model.EnrollmentType;
@@ -33,19 +35,14 @@ import gov.medicaid.entities.dto.FormError;
 import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.LookupService;
 import gov.medicaid.services.ProviderEnrollmentService;
+import org.apache.commons.lang.StringEscapeUtils;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.commons.lang.StringEscapeUtils;
-
-import com.lowagie.text.Document;
-import com.lowagie.text.DocumentException;
 
 /**
  * Base class for the form binders.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -35,7 +35,7 @@ import gov.medicaid.entities.dto.FormError;
 import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.LookupService;
 import gov.medicaid.services.ProviderEnrollmentService;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.springframework.web.util.HtmlUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Calendar;
@@ -190,7 +190,7 @@ public abstract class BaseFormBinder implements FormBinder {
      * @param value the value to be set
      */
     protected void attr(Map<String, Object> mv, String key, String value) {
-        mv.put(name(key), StringEscapeUtils.escapeHtml(value));
+        mv.put(name(key), HtmlUtils.htmlEscape(value));
     }
 
     /**
@@ -217,7 +217,7 @@ public abstract class BaseFormBinder implements FormBinder {
      * @param value the value to be set
      */
     protected void attr(Map<String, Object> mv, String key, int idx, String value) {
-        mv.put(name(key, idx), StringEscapeUtils.escapeHtml(value));
+        mv.put(name(key, idx), HtmlUtils.htmlEscape(value));
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
@@ -24,14 +24,12 @@ import gov.medicaid.entities.CMSUser;
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.dto.FormError;
+import org.apache.commons.lang.StringUtils;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.commons.lang.StringUtils;
 
 /**
  * This binder handles the organization disclosure.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
@@ -24,7 +24,7 @@ import gov.medicaid.entities.CMSUser;
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.dto.FormError;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;


### PR DESCRIPTION
The [Apache Commons Lang library](https://commons.apache.org/proper/commons-lang/) has two major versions, version 2 (legacy, unmaintained) and version 3 (stable). Stop using version 2 in our code, and replace those usages either with calls to version 3 or to other utility libraries - namely, `HtmlUtils` in `spring-web`.

As we are explicitly using code from `spring-web`, add an explicit dependency in gradle to the projects using it.

With #627, this will remove `commons-lang` from our project; the old version of Velocity depends on `commons-lang:2.4` (and therefore, transitively, so do we), but the new version depends on `commons-lang3`. This should be merged after #627, as it removes the pin to `commons-lang:2.6` which gradle applies to transitive dependencies.

Also clean up some code along the way.

---

I tested this by building, deploying, and verifying that I could submit an enrollment with HTML tags (side note: I also did a super cursory attempt at XSS, which the PSM resisted. Yay!); I also was able to edit an approved enrollment with a note, and see the full name of the person who added the note.

---

Issue #16 Manage sets of dependencies via Gradle or another tool