### PR TITLE
Improve color contrast of red "*" that indicate required fields

### DIFF
--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -1121,7 +1121,7 @@ input.date{
 }
 
 .required{
-  color:#ff2f2f;
+  color:#e60000;
 }
 
 /* newEnrollmentPanel */


### PR DESCRIPTION
For accessibility, we need sufficient color contrast for the red asterisks (*) that indicate required fields.  The
HTML_CodeSniffer tool does not flag these, but the axe-core tool we are now using for automated testing does.

Darken the shade of red from #ff2f2f (HSL: 0, 100%, 59.2%) to #e60000 (HSL: 0, 100%, 45.1%).

Before:
![red-asterisk-before](https://user-images.githubusercontent.com/1091693/35579904-cefdc4a6-05b5-11e8-9638-fee438eb947c.png)

After:
![red-asterisk-after-darker](https://user-images.githubusercontent.com/1091693/35579923-db02bba8-05b5-11e8-9c16-092ddcdd3ed1.png)

Tested by running the [axe-core browser add-on](https://axe-core.org/) to confirm that the color contrast violation does not appear.  (Note: you may have to hit "refresh" on a PSM page to get your browser to use the current CSS file rather than a cached version.)

Issue #465 Improve ADA compliance