### PR TITLE
Fix agreement documents for organization providers

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
@@ -53,18 +53,19 @@
                     <label class="checkboxLabel">
                       <input type="checkbox" value="" class="checkbox" ${formValue eq 'Y' ? 'checked' : ''} name="${formName}"/>
                       I have read and agree to the terms of the
+                      <c:set var="formName" value="_19_documentId_${status.index - 1}"/>
+                      <c:set var="documentId" value="${requestScope[formName]}"/>
+                      <input type="hidden" value="${documentId}" name="${formName}"/>
+                      <c:set var="formName" value="_19_documentName_${status.index - 1}"/>
+                      <c:set var="documentName" value="${requestScope[formName]}"/>
+                      <c:url var="viewDocumentUrl" value="/provider/enrollment/agreement">
+                        <c:param name="id" value="${documentId}"/>
+                      </c:url>
                       <a href="${viewDocumentUrl}" target="_blank">${documentName}</a>
+                      <c:set var="formName" value="_19_updatedVersion_${status.index - 1}"/>
+                      <c:set var="formValue" value="${requestScope[formName]}"/>
+                      <c:if test="${formValue eq 'Y'}">(Updated)</c:if>
                     </label>
-
-                    <c:set var="formName" value="_19_documentId_${status.index - 1}"></c:set>
-                    <c:set var="documentId" value="${requestScope[formName]}"></c:set>
-                    <input type="hidden" value="${documentId}" name="${formName}"/>
-                    <c:set var="formName" value="_19_documentName_${status.index - 1}"></c:set>
-                    <c:set var="documentName" value="${requestScope[formName]}"></c:set>
-                    <c:url var="viewDocumentUrl" value="/provider/enrollment/agreement"><c:param name="id" value="${documentId}"></c:param></c:url>
-                    <c:set var="formName" value="_19_updatedVersion_${status.index - 1}"></c:set>
-                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <c:if test="${formValue eq 'Y'}"><span>(Updated)</span></c:if>
                 </div>
             </c:forEach>
             <div class="clearFixed"></div>


### PR DESCRIPTION
The form for gathering the provider statement for an organization provider type was broken when adding labels in PR #583. The URL of the agreement document, the name of the agreement document, and a hidden input each depend on a variable set, in-order, in the JSP; by rearranging the label, the link to the agreement document was broken.

Rearrange the agreement document variables and elements to match their original order (but now within a `<label>`), and update the `<c:set>` JSP tags to be empty elements (`<c:set ... />`) instead of start + end tags (`<c:set ...></c:set>`).

---

To test this, I edited an organization provider type to have it require an agreement document, created an enrollment with that provider type, and verified that I could both read and agree to the agreement document. See also PR #663 for the example that led me to discover this issue.

---

Issue #554 Give form input elements a name for accessibility
PR #583 Associate labels and add titles