### PR TITLE
Remove unused JavaScript reference to EFT input

### DIFF
--- a/psm-app/cms-web/WebContent/js/script.js
+++ b/psm-app/cms-web/WebContent/js/script.js
@@ -196,7 +196,6 @@ $(document).ready(function () {
   $("input.npiMasked").mask("9999999999");
   $("input.umpiMasked").mask("**********");
   $("input.feinMasked").mask("99-9999999");
-  $("input.eftMasked").mask("9999999999-999");
   $("input.taxIdMasked").mask("9999999");
   $("input.countyMask").mask("999");
   $("input.fiscalMonthInput, input.fiscalYearInput").mask("99");


### PR DESCRIPTION
The EFT input form field had some client-side JavaScript input validation, using the masked input library. The form field was deleted in PR #531; also delete the related JavaScript.

Discovered while reviewing the input field validation around FEIN for #635.

Issue #411 Add a "do you accept EFT" checkbox
PR #531 Convert 'EFT Vendor Number' to 'EFT Accepted' 