### PR TITLE
Remove Get Ticket Details JAXB data types

### DIFF
--- a/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
@@ -20,17 +20,6 @@
 	    </complexType>
     </element>
 
-    <element name="GetTicketDetailsRequest">
-        <complexType>
-            <sequence>
-                <element name="username" maxOccurs="1" minOccurs="1" type="string" />
-                <element name="systemId" maxOccurs="1" minOccurs="1" type="string" />
-                <element name="npi" maxOccurs="1" minOccurs="0" type="string" />
-                <element name="ticketNumber" maxOccurs="1" minOccurs="1" type="long" />
-            </sequence>
-        </complexType>
-    </element>
-    
     <element name="GetTicketDetailsResponse">
         <complexType>
             <sequence>

--- a/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
@@ -20,14 +20,6 @@
 	    </complexType>
     </element>
 
-    <element name="GetTicketDetailsResponse">
-        <complexType>
-            <sequence>
-                <element name="Enrollment" maxOccurs="1" minOccurs="1" type="Q1:EnrollmentType" />
-            </sequence>
-        </complexType>
-    </element>
-    
     <element name="GetProfileDetailsRequest">
         <complexType>
             <sequence>

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -20,7 +20,6 @@ import gov.medicaid.binders.BinderUtils;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.GetTicketDetailsRequest;
 import gov.medicaid.domain.model.GetTicketDetailsResponse;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
@@ -106,14 +105,22 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
     /**
      * Retrieves the ticket details.
      *
-     * @param request the service request
+     * @param username     the username of the requesting user
+     * @param systemId     the system that authenticated the requesting user
+     * @param npi          the NPI for which this user is a proxy, if any
+     * @param enrollmentId the ID of the enrollment (ticket)
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
-    public GetTicketDetailsResponse getTicketDetails(GetTicketDetailsRequest request) throws PortalServiceException {
+    public GetTicketDetailsResponse getTicketDetails(
+            String username,
+            String systemId,
+            String npi,
+            long enrollmentId
+    ) throws PortalServiceException {
         GetTicketDetailsResponse response = new GetTicketDetailsResponse();
-        CMSUser user = findUser(request.getUsername(), request.getSystemId(), request.getNpi());
-        Enrollment ticket = providerEnrollmentService.getTicketDetails(user, request.getTicketNumber());
+        CMSUser user = findUser(username, systemId, npi);
+        Enrollment ticket = providerEnrollmentService.getTicketDetails(user, enrollmentId);
         response.setEnrollment(XMLAdapter.toXML(ticket));
         return response;
     }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -20,7 +20,6 @@ import gov.medicaid.binders.BinderUtils;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.GetTicketDetailsResponse;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
@@ -109,20 +108,18 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
      * @param systemId     the system that authenticated the requesting user
      * @param npi          the NPI for which this user is a proxy, if any
      * @param enrollmentId the ID of the enrollment (ticket)
-     * @return the service response
+     * @return the enrollment (ticket)
      * @throws PortalServiceException for any errors encountered
      */
-    public GetTicketDetailsResponse getTicketDetails(
+    public EnrollmentType getTicketDetails(
             String username,
             String systemId,
             String npi,
             long enrollmentId
     ) throws PortalServiceException {
-        GetTicketDetailsResponse response = new GetTicketDetailsResponse();
         CMSUser user = findUser(username, systemId, npi);
         Enrollment ticket = providerEnrollmentService.getTicketDetails(user, enrollmentId);
-        response.setEnrollment(XMLAdapter.toXML(ticket));
-        return response;
+        return XMLAdapter.toXML(ticket);
     }
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -29,7 +29,6 @@ import gov.medicaid.domain.model.DocumentType;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.GetTicketDetailsResponse;
 import gov.medicaid.domain.model.IndividualApplicantType;
 import gov.medicaid.domain.model.OperationStatusType;
 import gov.medicaid.domain.model.ProviderInformationType;
@@ -884,15 +883,12 @@ public class EnrollmentPageFlowController extends BaseController {
             long ticketId
     ) throws PortalServiceException {
         CMSPrincipal principal = ControllerHelper.getPrincipal();
-        GetTicketDetailsResponse response = enrollmentWebService.getTicketDetails(
+        return enrollmentWebService.getTicketDetails(
                 principal.getUsername(),
                 principal.getAuthenticatedBySystem().name(),
                 principal.getUser().getProxyForNPI(),
                 ticketId
         );
-
-        EnrollmentType enrollment = response.getEnrollment();
-        return enrollment;
     }
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -29,7 +29,6 @@ import gov.medicaid.domain.model.DocumentType;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.GetTicketDetailsRequest;
 import gov.medicaid.domain.model.GetTicketDetailsResponse;
 import gov.medicaid.domain.model.IndividualApplicantType;
 import gov.medicaid.domain.model.OperationStatusType;
@@ -884,13 +883,13 @@ public class EnrollmentPageFlowController extends BaseController {
     private EnrollmentType getTicket(
             long ticketId
     ) throws PortalServiceException {
-        GetTicketDetailsRequest request = new GetTicketDetailsRequest();
         CMSPrincipal principal = ControllerHelper.getPrincipal();
-        request.setSystemId(principal.getAuthenticatedBySystem().name());
-        request.setUsername(principal.getUsername());
-        request.setNpi(principal.getUser().getProxyForNPI());
-        request.setTicketNumber(ticketId);
-        GetTicketDetailsResponse response = enrollmentWebService.getTicketDetails(request);
+        GetTicketDetailsResponse response = enrollmentWebService.getTicketDetails(
+                principal.getUsername(),
+                principal.getAuthenticatedBySystem().name(),
+                principal.getUser().getProxyForNPI(),
+                ticketId
+        );
 
         EnrollmentType enrollment = response.getEnrollment();
         return enrollment;

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -19,7 +19,6 @@ package gov.medicaid.services;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.GetTicketDetailsRequest;
 import gov.medicaid.domain.model.GetTicketDetailsResponse;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
@@ -35,12 +34,18 @@ public interface EnrollmentWebService {
     /**
      * Retrieves the ticket details.
      *
-     * @param request the service request
+     * @param username     the username of the requesting user
+     * @param systemId     the system that authenticated the requesting user
+     * @param npi          the NPI for which this user is a proxy, if any
+     * @param enrollmentId the ID of the enrollment (ticket)
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
     GetTicketDetailsResponse getTicketDetails(
-            GetTicketDetailsRequest request
+            String username,
+            String systemId,
+            String npi,
+            long enrollmentId
     ) throws PortalServiceException;
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -19,7 +19,6 @@ package gov.medicaid.services;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.GetTicketDetailsResponse;
 import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
@@ -38,10 +37,10 @@ public interface EnrollmentWebService {
      * @param systemId     the system that authenticated the requesting user
      * @param npi          the NPI for which this user is a proxy, if any
      * @param enrollmentId the ID of the enrollment (ticket)
-     * @return the service response
+     * @return the enrollment (ticket)
      * @throws PortalServiceException for any errors encountered
      */
-    GetTicketDetailsResponse getTicketDetails(
+    EnrollmentType getTicketDetails(
             String username,
             String systemId,
             String npi,


### PR DESCRIPTION
As with #597, remove a pair of JAXB data types that I find obscure the code more than clarify it.

To test this, I did a clean build (cleaning is necessary to regenerate the JAXB classes), deployed, and ran the integration tests (and verified the they called the method by attaching the debugger and setting a breakpoint).

Issue #596 Reduce use of JAXB class generation