### PR TITLE
Remove GetProfileDetails JAXB

### DIFF
--- a/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
@@ -20,17 +20,6 @@
 	    </complexType>
     </element>
 
-    <element name="GetProfileDetailsRequest">
-        <complexType>
-            <sequence>
-                <element name="username" maxOccurs="1" minOccurs="1" type="string" />
-                <element name="systemId" maxOccurs="1" minOccurs="1" type="string" />
-                <element name="npi" maxOccurs="1" minOccurs="0" type="string" />
-                <element name="profileId" maxOccurs="1" minOccurs="1" type="long" />
-            </sequence>
-        </complexType>
-    </element>
-    
     <element name="GetProfileDetailsResponse">
         <complexType>
             <sequence>

--- a/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
@@ -20,14 +20,6 @@
 	    </complexType>
     </element>
 
-    <element name="GetProfileDetailsResponse">
-        <complexType>
-            <sequence>
-                <element name="Enrollment" maxOccurs="1" minOccurs="1" type="Q1:EnrollmentType" />
-            </sequence>
-        </complexType>
-    </element>
-
     <element name="SubmitTicketRequest">
         <complexType>
             <sequence>

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -247,13 +247,7 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
         }
     }
 
-    /**
-     * Retrieves the profile details.
-     *
-     * @param request the service request
-     * @return the service response
-     * @throws PortalServiceException for any errors encountered
-     */
+    @Override
     public GetProfileDetailsResponse getProfile(GetProfileDetailsRequest request) throws PortalServiceException {
         GetProfileDetailsResponse response = new GetProfileDetailsResponse();
         CMSUser user = findUser(request.getUsername(), request.getSystemId(), request.getNpi());

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -18,7 +18,6 @@ package gov.medicaid.services.impl;
 
 import gov.medicaid.binders.BinderUtils;
 import gov.medicaid.domain.model.EnrollmentType;
-import gov.medicaid.domain.model.GetProfileDetailsResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
 import gov.medicaid.entities.CMSUser;
@@ -247,13 +246,12 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
     }
 
     @Override
-    public GetProfileDetailsResponse getProfile(
+    public EnrollmentType getProfile(
             String username,
             String systemId,
             String npi,
             long profileId
     ) throws PortalServiceException {
-        GetProfileDetailsResponse response = new GetProfileDetailsResponse();
         CMSUser user = findUser(username, systemId, npi);
         ProviderProfile profile = providerEnrollmentService.getProviderDetails(
                 user,
@@ -261,8 +259,7 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
         );
         Enrollment wrapper = new Enrollment();
         wrapper.setDetails(profile);
-        response.setEnrollment(XMLAdapter.toXML(wrapper));
-        return response;
+        return XMLAdapter.toXML(wrapper);
     }
 
     @Override

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -18,7 +18,6 @@ package gov.medicaid.services.impl;
 
 import gov.medicaid.binders.BinderUtils;
 import gov.medicaid.domain.model.EnrollmentType;
-import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
@@ -248,10 +247,18 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
     }
 
     @Override
