### PR TITLE
Explicitly depend on WildFly-provided libraries

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -56,7 +56,12 @@ ext.libs = [
 ]
 
 ext.provided_libs = [
+    ejb_api: 'javax.ejb:javax.ejb-api:3.2',
     hibernate_core: 'org.hibernate:hibernate-core:5.0.10.Final',
+    hibernate_jpa: 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final',
+    jsp_api: 'javax.servlet.jsp:javax.servlet.jsp-api:2.3.0',
+    servlet_api: 'javax.servlet:javax.servlet-api:3.1.0',
+    validation_api: 'javax.validation:validation-api:1.1.0.Final',
 ]
 
 allprojects {
@@ -77,6 +82,10 @@ allprojects {
 ].each { name ->
     project(":$name") {
         apply plugin: 'groovy'
+
+        configurations {
+            testCompile.extendsFrom compileOnly
+        }
 
         repositories {
             mavenCentral()
@@ -101,8 +110,10 @@ project(':services') {
         compile libs.velocity
         compile fileTree(dir: '../cms-portal-services/lib', include: '*.jar')
         compile project(path: ':cms-business-model', configuration: 'archives')
-        compile fileTree(dir: '../../../wildfly-10.1.0.Final/modules/system/layers/base/javax')
+        compileOnly provided_libs.ejb_api
         compileOnly provided_libs.hibernate_core
+        compileOnly provided_libs.hibernate_jpa
+        compileOnly provided_libs.servlet_api
     }
     sourceSets {
         main {
@@ -132,8 +143,9 @@ project(':cms-business-process') {
         compile libs.spring_security_core
         compile libs.velocity
         compile fileTree(dir: '../cms-portal-services/lib', include: '*.jar')
-        compile fileTree(dir: '../../../wildfly-10.1.0.Final/modules/system/layers/base/javax')
+        compileOnly provided_libs.ejb_api
         compileOnly provided_libs.hibernate_core
+        compileOnly provided_libs.servlet_api
         runtime libs.jbpm_persistence_jpa
     }
 
@@ -169,6 +181,10 @@ project(':cms-web') {
         compile libs.spring_security_taglibs
         compile libs.spring_web
         compile libs.spring_webmvc
+        compileOnly provided_libs.hibernate_jpa
+        compileOnly provided_libs.jsp_api
+        compileOnly provided_libs.servlet_api
+        compileOnly provided_libs.validation_api
         runtime libs.handlebars
         runtime libs.handlebars_springmvc
     }

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -55,6 +55,10 @@ ext.libs = [
     velocity: 'org.apache.velocity:velocity-engine-core:2.0',
 ]
 
+ext.provided_libs = [
+    hibernate_core: 'org.hibernate:hibernate-core:5.0.10.Final',
+]
+
 allprojects {
     apply plugin: 'checkstyle'
 
@@ -98,7 +102,7 @@ project(':services') {
         compile fileTree(dir: '../cms-portal-services/lib', include: '*.jar')
         compile project(path: ':cms-business-model', configuration: 'archives')
         compile fileTree(dir: '../../../wildfly-10.1.0.Final/modules/system/layers/base/javax')
-        compile fileTree(dir: '../../../wildfly-10.1.0.Final/modules/system/layers/base/org/hibernate')
+        compileOnly provided_libs.hibernate_core
     }
     sourceSets {
         main {
@@ -129,7 +133,7 @@ project(':cms-business-process') {
         compile libs.velocity
         compile fileTree(dir: '../cms-portal-services/lib', include: '*.jar')
         compile fileTree(dir: '../../../wildfly-10.1.0.Final/modules/system/layers/base/javax')
-        compile fileTree(dir: '../../../wildfly-10.1.0.Final/modules/system/layers/base/org/hibernate')
+        compileOnly provided_libs.hibernate_core
         runtime libs.jbpm_persistence_jpa
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
@@ -21,7 +21,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
 
 /**
  * Audit record details.
@@ -43,8 +42,10 @@ public class AuditDetail {
     /**
      * The header record id.
      */
-    @NotNull
-    @Column(name = "audit_record_id")
+    @Column(
+            name = "audit_record_id",
+            nullable = false
+    )
     private long auditRecordId;
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
@@ -16,9 +16,9 @@
 
 package gov.medicaid.entities;
 
+import javax.persistence.Column;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 
 /**
@@ -36,7 +36,7 @@ public class Authentication implements Serializable {
     /**
      * The hashed password.
      */
-    @NotNull
+    @Column(nullable = false)
     private String password;
 
     /**


### PR DESCRIPTION
WildFly ships with several libraries, which are available to applications deployed to it at runtime. We also need those libraries to compile our application. Previously, we required a copy of WildFly to live in a particular directory to pick up those libraries. We shouldn't do that, though!

Instead, explicitly depend on the libraries we require, and use the [gradle `compileOnly` scope](https://blog.gradle.org/introducing-compile-only-dependencies) to indicate that these dependencies are available at runtime and should not be bundled into our application.

Along the way, fix a `@NotNull` vs `@Column(nullable = false)` mistake I made during our Hibernate migration, so as to avoid introducing an additional dependency.

I believe this is the last piece of issue #16!

---

I tested this by doing a clean build (which should pick up any missing dependencies), running the unit tests (`./gradlew {cms-business-model,cms-business-process,cms-portal-services,cms-web,services}:test`), deploying, and running the integration tests (`./gradlew integration-tests:{clean,test,aggregate}`).

---

Resolves #16 Manage sets of dependencies via Gradle or another tool