### PR TITLE
Remove ResubmitTicket JAXB data types

### DIFF
--- a/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
@@ -58,18 +58,6 @@
             </sequence>
         </complexType>
     </element>
-    
-    <element name="ResubmitTicketRequest">
-        <complexType>
-            <sequence>
-                <element name="username" maxOccurs="1" minOccurs="1" type="string" />
-                <element name="systemId" maxOccurs="1" minOccurs="1" type="string" />
-                <element name="npi" maxOccurs="1" minOccurs="0" type="string" />
-                <element name="ticketId" maxOccurs="1" minOccurs="1" type="string" />
-                <element name="Enrollment" type="Q1:EnrollmentType" maxOccurs="1" minOccurs="1"></element>
-            </sequence>
-        </complexType>
-    </element>
 
     <element name="ResubmitTicketResponse">
         <complexType>

--- a/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentServiceAPI.xsd
@@ -59,14 +59,6 @@
         </complexType>
     </element>
 
-    <element name="ResubmitTicketResponse">
-        <complexType>
-            <sequence>
-                <element name="status" maxOccurs="1" minOccurs="1" type="string" />
-            </sequence>
-        </complexType>
-    </element>
-
 	<simpleType name="UISection">
 		<restriction base="string">
 			<enumeration value="Provider Type Page"></enumeration>

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -20,7 +20,6 @@ import gov.medicaid.binders.BinderUtils;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
@@ -268,11 +267,15 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
 
     @Override
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED) // allow SAVE even if SUBMIT fails
-    public ResubmitTicketResponse resubmitEnrollment(ResubmitTicketRequest request) throws PortalServiceException {
-        EnrollmentType enrollment = request.getEnrollment();
-        CMSUser user = findUser(request.getUsername(), request.getSystemId(), request.getNpi());
+    public ResubmitTicketResponse resubmitEnrollment(
+            String username,
+            String systemId,
+            String npi,
+            EnrollmentType enrollment
+    ) throws PortalServiceException {
+        CMSUser user = findUser(username, systemId, npi);
 
-        long ticketId = BinderUtils.getAsLong(request.getTicketId());
+        long ticketId = BinderUtils.getAsLong(enrollment.getObjectId());
         long profileId = BinderUtils.getAsLong(enrollment.getProviderInformation().getObjectId());
         Validity validity = providerEnrollmentService.getSubmissionValidity(ticketId, profileId);
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -20,7 +20,6 @@ import gov.medicaid.binders.BinderUtils;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.ResubmitTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
 import gov.medicaid.entities.CMSUser;
@@ -267,7 +266,7 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
 
     @Override
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED) // allow SAVE even if SUBMIT fails
-    public ResubmitTicketResponse resubmitEnrollment(
+    public String resubmitEnrollment(
             String username,
             String systemId,
             String npi,
@@ -279,7 +278,6 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
         long profileId = BinderUtils.getAsLong(enrollment.getProviderInformation().getObjectId());
         Validity validity = providerEnrollmentService.getSubmissionValidity(ticketId, profileId);
 
-        ResubmitTicketResponse response = new ResubmitTicketResponse();
         if (validity == Validity.VALID) {
             try {
                 saveTicket(user, enrollment, false); // retain status
@@ -289,12 +287,9 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
             } catch (Exception e) {
                 throw new PortalServiceException("Resubmit failed.", e);
             }
-            response.setStatus("SUCCESS");
-            return response;
+            return "SUCCESS";
         } else {
-            response.setStatus(validity.name());
-            return response;
+            return validity.name();
         }
     }
-
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -33,7 +33,6 @@ import gov.medicaid.domain.model.IndividualApplicantType;
 import gov.medicaid.domain.model.OperationStatusType;
 import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.domain.model.RequestType;
-import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
 import gov.medicaid.domain.model.StatusMessageType;
 import gov.medicaid.domain.model.StatusMessagesType;
@@ -1146,14 +1145,13 @@ public class EnrollmentPageFlowController extends BaseController {
 
         List<FormError> errors = validate(enrollment, pageName, formNames);
         if (errors.isEmpty()) {
-            ResubmitTicketRequest serviceRequest = new ResubmitTicketRequest();
             CMSPrincipal principal = ControllerHelper.getPrincipal();
-            serviceRequest.setSystemId(principal.getAuthenticatedBySystem().name());
-            serviceRequest.setUsername(principal.getUsername());
-            serviceRequest.setNpi(principal.getUser().getProxyForNPI());
-            serviceRequest.setTicketId(enrollment.getObjectId());
-            serviceRequest.setEnrollment(enrollment);
-            ResubmitTicketResponse serviceResponse = enrollmentWebService.resubmitEnrollment(serviceRequest);
+            ResubmitTicketResponse serviceResponse = enrollmentWebService.resubmitEnrollment(
+                    principal.getUsername(),
+                    principal.getAuthenticatedBySystem().name(),
+                    principal.getUser().getProxyForNPI(),
+                    enrollment
+            );
 
             ModelAndView mv = new ModelAndView("redirect:/provider/enrollment/view");
             status.setComplete();

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -33,7 +33,6 @@ import gov.medicaid.domain.model.IndividualApplicantType;
 import gov.medicaid.domain.model.OperationStatusType;
 import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.domain.model.RequestType;
-import gov.medicaid.domain.model.ResubmitTicketResponse;
 import gov.medicaid.domain.model.StatusMessageType;
 import gov.medicaid.domain.model.StatusMessagesType;
 import gov.medicaid.domain.model.SubmitTicketRequest;
@@ -1146,7 +1145,7 @@ public class EnrollmentPageFlowController extends BaseController {
         List<FormError> errors = validate(enrollment, pageName, formNames);
         if (errors.isEmpty()) {
             CMSPrincipal principal = ControllerHelper.getPrincipal();
-            ResubmitTicketResponse serviceResponse = enrollmentWebService.resubmitEnrollment(
+            String resubmissionStatus = enrollmentWebService.resubmitEnrollment(
                     principal.getUsername(),
                     principal.getAuthenticatedBySystem().name(),
                     principal.getUser().getProxyForNPI(),
@@ -1155,8 +1154,8 @@ public class EnrollmentPageFlowController extends BaseController {
 
             ModelAndView mv = new ModelAndView("redirect:/provider/enrollment/view");
             status.setComplete();
-            if (!"SUCCESS".equals(serviceResponse.getStatus())) {
-                if (Validity.SUPERSEDED.name().equals(serviceResponse.getStatus())) {
+            if (!"SUCCESS".equals(resubmissionStatus)) {
+                if (Validity.SUPERSEDED.name().equals(resubmissionStatus)) {
                     ControllerHelper.popup("supersededTicket");
                     return showPage(enrollment.getProgressPage(), enrollment);
                 } else {

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -19,7 +19,6 @@ package gov.medicaid.services;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.ResubmitTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
 
@@ -92,10 +91,10 @@ public interface EnrollmentWebService {
      * @param systemId   the system that authenticated the requesting user
      * @param npi        the NPI for which this user is a proxy, if any
      * @param enrollment the enrollment to resubmit
-     * @return the service response
+     * @return the status of the resubmission
      * @throws PortalServiceException for any errors encountered
      */
-    ResubmitTicketResponse resubmitEnrollment(
+    String resubmitEnrollment(
             String username,
             String systemId,
             String npi,

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -19,7 +19,6 @@ package gov.medicaid.services;
 import gov.medicaid.domain.model.EnrollmentType;
 import gov.medicaid.domain.model.GetProfileDetailsRequest;
 import gov.medicaid.domain.model.GetProfileDetailsResponse;
-import gov.medicaid.domain.model.ResubmitTicketRequest;
 import gov.medicaid.domain.model.ResubmitTicketResponse;
 import gov.medicaid.domain.model.SubmitTicketRequest;
 import gov.medicaid.domain.model.SubmitTicketResponse;
@@ -89,11 +88,17 @@ public interface EnrollmentWebService {
     /**
      * Resubmits the given enrollment request.
      *
-     * @param request the service request
+     * @param username   the username of the requesting user
+     * @param systemId   the system that authenticated the requesting user
+     * @param npi        the NPI for which this user is a proxy, if any
+     * @param enrollment the enrollment to resubmit
      * @return the service response
      * @throws PortalServiceException for any errors encountered
      */
     ResubmitTicketResponse resubmitEnrollment(
-            ResubmitTicketRequest serviceRequest
+            String username,
+            String systemId,
+            String npi,
+            EnrollmentType enrollment
     ) throws PortalServiceException;
 }


### PR DESCRIPTION
As with #658, remove a pair of JAXB data types that I find obscure the code more than clarify it.

To test this, I did a clean build (cleaning is necessary to regenerate the JAXB classes), deployed, ran the integration tests, and resubmitted a pending enrollment as the admin.

Issue #596 Reduce use of JAXB class generation