### PR TITLE
Add language declarations to <html> tags in 6 JSP templates

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
@@ -11,7 +11,7 @@
 <c:set value="false" var="hasArrow"></c:set>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set value="Advanced Search (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
@@ -11,7 +11,7 @@
 <c:set value="false" var="hasArrow"></c:set>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set value="Advanced Search (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
@@ -11,7 +11,7 @@
 <c:set value="true" var="hasArrow"></c:set>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set value="User Account Details (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
@@ -11,7 +11,7 @@
 <c:set value="true" var="hasArrow"></c:set>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:choose>
     <c:when test="${not empty user.userId}">
       <c:set value="Edit User Account (System Admin)" var="title"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
@@ -11,7 +11,7 @@
 <c:set value="true" var="hasArrow"></c:set>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set value="User Account (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
@@ -11,7 +11,7 @@
 <c:set value="false" var="hasArrow"></c:set>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
   <c:set value="Advanced Search (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />


### PR DESCRIPTION
These 6 JSP templates did not have an <html> tag before PR #542
"Refactor and remove admin/includes/header.jsp and footer.jsp",
so the language declaration was not added to them in PR #549:
"Add language declaration to <html> tags (accessibility)".

Issue #517: Add language declaration to HTML header