### PR TITLE
Fix "Invalid CSRF token" for PDF export & print

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
@@ -12,22 +12,22 @@
     <form:hidden id="searchFormSortColumn" path="sortColumn" />
     <form:hidden id="searchFormAscending" path="ascending" />
     <form:hidden id="searchFormShowFilterPanel" path="showFilterPanel" />
-    
+
     <form:hidden id="enrollmentNumberSearchField" path="enrollmentNumber" />
     <form:hidden id="npiSearchField" path="npi" />
     <form:hidden id="providerTypeSearchField" path="providerType" />
     <form:hidden id="providerNameSearchField" path="providerName" />
     <form:hidden id="submissionDateStartSearchField" path="submissionDateStart" />
     <form:hidden id="submissionDateEndSearchField" path="submissionDateEnd" />
-    
+
     <c:forEach varStatus="status" var="item" items="${searchCriteria.riskLevels}">
         <input class="riskLevelValue" type="hidden" name="riskLevels[${status.index}]" value="${item}"/>
     </c:forEach>
-    
+
     <c:forEach varStatus="status" var="item" items="${searchCriteria.requestTypes}">
         <input class="requestTypeValue" type="hidden" name="requestTypes[${status.index}]" value="${item}"/>
     </c:forEach>
-    
+
     <c:forEach varStatus="status" var="item" items="${searchCriteria.statuses}">
         <input class="enrollmentStatusValue" type="hidden" name="statuses[${status.index}]" value="${item}"/>
     </c:forEach>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
@@ -38,11 +38,11 @@
 <form:form id="exportForm"
   action="${ctx}/provider/search/exportBatch"
   modelAttribute="searchCriteria"
-  method="post">
+  method="get">
 </form:form>
 <form:form id="printForm"
   action="${ctx}/provider/search/print?print=yes"
   target="_blank"
   modelAttribute="searchCriteria"
-  method="post">
+  method="get">
 </form:form>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
@@ -6,7 +6,10 @@
   - Description: it is used to build the enrollment search form.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
-<form:form id="searchForm" action="${enrollmentSearchFormAction}" modelAttribute="searchCriteria" method="get">
+<form:form id="searchForm"
+  action="${enrollmentSearchFormAction}"
+  modelAttribute="searchCriteria"
+  method="get">
     <form:hidden cssClass="searchFormPageSize" id="searchFormPageSize" path="pageSize" />
     <form:hidden cssClass="searchFormPageNumber" id="searchFormPageNumber" path="pageNumber" />
     <form:hidden id="searchFormSortColumn" path="sortColumn" />
@@ -32,7 +35,14 @@
         <input class="enrollmentStatusValue" type="hidden" name="statuses[${status.index}]" value="${item}"/>
     </c:forEach>
 </form:form>
-<form:form id="exportForm" action="${ctx}/provider/search/exportBatch" modelAttribute="searchCriteria" method="post">
+<form:form id="exportForm"
+  action="${ctx}/provider/search/exportBatch"
+  modelAttribute="searchCriteria"
+  method="post">
 </form:form>
-<form:form id="printForm" action="${ctx}/provider/search/print?print=yes" target="_blank" modelAttribute="searchCriteria" method="post">
+<form:form id="printForm"
+  action="${ctx}/provider/search/print?print=yes"
+  target="_blank"
+  modelAttribute="searchCriteria"
+  method="post">
 </form:form>


### PR DESCRIPTION
The enrollment advanced search page has three forms, one each for searching, exporting to PDF, and printing. The latter two forms have some [JavaScript that copies the current search terms from the first form](https://github.com/SolutionGuidance/psm/blob/51585a539d92f75d2ab77c1f192db0564a592356/psm-app/cms-web/WebContent/js/admin/script.js#L38-L99). Previously, PDF and print were `POST` forms, and search was a `GET` form. Spring automatically provides a CSRF token for `POST` forms constructed using its helpers, but the JavaScript search term copy removed the CSRF hidden field and value, leading to the "Invalid CSRF token" error.

All three views - search, export to PDF, and print - are read-only, and so do not need to have different protection levels. I went back and forth about making all three `GET` or all three `POST`, but I think the value of having the search results be bookmarkable (by having the query terms in the URL instead of in the `POST` form data) outweighs whatever potential security concern would be protected against by a CSRF token.

Switch the export to PDF and print forms to be `GET` forms, avoiding the need for a CSRF token.

---

I tested this by deploying and verifying that I could log in as a provider, click "advanced search", and clicking "Export to PDF" and "Print".

---

Resolves #566 Invalid CSRF token for 'PDF export' and 'Print' buttons