### PR TITLE
Improve accessibility for "Update Password" page 

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
@@ -4,7 +4,7 @@
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Link Account"/>
+  <c:set var="title" value="Update Password"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
@@ -44,7 +44,7 @@
                 <div id="updateProfile" class="section">
                   <div class="wholeCol">
                     <div class="row">
-                      <label>Old Password</label>
+                      <label for="oldPassword">Old Password</label>
                       <span class="floatL">
                         <b>:</b>
                       </span>
@@ -56,7 +56,7 @@
                       <form:password path="oldPassword" cssClass="passwordNormalInput ${errorCls}"/>
                     </div>
                     <div class="row">
-                      <label>New Password</label>
+                      <label for="password">New Password</label>
                       <span class="floatL">
                         <b>:</b>
                       </span>
@@ -68,7 +68,7 @@
                       <form:password path="password" cssClass="passwordNormalInput ${errorCls}"/>
                     </div>
                     <div class="row">
-                      <label>Confirm New Password</label>
+                      <label for="confirmPassword">Confirm New Password</label>
                       <span class="floatL">
                         <b>:</b>
                       </span>

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
@@ -24,4 +24,14 @@ public class ChangePasswordStepDefinitions {
     public void i_should_see_change_password()  {
         generalSteps.seeChangePassword();
     }
+
+    @When("^I click on Change Password$")
+    public void i_click_on_change_password() {
+        generalSteps.clickChangePassword();
+    }
+
+    @Then("^I should see the Update Password page$")
+    public void i_should_see_the_update_password_page() {
+        generalSteps.seeUpdatePassword();
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
@@ -34,4 +34,10 @@ public class ChangePasswordStepDefinitions {
     public void i_should_see_the_update_password_page() {
         generalSteps.seeUpdatePassword();
     }
+
+    @Given("^I am on the Update Password page$")
+    public void i_am_on_the_update_password_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.openUpdatePasswordPage();
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -3,6 +3,7 @@ package gov.medicaid.features.general.steps;
 import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.LoginPage;
 import gov.medicaid.features.general.ui.MyProfilePage;
+import gov.medicaid.features.general.ui.UpdatePasswordPage;
 import net.thucydides.core.annotations.Step;
 
 @SuppressWarnings("unused")
@@ -11,6 +12,7 @@ public class GeneralSteps {
     private DashboardPage dashboardPage;
     private LoginPage loginPage;
     private MyProfilePage profilePage;
+    private UpdatePasswordPage updatePasswordPage;
 
     @Step
     public void loginAsProvider() {
@@ -35,5 +37,13 @@ public class GeneralSteps {
         profilePage.checkChangePassword();
     }
 
-}
+    @Step
+    public void clickChangePassword() {
+        profilePage.clickChangePassword();
+    }
 
+    @Step
+    public void seeUpdatePassword() {
+        updatePasswordPage.checkUpdatePassword();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -46,4 +46,9 @@ public class GeneralSteps {
     public void seeUpdatePassword() {
         updatePasswordPage.checkUpdatePassword();
     }
+
+    @Step
+    public void openUpdatePasswordPage() {
+        updatePasswordPage.open();
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/MyProfilePage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/MyProfilePage.java
@@ -10,4 +10,8 @@ public class MyProfilePage extends PsmPage {
         String changeLinkText = $("#change_password_link").getText();
         assertThat(changeLinkText).contains("Change Password");
     }
+
+    public void clickChangePassword() {
+        click($("#change_password_link"));
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/UpdatePasswordPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/UpdatePasswordPage.java
@@ -1,9 +1,11 @@
 package gov.medicaid.features.general.ui;
 
 import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.DefaultUrl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DefaultUrl("http://localhost:8080/cms/provider/profile/reset")
 public class UpdatePasswordPage extends PsmPage {
     public void checkUpdatePassword() {
         assertThat(getTitle()).isEqualTo("Update Password");

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/UpdatePasswordPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/UpdatePasswordPage.java
@@ -1,0 +1,11 @@
+package gov.medicaid.features.general.ui;
+
+import gov.medicaid.features.PsmPage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UpdatePasswordPage extends PsmPage {
+    public void checkUpdatePassword() {
+        assertThat(getTitle()).isEqualTo("Update Password");
+    }
+}

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -16,3 +16,7 @@ Feature: Accessibility Checks
     Given I am logged in
     When I click on My Profile
     Then I should have no accessibility issues
+
+  Scenario: Update Password Page
+    Given I am on the Update Password page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/general/changepassword.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/changepassword.feature
@@ -8,9 +8,9 @@ Scenario: Change Password Option
   When I click on My Profile
   Then I should see the Change Password link
 
-@ignore
-Scenario: Visit Change Provider Page
-  Given I am on the My Profile page
+Scenario: Visit Update Password Page
+  Given I am logged in
+  And I click on My Profile
   When I click on Change Password
   Then I should see the Update Password page
 


### PR DESCRIPTION
Fix an accessibility issue on the "Update Password" page (labels for input elements) and add an accessibility test for that page.  Also add an integration test for navigating to the change password page.

Tested by running these two new integration tests.

Issue #554 Give input elements a name for accessibility
Issue #518 Implement accessibility checking in CI
PR #591 Test that change password link exists