### PR TITLE
Add a label to improve accessibility of provider dashboard

### DIFF
--- a/psm-app/cms-web/WebContent/templates/includes/pagination_details.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/pagination_details.template.html
@@ -1,9 +1,10 @@
 {{!-- Fragment for common pagination details. --}}
 
- Displaying <strong>{{pageStartItem}}</strong> - <strong>{{pageEndItem}}</strong> of <strong>{{results.total}}</strong> Enrollment | Show:
+ Displaying <strong>{{pageStartItem}}</strong> - <strong>{{pageEndItem}}</strong> of <strong>{{results.total}}</strong> Enrollment | <label>Show
  <select onchange="changePageSize(this.value);">
      <option value="10" {{#if pageSize10}} selected {{/if}}>10</option>
      <option value="25" {{#if pageSize25}} selected {{/if}}>25</option>
      <option value="50" {{#if pageSize50}} selected {{/if}}>50</option>
      <option value="0" {{#if pageSize0}} selected {{/if}}>All</option>
  </select>
+</label>

--- a/psm-app/cms-web/WebContent/templates/includes/pagination_details.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/pagination_details.template.html
@@ -1,10 +1,11 @@
 {{!-- Fragment for common pagination details. --}}
 
- Displaying <strong>{{pageStartItem}}</strong> - <strong>{{pageEndItem}}</strong> of <strong>{{results.total}}</strong> Enrollment | <label>Show
- <select onchange="changePageSize(this.value);">
-     <option value="10" {{#if pageSize10}} selected {{/if}}>10</option>
-     <option value="25" {{#if pageSize25}} selected {{/if}}>25</option>
-     <option value="50" {{#if pageSize50}} selected {{/if}}>50</option>
-     <option value="0" {{#if pageSize0}} selected {{/if}}>All</option>
- </select>
-</label>
+  Displaying <strong>{{pageStartItem}}</strong> - <strong>{{pageEndItem}}</strong> of <strong>{{results.total}}</strong> Enrollment |
+  <label>Show
+    <select onchange="changePageSize(this.value);">
+      <option value="10" {{#if pageSize10}} selected {{/if}}>10</option>
+      <option value="25" {{#if pageSize25}} selected {{/if}}>25</option>
+      <option value="50" {{#if pageSize50}} selected {{/if}}>50</option>
+      <option value="0" {{#if pageSize0}} selected {{/if}}>All</option>
+    </select>
+  </label>

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -6,7 +6,6 @@ Feature: Accessibility Checks
     Given I have the application open in my browser
     Then I should have no accessibility issues
 
-  @ignore
   Scenario: Dashboard Page
     Given I am logged in
     And I am on the dashboard page


### PR DESCRIPTION
Add a `<label>` to improve accessibility of provider dashboard.

Tested by logging in as a provider and running the [axe-core browser add-on](https://axe-core.org/) on the dashboard page to confirm that this change removes the accessibility violation where the `<select>` element (for how many items to show in the table) did not have a label or title.  And confirm that there were no CSS problems with using a label here.

Issue #554 Give input elements a name for accessibility