### PR TITLE
Tell Javadoc about WildFly-provided libraries

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -193,6 +193,7 @@ project(':cms-web') {
     task apiDocs(type: Javadoc) {
         source = sourceSets.main.allJava
         classpath += configurations.compile
+        classpath += configurations.compileOnly
         destinationDir = reporting.file('api-docs')
         configure(options) {
             noTimestamp true


### PR DESCRIPTION
Allow Javadoc to better-understand the controllers' source code by giving it access to the libraries in the `compileOnly` configuration.

This cleans up the warnings when running `./gradlew cms-web:apiDocs`, introduced in #630 and discovered as part of setting up Jenkins.

Issue #16 Manage sets of dependencies via Gradle or another tool
PR #630 Explicitly depend on WildFly-provided libraries