### PR TITLE
Fix maximum length attribute on input fields

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
@@ -43,7 +43,7 @@
     
                 <c:set var="formName" value="_10_ssn"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="text" class="normalInput ssnMasked" name="${formName}" value="${formValue}" maxlength="9"/>
+                <input type="text" class="normalInput ssnMasked" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
 
             <div class="row addressline1">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
@@ -98,7 +98,7 @@
                         
                         <c:set var="formName" value="_15_fein"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="7"/>
+                        <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
                     <div class="row requireField">
@@ -246,7 +246,7 @@
                         
                         <c:set var="formName" value="_15_fein"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="7"/>
+                        <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
                     <div class="row requireField">
@@ -373,7 +373,7 @@
 
                         <c:set var="formName" value="_15_fein"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="7"/>
+                        <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
                     <div class="row">
@@ -658,7 +658,7 @@
 
                     <c:set var="formName" value="_15_fein"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="7"/>
+                    <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="10"/>
                 </div>
 
                 <div class="row">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -618,7 +618,7 @@
                 <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_17_cboFEIN"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="text" class="wholeInput smallInput feinMasked" name="${formName}" value="${formValue}" maxlength="7"/>
+                <input type="text" class="wholeInput smallInput feinMasked" name="${formName}" value="${formValue}" maxlength="10"/>
                 <div class="clearFixed"></div>
             </div>
             <div class="row requiredField addressline1">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
@@ -98,7 +98,7 @@
                 <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_ssn_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <input type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="9"/>
+                <input type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
             <div class="row requireField">
                 <label>


### PR DESCRIPTION
We use some JavaScript client-side validation to make sure the user's input matches some patterns and to ease input of such patterns; you can see the list [in the source code](https://github.com/SolutionGuidance/psm/blob/9ccd7f97622ae841ac61dc581b414a0a6f8cb20d/psm-app/cms-web/WebContent/js/script.js#L194-L202). We also use the HTML `<input>` element attribute [`maxlength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-maxlength), but those attributes were not all set correctly. Fix them for FEIN and SSN input fields.

---

As neither Firefox nor Chrome seem to be validating the `maxlength` property in our app, and Edge is, and I don't currently have access to an Edge browser, I'm not able to test that this fixes the problem on Edge. @cecilia-donnelly has graciously agreed to test this PR.

---

Issue #635 FEIN validation error in Internet Explorer