### PR TITLE
Add CTCC Agreement to seed data

### DIFF
--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -818,7 +818,8 @@ INSERT INTO agreement_documents (
   created_at
 ) VALUES
   (1, '01', 'Agreement (1)', 0, 'This is the content of the agreement.', 'system', NOW()),
-  (2, '02', 'Addendum (2)', 0, 'This is the content of the addendum.', 'system', NOW());
+  (2, '02', 'Addendum (2)', 0, 'This is the content of the addendum.', 'system', NOW()),
+  (3, '01', 'Child And Teen Checkup Agreement (DHS-4646)', 0, 'This is a required document.', 'system', NOW());
 
 CREATE TABLE contacts(
   contact_id BIGINT PRIMARY KEY,
@@ -859,7 +860,8 @@ INSERT INTO provider_type_agreement_documents (
   provider_type_code,
   agreement_document_id
 ) VALUES
-  ('18', 1);
+  ('18', 1),
+  ('54', 3);
 
 CREATE TABLE provider_type_license_types(
   provider_type_code CHARACTER VARYING(2)


### PR DESCRIPTION
We have [a pair of rules that requires the Child And Teen Checkup Clinic organization provider type to agree to an agreement document named "Child And Teen Checkup Agreement (DHS-4646)"](https://github.com/SolutionGuidance/psm/blob/12de0147519753a2891017518099a046292118f6/psm-app/cms-business-process/src/main/resources/cms.validation.drl#L4954-L4999). Add an example document with that name, and link it to the CTCC provider type.

See also PR #662, which fixes an issue with organization agreement documents.

---

To test this, I added the seed data, and verified that I could complete an enrollment as a Child And Teen Checkup Clinic organization by agreeing to the new agreement document.

---

This adds data to the database; to add only this data (without rerunning `seed.sql` and deleting your existing data), in a `psql` session run:

```sql
INSERT INTO agreement_documents (
  agreement_document_id,
  type,
  title,
  version,
  body,
  created_by,
  created_at
) VALUES
  (3, '01', 'Child And Teen Checkup Agreement (DHS-4646)', 0, 'This is a required document.', 'system', NOW());

INSERT INTO provider_type_agreement_documents (
  provider_type_code,
  agreement_document_id
) VALUES
  ('54', 3);
```

Issue #166 Review license names, rules, and seed data to find mismatches