### PR TITLE
Use generic page and steps code for accessibility tests

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
@@ -1,22 +1,8 @@
 package gov.medicaid.features;
 
-import com.deque.axe.AXE;
 import cucumber.api.CucumberOptions;
-import net.serenitybdd.core.pages.PageObject;
 import net.serenitybdd.cucumber.CucumberWithSerenity;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -27,44 +13,5 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(CucumberWithSerenity.class)
 @CucumberOptions(features = "src/test/resources/features")
 public class IntegrationTests {
-    public static final DateTimeFormatter DATE_FORMATTER =
-            DateTimeFormatter.ofPattern("MM/dd/yyyy");
 
-    public static String format(LocalDate date) {
-        return date.format(DATE_FORMATTER);
-    }
-
-    public static void click(PageObject pageObject, WebElement target) {
-        pageObject.evaluateJavascript("arguments[0].scrollIntoView()", target);
-        pageObject.clickOn(target);
-    }
-
-    public static void testAccessibility(PageObject pageObject) {
-        WebDriver driver = pageObject.getDriver();
-
-        Optional<URL> axeCoreUrl = getAxeCoreUrl(driver);
-
-        axeCoreUrl.ifPresent(url -> {
-            JSONObject responseJSON = new AXE.Builder(driver, url)
-                    .options("{ runOnly: { type: \"tag\", values: [\"wcag2a\", \"wcag2aa\"] } }")
-                    .analyze();
-
-            JSONArray violations = responseJSON.getJSONArray("violations");
-
-            assertThat(violations.length()).isEqualTo(0);
-        });
-    }
-
-    private static Optional<URL> getAxeCoreUrl(WebDriver driver) {
-        return Optional
-                .ofNullable(driver.getCurrentUrl())
-                .map(currentUrl -> {
-                    try {
-                        URL baseUrl = new URL(currentUrl);
-                        return new URL(baseUrl, "/cms/js/axe.min.js");
-                    } catch (MalformedURLException e) {
-                        return null;
-                    }
-                });
-    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
@@ -1,0 +1,60 @@
+package gov.medicaid.features;
+
+import com.deque.axe.AXE;
+import net.thucydides.core.pages.PageObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PsmPage extends PageObject {
+
+    public static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("MM/dd/yyyy");
+
+    public static String format(LocalDate date) {
+        return date.format(DATE_FORMATTER);
+    }
+
+    public void click(WebElement target) {
+        evaluateJavascript("arguments[0].scrollIntoView()", target);
+        clickOn(target);
+    }
+
+    public void checkAccessibility() {
+        WebDriver driver = getDriver();
+
+        Optional<URL> axeCoreUrl = getAxeCoreUrl(driver);
+
+        axeCoreUrl.ifPresent(url -> {
+            JSONObject responseJSON = new AXE.Builder(driver, url)
+                    .options("{ runOnly: { type: \"tag\", values: [\"wcag2a\", \"wcag2aa\"] } }")
+                    .analyze();
+
+            JSONArray violations = responseJSON.getJSONArray("violations");
+
+            assertThat(violations.length()).isEqualTo(0);
+        });
+    }
+
+    private static Optional<URL> getAxeCoreUrl(WebDriver driver) {
+        return Optional
+                .ofNullable(driver.getCurrentUrl())
+                .map(currentUrl -> {
+                    try {
+                        URL baseUrl = new URL(currentUrl);
+                        return new URL(baseUrl, "/cms/js/axe.min.js");
+                    } catch (MalformedURLException e) {
+                        return null;
+                    }
+                });
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmStepDefinitions.java
@@ -1,0 +1,15 @@
+package gov.medicaid.features;
+
+import cucumber.api.java.en.Then;
+
+@SuppressWarnings("unused")
+public class PsmStepDefinitions {
+
+    // This property is set by serenity at test time.
+    private PsmPage page;
+
+    @Then("^I should have no accessibility issues$")
+    public void i_should_have_no_accessibility_issues() {
+        page.checkAccessibility();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentDetailsPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentDetailsPage.java
@@ -1,12 +1,10 @@
 package gov.medicaid.features.enrollment.ui;
 
-import net.thucydides.core.pages.PageObject;
-
-import static gov.medicaid.features.IntegrationTests.click;
+import gov.medicaid.features.PsmPage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EnrollmentDetailsPage extends PageObject {
+public class EnrollmentDetailsPage extends PsmPage {
     public void verifySubmitModal() {
         assertThat($("#submitEnrollmentModal > div.inner > " +
                 "div.modal-content > div.right > div.middle").getText())
@@ -14,6 +12,6 @@ public class EnrollmentDetailsPage extends PageObject {
     }
 
     public void closeSubmitModal() {
-        click(this, $("#submitEnrollmentModal a.okBtn"));
+        click($("#submitEnrollmentModal a.okBtn"));
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
@@ -1,20 +1,18 @@
 package gov.medicaid.features.enrollment.ui;
 
+import gov.medicaid.features.PsmPage;
 import net.serenitybdd.core.annotations.findby.By;
-import net.thucydides.core.pages.PageObject;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
-import static gov.medicaid.features.IntegrationTests.click;
-
-public class EnrollmentPage extends PageObject {
+public class EnrollmentPage extends PsmPage {
     public void clickNext() {
-        click(this, $(".nextBtn"));
+        click($(".nextBtn"));
     }
 
     void setNoForRadioButton(String name) {
         List<WebElement> buttons = getDriver().findElements(By.cssSelector("[name='" + name + "']"));
-        click(this, buttons.get(1));
+        click(buttons.get(1));
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualInfoPage.java
@@ -1,11 +1,9 @@
 package gov.medicaid.features.enrollment.ui;
 
-import static gov.medicaid.features.IntegrationTests.click;
-
 public class IndividualInfoPage extends EnrollmentPage {
 
     public void enterIndividualMember() {
-        click(this, $("#addMember"));
+        click($("#addMember"));
     }
 
     public void setIndividualOwnerNPI(String npi) {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
@@ -1,19 +1,16 @@
 package gov.medicaid.features.enrollment.ui;
 
+import gov.medicaid.features.PsmPage;
 import net.serenitybdd.core.annotations.findby.By;
-import net.thucydides.core.pages.PageObject;
 
 import java.time.LocalDate;
-
-import static gov.medicaid.features.IntegrationTests.click;
-import static gov.medicaid.features.IntegrationTests.DATE_FORMATTER;
 
 /**
  * PageObject to interact with the "Personal Info" step of an individual
  * provider enrollment. This page is reached by logging in, creating an
  * enrollment, and selecting an individual provider type.
  */
-public class IndividualSummaryPage extends PageObject {
+public class IndividualSummaryPage extends PsmPage {
     private static final String FIRST_LICENSE_ROW_SELECTOR =
             "#licenseTable > tbody > tr:nth-child(1)";
     private static final String PRACTICE_ADDRESS_SELECTOR = ".h-adr.practice";
@@ -176,7 +173,7 @@ public class IndividualSummaryPage extends PageObject {
     }
 
     public void clickNext() {
-        click(this, $(".nextBtn"));
+        click($(".nextBtn"));
     }
 
     private String textOf(String xpathOrCssSelector) {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
@@ -1,6 +1,6 @@
 package gov.medicaid.features.enrollment.ui;
 
-import net.thucydides.core.pages.PageObject;
+import gov.medicaid.features.PsmPage;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -8,17 +8,15 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.LocalDate;
 
-import static gov.medicaid.features.IntegrationTests.click;
-import static gov.medicaid.features.IntegrationTests.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LicenseInfoPage extends PageObject {
+public class LicenseInfoPage extends PsmPage {
     public void clickNo() {
-        click(this, $("input[value='N'"));
+        click($("input[value='N'"));
     }
 
     public void addLicense() {
-        click(this, $("#addLicense"));
+        click($("#addLicense"));
     }
 
     public void addLicenseType(String licenseType) {
@@ -56,7 +54,7 @@ public class LicenseInfoPage extends PageObject {
     }
 
     public void clickNext() {
-        click(this, $(".nextBtn"));
+        click($(".nextBtn"));
         assertThat(getTitle()).contains("Practice Information");
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
@@ -1,7 +1,5 @@
 package gov.medicaid.features.enrollment.ui;
 
-import static gov.medicaid.features.IntegrationTests.click;
-
 /**
  * Created by ben on 8/22/17.
  */
@@ -11,7 +9,7 @@ public class OwnershipInfoPage extends EnrollmentPage {
     }
 
     public void addOwnership() {
-        click(this, $("#addOwnership"));
+        click($("#addOwnership"));
     }
 
     public void selectOwnershipType(String ownershipType) {
@@ -63,7 +61,7 @@ public class OwnershipInfoPage extends EnrollmentPage {
     }
 
     public void clickDisclosure() {
-        click(this, $("[name='_17_iboOtherInterestInd_0']"));
+        click($("[name='_17_iboOtherInterestInd_0']"));
     }
 
     public void setControlOwnershipOtherLegalName(String legalName) {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
@@ -1,11 +1,9 @@
 package gov.medicaid.features.enrollment.ui;
 
-import net.thucydides.core.pages.PageObject;
+import gov.medicaid.features.PsmPage;
 
 import java.time.LocalDate;
 
-import static gov.medicaid.features.IntegrationTests.click;
-import static gov.medicaid.features.IntegrationTests.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -13,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * provider enrollment. This page is reached by logging in, creating an
  * enrollment, and selecting an individual provider type.
  */
-public class PersonalInfoPage extends PageObject {
+public class PersonalInfoPage extends PsmPage {
     private static final String PROVIDER_TOO_YOUNG_ERROR_MESSAGE =
             "Provider age should be 18 or above during enrollment.";
 
@@ -46,11 +44,11 @@ public class PersonalInfoPage extends PageObject {
     }
 
     public void checkSameAsAbove() {
-        click(this, $("#sameAsAbove"));
+        click($("#sameAsAbove"));
     }
 
     public void clickNext() {
-        click(this, $(".nextBtn"));
+        click($(".nextBtn"));
     }
 
     public void checkForTooYoungError() throws Exception {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
@@ -1,29 +1,27 @@
 package gov.medicaid.features.enrollment.ui;
 
-import net.thucydides.core.pages.PageObject;
+import gov.medicaid.features.PsmPage;
 
 import java.time.LocalDate;
 
-import static gov.medicaid.features.IntegrationTests.click;
-import static gov.medicaid.features.IntegrationTests.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PracticeInfoPage extends PageObject {
+public class PracticeInfoPage extends PsmPage {
     public void checkNoPrivatePractice() {
-        click(this, $("[name=_04_maintainsOwnPrivatePractice][value=N]"));
+        click($("[name=_04_maintainsOwnPrivatePractice][value=N]"));
         assertThat($("#privatePracitce > div").getText().contains("Private Practice"));
     }
 
     public void checkYesPrivatePractice() {
-        click(this, $("[name=_04_maintainsOwnPrivatePractice][value=Y]"));
+        click($("[name=_04_maintainsOwnPrivatePractice][value=Y]"));
     }
 
     public void checkNoGroupPractice() {
-        click(this, $("[name=_04_employedOrContractedByGroup][value=N]"));
+        click($("[name=_04_employedOrContractedByGroup][value=N]"));
     }
 
     public void checkYesGroupPractice() {
-        click(this, $("[name=_04_employedOrContractedByGroup][value=Y]"));
+        click($("[name=_04_employedOrContractedByGroup][value=Y]"));
     }
 
     public void enterPracticeName(String practiceName) {
@@ -71,7 +69,7 @@ public class PracticeInfoPage extends PageObject {
     }
 
     public void clickSameAsAbove() {
-        click(this, $("[name=_05_billingSameAsPrimary]"));
+        click($("[name=_05_billingSameAsPrimary]"));
     }
 
     public void enterFein(String fein) {
@@ -91,14 +89,14 @@ public class PracticeInfoPage extends PageObject {
     }
 
     public void checkYesEftAccepted() {
-        click(this, $("[name=_05_eftAccepted]"));
+        click($("[name=_05_eftAccepted]"));
     }
 
     public void checkFirstRemittanceSequence() {
-        click(this, $("input[value='PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER'"));
+        click($("input[value='PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER'"));
     }
 
     public void clickNext() {
-        click(this, $(".nextBtn"));
+        click($(".nextBtn"));
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/ProviderStatementPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/ProviderStatementPage.java
@@ -1,35 +1,32 @@
 package gov.medicaid.features.enrollment.ui;
 
-import net.thucydides.core.pages.PageObject;
+import gov.medicaid.features.PsmPage;
 
 import java.time.LocalDate;
 
-import static gov.medicaid.features.IntegrationTests.click;
-import static gov.medicaid.features.IntegrationTests.DATE_FORMATTER;
-
-public class ProviderStatementPage extends PageObject {
+public class ProviderStatementPage extends PsmPage {
     public void checkNoCriminalConviction() {
-        click(this, $("[name=_08_criminalConvictionInd][value='N']"));
+        click($("[name=_08_criminalConvictionInd][value='N']"));
     }
 
     public void checkNoCivilPenalty() {
-        click(this, $("[name=_08_civilPenaltyInd][value='N']"));
+        click($("[name=_08_civilPenaltyInd][value='N']"));
     }
 
     public void checkNoPreviousExclusion() {
-        click(this, $("[name=_08_previousExclusionInd][value='N']"));
+        click($("[name=_08_previousExclusionInd][value='N']"));
     }
 
     public void checkYesCriminalConviction() {
-        click(this, $("[name=_08_criminalConvictionInd][value='Y']"));
+        click($("[name=_08_criminalConvictionInd][value='Y']"));
     }
 
     public void checkYesCivilPenalty() {
-        click(this, $("[name=_08_civilPenaltyInd][value='Y']"));
+        click($("[name=_08_civilPenaltyInd][value='Y']"));
     }
 
     public void checkYesPreviousExclusion() {
-        click(this, $("[name=_08_previousExclusionInd][value='Y']"));
+        click($("[name=_08_previousExclusionInd][value='Y']"));
     }
 
     public void enterProviderName(String providerName) {
@@ -46,6 +43,6 @@ public class ProviderStatementPage extends PageObject {
     }
 
     public void clickSubmitButton() {
-        click(this, $(".buttonBox > .purpleBtn"));
+        click($(".buttonBox > .purpleBtn"));
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
@@ -15,11 +15,6 @@ public class LoginStepDefinitions {
         loginPage.open();
     }
 
-    @Then("^I should have no accessibility issues$")
-    public void i_should_have_no_accessibility_issues() {
-        loginPage.checkAccessibility();
-    }
-
     @Given("^I enter my username and password$")
     public void i_enter_my_username_and_password()  {
         loginPage.enterProviderCredentials();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
@@ -1,13 +1,12 @@
 package gov.medicaid.features.general.ui;
 
-import net.thucydides.core.pages.PageObject;
+import gov.medicaid.features.PsmPage;
 
-import static gov.medicaid.features.IntegrationTests.click;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DashboardPage extends PageObject {
+public class DashboardPage extends PsmPage {
     public void clickOnNewEnrollment() {
-        click(this, $("#createNewEnrollment"));
+        click($("#createNewEnrollment"));
         assertThat(getTitle()).isEqualTo("Provider Type Page");
     }
 
@@ -16,15 +15,15 @@ public class DashboardPage extends PageObject {
     }
 
     public void clickNext() {
-        click(this, $(".nextBtn"));
+        click($(".nextBtn"));
     }
 
     public void logout() {
-        click(this, $(".logoutButton"));
+        click($(".logoutButton"));
     }
 
     public void clickMyProfile() {
-        click(this, $("#my_profile_tab"));
+        click($("#my_profile_tab"));
     }
 
     public void checkOnDashboard() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
@@ -1,14 +1,12 @@
 package gov.medicaid.features.general.ui;
 
-import net.thucydides.core.pages.PageObject;
+import gov.medicaid.features.PsmPage;
 import net.thucydides.core.annotations.DefaultUrl;
 
-import static gov.medicaid.features.IntegrationTests.testAccessibility;
-import static gov.medicaid.features.IntegrationTests.click;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DefaultUrl("http://localhost:8080/cms")
-public class LoginPage extends PageObject {
+public class LoginPage extends PsmPage {
 
     public void enterProviderCredentials() {
         $("#username").sendKeys("p1");
@@ -16,7 +14,7 @@ public class LoginPage extends PageObject {
     }
 
     public void login() {
-        click(this, $("#btnLogin"));
+        click($("#btnLogin"));
     }
 
     public void checkUserLoggedIn(String username) {
@@ -26,9 +24,5 @@ public class LoginPage extends PageObject {
 
     public void checkUserLoggedOut() {
         assertThat(getTitle()).contains("Login");
-    }
-
-    public void checkAccessibility() {
-        testAccessibility(this);
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/MyProfilePage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/MyProfilePage.java
@@ -1,10 +1,10 @@
 package gov.medicaid.features.general.ui;
 
-import net.thucydides.core.pages.PageObject;
+import gov.medicaid.features.PsmPage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MyProfilePage extends PageObject {
+public class MyProfilePage extends PsmPage {
 
     public void checkChangePassword() {
         String changeLinkText = $("#change_password_link").getText();

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -2,6 +2,17 @@
 Feature: Accessibility Checks
   Users wish to access accessible pages
 
-  Scenario: Login Page Accessibility
+  Scenario: Login Page
     Given I have the application open in my browser
+    Then I should have no accessibility issues
+
+  @ignore
+  Scenario: Dashboard Page
+    Given I am logged in
+    And I am on the dashboard page
+    Then I should have no accessibility issues
+
+  Scenario: My Profile Page
+    Given I am logged in
+    When I click on My Profile
     Then I should have no accessibility issues


### PR DESCRIPTION
Since accessibility tests will happen for every page, use generic code to avoid needless repetition and reduce boilerplate.  Namely, add and use GenericPage and GenericStepDefinitions classes.  Add two more tests, for "Dashboard" and "My Profile" pages, to confirm that this works.

Tested by running the accessibility tests both with and without `@ignore` for the Login and Dashboard tests.  They work as expected without the `@ignore` tag (currently Login and Dashboard fail, and My Profile passes).  With the ignore tags, the tests run successfully, but the html report shows all three as passing (rather than two as ignored, this is the less fancy report, not the full serenity one with screenshots, etc.).

Open question: what about the 'general' and 'enrollment' organization of these tests?  Will we be able to pull in these same 'generic' classes for the enrollment accessibility tests?  Have not tried that yet.  Is there a better place to put these generic things / organize this?

#518 Implement Accessibility Checking in CI