### PR TITLE
Change admin dashboard table heading from "action" to "status"

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -50,7 +50,7 @@
                       <th class="alignCenter">Provider Name<span class="sep"></span></th>
                       <th class="alignCenter">Request Type<span class="sep"></span></th>
                       <th class="alignCenter">Date<span class="sep"></span></th>
-                      <th class="alignCenter">Action<span class="sep"></span></th>
+                      <th class="alignCenter">Status<span class="sep"></span></th>
                     </tr>
                   </thead>
                   <tbody>


### PR DESCRIPTION
Fixes the admin dashboard table heading that was "Action" when it should have been "Status".

Tested by logging in as an admin user and confirming that the table heading was indeed changed to "Status" instead of the previous "Action".

![screenshot-2018-1-12 dashboard](https://user-images.githubusercontent.com/1091693/34896507-21544f88-f7b8-11e7-89c3-a90e767499b3.png)


Resolves #539 Admin dashboard menu has "action" instead of "status"