### PR TITLE
Add axe-core and axe-selenium dependencies

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -22,6 +22,7 @@ def serenity_version = '1.8.20'
 // These libraries are known to be used, since they are required during compile
 // or on immediate deployment
 ext.libs = [
+    axe_selenium: 'com.deque:axe-selenium:2.1',
     commons_codec: 'commons-codec:commons-codec:1.11',
     commons_fileupload: 'commons-fileupload:commons-fileupload:1.3.3',
     commons_io: 'commons-io:commons-io:2.6',
@@ -313,6 +314,9 @@ project(':frontend') {
     artifacts {
         javascript file('src/main/js')
         javascript file('src/vendor/js')
+        javascript(file('node_modules/axe-core/axe.min.js')) {
+            builtBy npmInstall
+        }
     }
 }
 
@@ -331,6 +335,7 @@ project(':integration-tests') {
         testCompile 'net.serenity-bdd:serenity-cucumber:1.6.9'
         testCompile 'junit:junit:4.12'
         testCompile 'org.assertj:assertj-core:3.8.0'
+        testCompile libs.axe_selenium
     }
 
     sourceSets {

--- a/psm-app/frontend/package-lock.json
+++ b/psm-app/frontend/package-lock.json
@@ -1,4 +1,12 @@
 {
   "name": "psm-frontend",
-  "lockfileVersion": 1
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "axe-core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
+      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw=="
+    }
+  }
 }

--- a/psm-app/frontend/package.json
+++ b/psm-app/frontend/package.json
@@ -2,5 +2,8 @@
   "name": "psm-frontend",
   "description": "The JavaScript of the Provider Screening Module",
   "license": "Apache-2.0",
-  "repository": "https://github.com/SolutionGuidance/psm"
+  "repository": "https://github.com/SolutionGuidance/psm",
+  "dependencies": {
+    "axe-core": "^2.6.1"
+  }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
@@ -1,13 +1,22 @@
 package gov.medicaid.features;
 
+import com.deque.axe.AXE;
 import cucumber.api.CucumberOptions;
 import net.serenitybdd.core.pages.PageObject;
 import net.serenitybdd.cucumber.CucumberWithSerenity;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -28,5 +37,34 @@ public class IntegrationTests {
     public static void click(PageObject pageObject, WebElement target) {
         pageObject.evaluateJavascript("arguments[0].scrollIntoView()", target);
         pageObject.clickOn(target);
+    }
+
+    public static void testAccessibility(PageObject pageObject) {
+        WebDriver driver = pageObject.getDriver();
+
+        Optional<URL> axeCoreUrl = getAxeCoreUrl(driver);
+
+        axeCoreUrl.ifPresent(url -> {
+            JSONObject responseJSON = new AXE.Builder(driver, url)
+                    .options("{ runOnly: { type: \"tag\", values: [\"wcag2a\", \"wcag2aa\"] } }")
+                    .analyze();
+
+            JSONArray violations = responseJSON.getJSONArray("violations");
+
+            assertThat(violations.length()).isEqualTo(0);
+        });
+    }
+
+    private static Optional<URL> getAxeCoreUrl(WebDriver driver) {
+        return Optional
+                .ofNullable(driver.getCurrentUrl())
+                .map(currentUrl -> {
+                    try {
+                        URL baseUrl = new URL(currentUrl);
+                        return new URL(baseUrl, "/cms/js/axe.min.js");
+                    } catch (MalformedURLException e) {
+                        return null;
+                    }
+                });
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
@@ -15,6 +15,11 @@ public class LoginStepDefinitions {
         loginPage.open();
     }
 
+    @Then("^I should have no accessibility issues$")
+    public void i_should_have_no_accessibility_issues() {
+        loginPage.checkAccessibility();
+    }
+
     @Given("^I enter my username and password$")
     public void i_enter_my_username_and_password()  {
         loginPage.enterProviderCredentials();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
@@ -3,6 +3,7 @@ package gov.medicaid.features.general.ui;
 import net.thucydides.core.pages.PageObject;
 import net.thucydides.core.annotations.DefaultUrl;
 
+import static gov.medicaid.features.IntegrationTests.testAccessibility;
 import static gov.medicaid.features.IntegrationTests.click;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,5 +26,9 @@ public class LoginPage extends PageObject {
 
     public void checkUserLoggedOut() {
         assertThat(getTitle()).contains("Login");
+    }
+
+    public void checkAccessibility() {
+        testAccessibility(this);
     }
 }

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -1,0 +1,8 @@
+@accessibility
+Feature: Accessibility Checks
+  Users wish to access accessible pages
+
+  @ignore
+  Scenario: Login Page Accessibility
+    Given I have the application open in my browser
+    Then I should have no accessibility issues


### PR DESCRIPTION
In order to automatically check accessibility compliance via Selenium tests, add the axe-selenium-java dependency to our Gradle set up. Confirm that it works by setting up an automated test for the accessibility of the Login page. 

Tested by building and deploying the app, running the integration tests, and seeing that the test for the login page did run.  It runs but currently fails.  It should pass after #583 lands.

Issue #518 Implement accessibility checking in CI