### PR TITLE
Remove redundant modifiers in interfaces

### DIFF
--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -38,6 +38,7 @@
       <property name="option" value="alone"/>
       <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
     </module>
+    <module name="RedundantModifier"/>
     <module name="AvoidStarImport"/>
     <module name="IllegalImport"/>
     <module name="UnusedImports"/>

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ResultMatchResolver.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ResultMatchResolver.java
@@ -38,6 +38,9 @@ public interface ResultMatchResolver {
      * @param results the external search results
      * @return the match status
      */
-    public MatchStatus match(ProviderInformationType provider, Object object,
-        ExternalSourcesScreeningResultType results);
+    MatchStatus match(
+            ProviderInformationType provider,
+            Object object,
+            ExternalSourcesScreeningResultType results
+    );
 }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/KnowledgeDelegate.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/KnowledgeDelegate.java
@@ -37,28 +37,31 @@ public interface KnowledgeDelegate {
      *
      * @return the session created
      */
-    public abstract StatefulKnowledgeSession newWorkflowSession(EntityManagerFactory entityManagerFactory, UserTransaction utx);
+    StatefulKnowledgeSession newWorkflowSession(
+            EntityManagerFactory entityManagerFactory,
+            UserTransaction utx
+    );
 
     /**
      * Creates a new validation session.
      *
      * @return a new screening knowledge session
      */
-    public abstract StatefulKnowledgeSession newScreeningValidationSession();
+    StatefulKnowledgeSession newScreeningValidationSession();
 
     /**
      * Creates a new session for configuring external sources.
      *
      * @return a new session.
      */
-    public abstract StatefulKnowledgeSession newExternalSourcesConfigSession();
+    StatefulKnowledgeSession newExternalSourcesConfigSession();
 
     /**
      * Creates a new session for running frontend validation.
      *
      * @return a new session.
      */
-    public abstract StatefulKnowledgeSession newValidationSession();
+    StatefulKnowledgeSession newValidationSession();
 
     /**
      * Reloads a persisted session
@@ -67,6 +70,9 @@ public interface KnowledgeDelegate {
      * @param utx the user transaction to be used
      * @return the loaded session
      */
-    public StatefulKnowledgeSession reloadWorkflowSession(int sessionId, EntityManagerFactory factory, UserTransaction utx);
-
+    StatefulKnowledgeSession reloadWorkflowSession(
+            int sessionId,
+            EntityManagerFactory factory,
+            UserTransaction utx
+    );
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
@@ -83,8 +83,7 @@ public interface FormBinder {
      * @param ticket the persistent model
      * @param enrollment the front end model
      */
-    public void bindFromHibernate(Enrollment ticket, EnrollmentType enrollment);
-
+    void bindFromHibernate(Enrollment ticket, EnrollmentType enrollment);
 
     /**
      * Renders the PDF representation of the form.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SystemId.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SystemId.java
@@ -53,7 +53,7 @@ public enum SystemId {
      * Creates a new instance with the given value.
      * @param value the value to be assigned
      */
-    private SystemId(String value) {
+    SystemId(String value) {
         this.value = value;
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/AgreementDocumentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/AgreementDocumentService.java
@@ -41,7 +41,7 @@ public interface AgreementDocumentService {
      * @throws IllegalArgumentException If agreement document is null
      * @throws PortalServiceException If there are any errors during the execution of this method
      */
-    public long create(AgreementDocument agreementDocument)
+    long create(AgreementDocument agreementDocument)
         throws PortalServiceException;
 
     /**
@@ -52,7 +52,7 @@ public interface AgreementDocumentService {
      * @throws IllegalArgumentException If agreement document is null
      * @throws PortalServiceException If there are any errors during the execution of this method
      */
-    public void update(AgreementDocument agreementDocument)
+    void update(AgreementDocument agreementDocument)
         throws PortalServiceException;
 
     /**
@@ -64,7 +64,7 @@ public interface AgreementDocumentService {
      *
      * @throws PortalServiceException If there are any errors during the execution of this method
      */
-    public AgreementDocument get(long agreementDocumentId)
+    AgreementDocument get(long agreementDocumentId)
         throws PortalServiceException;
 
     /**
@@ -74,7 +74,7 @@ public interface AgreementDocumentService {
      *
      * @throws PortalServiceException If there are any errors during the execution of this method
      */
-    public void delete(long agreementDocumentId) throws PortalServiceException;
+    void delete(long agreementDocumentId) throws PortalServiceException;
 
     /**
      * This method gets all the agreement documents that meet the search criteria. If none available, the
@@ -88,6 +88,6 @@ public interface AgreementDocumentService {
      *  or if criteria.pageSize is less than 1 unless criteria.pageNumber is less than 0
      * @throws PortalServiceException If an error occurs while performing the operation
      */
-    public SearchResult<AgreementDocument> search(AgreementDocumentSearchCriteria criteria)
+    SearchResult<AgreementDocument> search(AgreementDocumentSearchCriteria criteria)
         throws PortalServiceException;
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
@@ -82,10 +82,10 @@ public interface BusinessProcessService {
      * @throws Exception for any errors encountered
      */
     void completeReview(
-            final long taskId,
+            long taskId,
             String username,
             List<String> roles,
-            final ProviderInformationType updates,
+            ProviderInformationType updates,
             boolean reject,
             String comment
     ) throws Exception;

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -42,7 +42,9 @@ public interface EnrollmentWebService {
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
-    public GetLookupGroupsResponse getLookupGroups(GetLookupGroupsRequest request) throws PortalServiceException;
+    GetLookupGroupsResponse getLookupGroups(
+            GetLookupGroupsRequest request
+    ) throws PortalServiceException;
 
     /**
      * Retrieves the ticket details.
@@ -51,7 +53,9 @@ public interface EnrollmentWebService {
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
-    public GetTicketDetailsResponse getTicketDetails(GetTicketDetailsRequest request) throws PortalServiceException;
+    GetTicketDetailsResponse getTicketDetails(
+            GetTicketDetailsRequest request
+    ) throws PortalServiceException;
 
     /**
      * Saves the ticket details.
@@ -63,7 +67,7 @@ public interface EnrollmentWebService {
      * @return the enrollment (ticket) ID
      * @throws PortalServiceException for any errors encountered
      */
-    public long saveTicket(
+    long saveTicket(
             String username,
             String systemId,
             String npi,
@@ -77,7 +81,9 @@ public interface EnrollmentWebService {
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
-    public SubmitTicketResponse submitEnrollment(SubmitTicketRequest request) throws PortalServiceException;
+    SubmitTicketResponse submitEnrollment(
+            SubmitTicketRequest request
+    ) throws PortalServiceException;
 
     /**
      * Retrieves the profile details.
@@ -86,7 +92,9 @@ public interface EnrollmentWebService {
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
-    public GetProfileDetailsResponse getProfile(GetProfileDetailsRequest request) throws PortalServiceException;
+    GetProfileDetailsResponse getProfile(
+            GetProfileDetailsRequest request
+    ) throws PortalServiceException;
 
     /**
      * Resubmits the given enrollment request.
@@ -95,5 +103,7 @@ public interface EnrollmentWebService {
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
-    public ResubmitTicketResponse resubmitEnrollment(ResubmitTicketRequest serviceRequest) throws PortalServiceException;
+    ResubmitTicketResponse resubmitEnrollment(
+            ResubmitTicketRequest serviceRequest
+    ) throws PortalServiceException;
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/EventService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EventService.java
@@ -43,7 +43,7 @@ public interface EventService {
      * @throws IllegalArgumentException If event is null
      * @throws PortalServiceException If there are any errors during the execution of this method
      */
-    public long create(Event event) throws PortalServiceException;
+    long create(Event event) throws PortalServiceException;
 
     /**
      * This method gets the latest events.
@@ -52,5 +52,5 @@ public interface EventService {
      *
      * @throws PortalServiceException If there are any errors during the execution of this method
      */
-    public List<Event> getLatest() throws PortalServiceException;
+    List<Event> getLatest() throws PortalServiceException;
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -43,7 +43,7 @@ public interface LookupService {
      *            individual or organizations
      * @return the filtered provider types
      */
-    public List<ProviderType> getProviderTypes(ApplicantType applicantType);
+    List<ProviderType> getProviderTypes(ApplicantType applicantType);
 
     /**
      * Finds a ProviderType by its description, and eager-load
@@ -119,7 +119,7 @@ public interface LookupService {
      *            the return type
      * @return the matched lookups
      */
-    public <T extends LookupEntity> List<T> findAllLookups(Class<T> cls);
+    <T extends LookupEntity> List<T> findAllLookups(Class<T> cls);
 
     /**
      * Retrieves all the owner types allowed for the given structure.
@@ -128,7 +128,7 @@ public interface LookupService {
      *            the corporate structure types
      * @return the matched lookups
      */
-    public List<BeneficialOwnerType> findBeneficialOwnerTypes(String entityType);
+    List<BeneficialOwnerType> findBeneficialOwnerTypes(String entityType);
 
     /**
      * Updates the ProviderTypeSettings for agreements.
@@ -136,5 +136,8 @@ public interface LookupService {
      * @param providerType providerType
      * @param agreementIds agreement ids
      */
-    public void updateProviderTypeAgreementSettings(ProviderType providerType, long[] agreementIds);
+    void updateProviderTypeAgreementSettings(
+            ProviderType providerType,
+            long[] agreementIds
+    );
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
@@ -72,8 +72,11 @@ public interface RegistrationService {
      * @throws PortalServiceException for any errors encountered, or if any field is considered invalid by the
      *             underlying implementations
      */
-    public String registerExternalUser(SystemId systemId, String username, CMSUser registrant)
-        throws PortalServiceException;
+    String registerExternalUser(
+            SystemId systemId,
+            String username,
+            CMSUser registrant
+    ) throws PortalServiceException;
 
     /**
      * Suspends the given user.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -41,7 +41,7 @@ public interface ScreeningService {
      * @param userId - the user ID
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
-    public void performScreening(long userId) throws PortalServiceException;
+    void performScreening(long userId) throws PortalServiceException;
 
     /**
      * This method performs the screening by ID.
@@ -49,7 +49,7 @@ public interface ScreeningService {
      * @param enrollmentId - the enrollment ID
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
-    public void performScreeningById(long enrollmentId) throws PortalServiceException;
+    void performScreeningById(long enrollmentId) throws PortalServiceException;
 
     /**
      * This method schedules the medicaid program data change.
@@ -57,7 +57,7 @@ public interface ScreeningService {
      * @param time - the time
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
-    public void scheduleMediCareProgramDataChange(int time) throws PortalServiceException;
+    void scheduleMediCareProgramDataChange(int time) throws PortalServiceException;
 
     /**
      * This method schedules a revalidation.
@@ -66,7 +66,7 @@ public interface ScreeningService {
      * @param userId - the user ID
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
-    public void scheduleRevalidation(int time, long userId) throws PortalServiceException;
+    void scheduleRevalidation(int time, long userId) throws PortalServiceException;
 
     /**
      * This method schedules a screening.
@@ -74,7 +74,7 @@ public interface ScreeningService {
      * @param time - the time
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
-    public void scheduleScreening(int time) throws PortalServiceException;
+    void scheduleScreening(int time) throws PortalServiceException;
 
     /**
      * This method gets the screening schedule.
@@ -82,7 +82,7 @@ public interface ScreeningService {
      * @return the screening schedule
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
-    public ScreeningSchedule getScreeningSchedule() throws PortalServiceException;
+    ScreeningSchedule getScreeningSchedule() throws PortalServiceException;
 
     /**
      * This method saves the screening schedule.
@@ -92,7 +92,9 @@ public interface ScreeningService {
      * @throws IllegalArgumentException - If screeningSchedule is null
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
-    public void saveScreeningSchedule(ScreeningSchedule screeningSchedule) throws PortalServiceException;
+    void saveScreeningSchedule(
+            ScreeningSchedule screeningSchedule
+    ) throws PortalServiceException;
 
     /**
      * Schedules screening for the given ticket.
@@ -100,5 +102,5 @@ public interface ScreeningService {
      * @param date the schedule date.
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
-    public void scheduleScreening(long id, Date date) throws PortalServiceException;
+    void scheduleScreening(long id, Date date) throws PortalServiceException;
 }


### PR DESCRIPTION
Methods in interfaces are automatically `public` and `abstract`, and adding the `final` modifier to arguments in interface methods (as opposed to implementation methods) does not affect anything. Explicitly declaring these modifiers is unnecessary noise, and they show up as warnings in IntelliJ.

From the [Checkstyle rule description](http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier):

> The Java Language Specification strongly discourages the usage of public and abstract for method declarations in interface definitions as a matter of style.
>
> Interfaces by definition are abstract so the abstract modifier on the interface is redundant.

Remove the redundant modifiers, and add a Checkstyle rule to prevent any more of them.

---

This is the warmup exercise I did yesterday. I tested by doing a clean build, since any errors would be compile time.

---

Issue #456 Use consistent code style