-    public GetProfileDetailsResponse getProfile(GetProfileDetailsRequest request) throws PortalServiceException {
+    public GetProfileDetailsResponse getProfile(
+            String username,
+            String systemId,
+            String npi,
+            long profileId
+    ) throws PortalServiceException {
         GetProfileDetailsResponse response = new GetProfileDetailsResponse();
-        CMSUser user = findUser(request.getUsername(), request.getSystemId(), request.getNpi());
-        ProviderProfile profile = providerEnrollmentService.getProviderDetails(user, request.getProfileId());
+        CMSUser user = findUser(username, systemId, npi);
+        ProviderProfile profile = providerEnrollmentService.getProviderDetails(
+                user,
+                profileId
+        );
         Enrollment wrapper = new Enrollment();
         wrapper.setDetails(profile);
         response.setEnrollment(XMLAdapter.toXML(wrapper));

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -27,7 +27,6 @@ import gov.medicaid.domain.model.AttachedDocumentsType;
 import gov.medicaid.domain.model.ContactInformationType;
 import gov.medicaid.domain.model.DocumentType;
 import gov.medicaid.domain.model.EnrollmentType;
-import gov.medicaid.domain.model.GetProfileDetailsResponse;
 import gov.medicaid.domain.model.IndividualApplicantType;
 import gov.medicaid.domain.model.OperationStatusType;
 import gov.medicaid.domain.model.ProviderInformationType;
@@ -423,14 +422,13 @@ public class EnrollmentPageFlowController extends BaseController {
             Model model
     ) throws PortalServiceException {
         CMSPrincipal principal = ControllerHelper.getPrincipal();
-        GetProfileDetailsResponse response = enrollmentWebService.getProfile(
+        EnrollmentType enrollment = enrollmentWebService.getProfile(
                 principal.getUsername(),
                 principal.getAuthenticatedBySystem().name(),
                 principal.getUser().getProxyForNPI(),
                 profileId
         );
 
-        EnrollmentType enrollment = response.getEnrollment();
         model.addAttribute("enrollment", enrollment);
         return showPage(null, enrollment);
     }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -27,7 +27,6 @@ import gov.medicaid.domain.model.AttachedDocumentsType;
 import gov.medicaid.domain.model.ContactInformationType;
 import gov.medicaid.domain.model.DocumentType;
 import gov.medicaid.domain.model.EnrollmentType;
-import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
 import gov.medicaid.domain.model.IndividualApplicantType;
 import gov.medicaid.domain.model.OperationStatusType;
@@ -423,13 +422,13 @@ public class EnrollmentPageFlowController extends BaseController {
             @RequestParam("id") long profileId,
             Model model
     ) throws PortalServiceException {
-        GetProfileDetailsRequest request = new GetProfileDetailsRequest();
         CMSPrincipal principal = ControllerHelper.getPrincipal();
-        request.setSystemId(principal.getAuthenticatedBySystem().name());
-        request.setUsername(principal.getUsername());
-        request.setNpi(principal.getUser().getProxyForNPI());
-        request.setProfileId(profileId);
-        GetProfileDetailsResponse response = enrollmentWebService.getProfile(request);
+        GetProfileDetailsResponse response = enrollmentWebService.getProfile(
+                principal.getUsername(),
+                principal.getAuthenticatedBySystem().name(),
+                principal.getUser().getProxyForNPI(),
+                profileId
+        );
 
         EnrollmentType enrollment = response.getEnrollment();
         model.addAttribute("enrollment", enrollment);

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -17,7 +17,6 @@
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.EnrollmentType;
-import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
@@ -76,12 +75,18 @@ public interface EnrollmentWebService {
     /**
      * Retrieves the profile details.
      *
-     * @param request the service request
+     * @param username  the username of the requesting user
+     * @param systemId  the system that authenticated the requesting user
+     * @param npi       the NPI for which this user is a proxy, if any
+     * @param profileId the ID of the enrollment (profile) to look up
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
     GetProfileDetailsResponse getProfile(
-            GetProfileDetailsRequest request
+            String username,
+            String systemId,
+            String npi,
+            long profileId
     ) throws PortalServiceException;
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -17,7 +17,6 @@
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.EnrollmentType;
-import gov.medicaid.domain.model.GetProfileDetailsResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
 
@@ -79,10 +78,10 @@ public interface EnrollmentWebService {
      * @param systemId  the system that authenticated the requesting user
      * @param npi       the NPI for which this user is a proxy, if any
      * @param profileId the ID of the enrollment (profile) to look up
-     * @return the service response
+     * @return the enrollment (profile) found
      * @throws PortalServiceException for any errors encountered
      */
-    GetProfileDetailsResponse getProfile(
+    EnrollmentType getProfile(
             String username,
             String systemId,
             String npi,


### PR DESCRIPTION
As with #654, remove a pair of JAXB data types that I find obscure the code more than clarify it.

To test this, I did a clean build (cleaning is necessary to regenerate the JAXB classes), deployed, and ran the integration tests.

Issue #596 Reduce use of JAXB class generation