### PR TITLE
Add more general accessibility tests

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -72,7 +72,7 @@
                       <spring:bind path="firstName">
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
                       </spring:bind>
-                      <form:input id="registerFirstname" path="firstName" cssClass="normalInput ${errorCls}"/>
+                      <form:input id="registerFirstName" path="firstName" cssClass="normalInput ${errorCls}"/>
                     </div>
                     <div class="row">
                       <label for="registerMiddleName">Middle Name</label>

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AccountSetupDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AccountSetupDefinitions.java
@@ -1,0 +1,16 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class AccountSetupDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Account Setup page$")
+    public void i_am_on_the_account_setup_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.openAccountSetupPage();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AdvancedSearchStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AdvancedSearchStepDefinitions.java
@@ -1,0 +1,16 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class AdvancedSearchStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Advanced Search page$")
+    public void i_am_on_the_advanced_search_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.openAdvancedSearchPage();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
@@ -10,14 +10,17 @@ public class ChangePasswordStepDefinitions {
     @Steps
     GeneralSteps generalSteps;
 
+    @Steps
+    DashboardSteps dashboardSteps;
+
     @Given("^I am on the dashboard page$")
     public void check_dashboard_page() {
-        generalSteps.checkOnDashboard();
+        dashboardSteps.checkOnDashboard();
     }
 
     @When("^I click on My Profile$")
     public void i_click_on_my_profile()  {
-        generalSteps.clickMyProfile();
+        dashboardSteps.clickMyProfile();
     }
 
     @Then("^I should see the Change Password link$")

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
@@ -41,4 +41,15 @@ public class DashboardStepDefinitions {
     public void i_open_the_filter_panel_on_the_dashboard_approved_page() {
         generalSteps.clickDashboardApprovedPageFilterButton();
     }
+
+    @Given("^I am on the Dashboard Denied page$")
+    public void i_am_on_the_dashboard_denied_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.openDashboardDeniedPage();
+    }
+
+    @When("^I open the filter panel on the Dashboard Denied page")
+    public void i_open_the_filter_panel_on_the_dashboard_denied_page() {
+        generalSteps.clickDashboardDeniedPageFilterButton();
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
@@ -8,48 +8,50 @@ import net.thucydides.core.annotations.Steps;
 public class DashboardStepDefinitions {
     @Steps
     GeneralSteps generalSteps;
+    @Steps
+    DashboardSteps dashboardSteps;
 
     @Given("^I am on the Dashboard Draft page$")
     public void i_am_on_the_dashboard_draft_page() {
         generalSteps.loginAsProvider();
-        generalSteps.openDashboardDraftPage();
+        dashboardSteps.openDashboardDraftPage();
     }
 
     @When("^I open the filter panel on the Dashboard Draft page")
     public void i_open_the_filter_panel_on_the_dashboard_draft_page() {
-        generalSteps.clickDashboardDraftPageFilterButton();
+        dashboardSteps.clickDashboardDraftPageFilterButton();
     }
 
     @Given("^I am on the Dashboard Pending page$")
     public void i_am_on_the_dashboard_pending_page() {
         generalSteps.loginAsProvider();
-        generalSteps.openDashboardPendingPage();
+        dashboardSteps.openDashboardPendingPage();
     }
 
     @When("^I open the filter panel on the Dashboard Pending page")
     public void i_open_the_filter_panel_on_the_dashboard_pending_page() {
-        generalSteps.clickDashboardPendingPageFilterButton();
+        dashboardSteps.clickDashboardPendingPageFilterButton();
     }
 
     @Given("^I am on the Dashboard Approved page$")
     public void i_am_on_the_dashboard_approved_page() {
         generalSteps.loginAsProvider();
-        generalSteps.openDashboardApprovedPage();
+        dashboardSteps.openDashboardApprovedPage();
     }
 
     @When("^I open the filter panel on the Dashboard Approved page")
     public void i_open_the_filter_panel_on_the_dashboard_approved_page() {
-        generalSteps.clickDashboardApprovedPageFilterButton();
+        dashboardSteps.clickDashboardApprovedPageFilterButton();
     }
 
     @Given("^I am on the Dashboard Denied page$")
     public void i_am_on_the_dashboard_denied_page() {
         generalSteps.loginAsProvider();
-        generalSteps.openDashboardDeniedPage();
+        dashboardSteps.openDashboardDeniedPage();
     }
 
     @When("^I open the filter panel on the Dashboard Denied page")
     public void i_open_the_filter_panel_on_the_dashboard_denied_page() {
-        generalSteps.clickDashboardDeniedPageFilterButton();
+        dashboardSteps.clickDashboardDeniedPageFilterButton();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
@@ -11,6 +11,11 @@ public class DashboardStepDefinitions {
     @Steps
     DashboardSteps dashboardSteps;
 
+    @When("^I open the filter panel on the Dashboard page$")
+    public void i_open_the_filter_panel_on_the_dashboard_page() {
+        dashboardSteps.clickDashboardPageFilterButton();
+    }
+
     @Given("^I am on the Dashboard Draft page$")
     public void i_am_on_the_dashboard_draft_page() {
         generalSteps.loginAsProvider();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
@@ -1,0 +1,22 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.When;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class DashboardStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Dashboard Draft page$")
+    public void i_am_on_the_dashboard_draft_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.openDashboardDraftPage();
+    }
+
+    @When("^I open the filter panel on the Dashboard Draft page")
+    public void i_open_the_filter_panel_on_the_dashboard_draft_page() {
+        generalSteps.clickDashboardDraftPageFilterButton();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
@@ -30,4 +30,15 @@ public class DashboardStepDefinitions {
     public void i_open_the_filter_panel_on_the_dashboard_pending_page() {
         generalSteps.clickDashboardPendingPageFilterButton();
     }
+
+    @Given("^I am on the Dashboard Approved page$")
+    public void i_am_on_the_dashboard_approved_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.openDashboardApprovedPage();
+    }
+
+    @When("^I open the filter panel on the Dashboard Approved page")
+    public void i_open_the_filter_panel_on_the_dashboard_approved_page() {
+        generalSteps.clickDashboardApprovedPageFilterButton();
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
@@ -19,4 +19,15 @@ public class DashboardStepDefinitions {
     public void i_open_the_filter_panel_on_the_dashboard_draft_page() {
         generalSteps.clickDashboardDraftPageFilterButton();
     }
+
+    @Given("^I am on the Dashboard Pending page$")
+    public void i_am_on_the_dashboard_pending_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.openDashboardPendingPage();
+    }
+
+    @When("^I open the filter panel on the Dashboard Pending page")
+    public void i_open_the_filter_panel_on_the_dashboard_pending_page() {
+        generalSteps.clickDashboardPendingPageFilterButton();
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardSteps.java
@@ -22,7 +22,12 @@ public class DashboardSteps {
     }
 
     @Step
-    public void clickMyProfile()  {
+    public void clickDashboardPageFilterButton() {
+        dashboardPage.clickFilterButton();
+    }
+
+    @Step
+    public void clickMyProfile() {
         dashboardPage.clickMyProfile();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardSteps.java
@@ -1,0 +1,68 @@
+package gov.medicaid.features.general.steps;
+
+import gov.medicaid.features.general.ui.DashboardApprovedPage;
+import gov.medicaid.features.general.ui.DashboardDeniedPage;
+import gov.medicaid.features.general.ui.DashboardDraftPage;
+import gov.medicaid.features.general.ui.DashboardPage;
+import gov.medicaid.features.general.ui.DashboardPendingPage;
+import net.thucydides.core.annotations.Step;
+
+@SuppressWarnings("unused")
+public class DashboardSteps {
+
+    private DashboardPage dashboardPage;
+    private DashboardDraftPage dashboardDraftPage;
+    private DashboardPendingPage dashboardPendingPage;
+    private DashboardApprovedPage dashboardApprovedPage;
+    private DashboardDeniedPage dashboardDeniedPage;
+
+    @Step
+    public void checkOnDashboard() {
+        dashboardPage.checkOnDashboard();
+    }
+
+    @Step
+    public void clickMyProfile()  {
+        dashboardPage.clickMyProfile();
+    }
+
+    @Step
+    public void openDashboardDraftPage() {
+        dashboardDraftPage.open();
+    }
+
+    @Step
+    public void clickDashboardDraftPageFilterButton() {
+        dashboardDraftPage.clickFilterButton();
+    }
+
+    @Step
+    public void openDashboardPendingPage() {
+        dashboardPendingPage.open();
+    }
+
+    @Step
+    public void clickDashboardPendingPageFilterButton() {
+        dashboardPendingPage.clickFilterButton();
+    }
+
+    @Step
+    public void openDashboardApprovedPage() {
+        dashboardApprovedPage.open();
+    }
+
+    @Step
+    public void clickDashboardApprovedPageFilterButton() {
+        dashboardApprovedPage.clickFilterButton();
+    }
+
+    @Step
+    public void openDashboardDeniedPage() {
+        dashboardDeniedPage.open();
+    }
+
+    @Step
+    public void clickDashboardDeniedPageFilterButton() {
+        dashboardDeniedPage.clickFilterButton();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ForgotPasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ForgotPasswordStepDefinitions.java
@@ -1,0 +1,15 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class ForgotPasswordStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Forgot Password page$")
+    public void i_am_on_the_forgot_password_page() {
+        generalSteps.openForgotPasswordPage();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -3,6 +3,7 @@ package gov.medicaid.features.general.steps;
 import gov.medicaid.features.general.ui.AccountSetupPage;
 import gov.medicaid.features.general.ui.DashboardDraftPage;
 import gov.medicaid.features.general.ui.DashboardPage;
+import gov.medicaid.features.general.ui.DashboardPendingPage;
 import gov.medicaid.features.general.ui.ForgotPasswordPage;
 import gov.medicaid.features.general.ui.LoginPage;
 import gov.medicaid.features.general.ui.MyProfilePage;
@@ -18,6 +19,7 @@ public class GeneralSteps {
     private ForgotPasswordPage forgotPasswordPage;
     private DashboardPage dashboardPage;
     private DashboardDraftPage dashboardDraftPage;
+    private DashboardPendingPage dashboardPendingPage;
     private MyProfilePage profilePage;
     private AccountSetupPage accountSetupPage;
     private UpdatePasswordPage updatePasswordPage;
@@ -53,6 +55,16 @@ public class GeneralSteps {
     @Step
     public void clickDashboardDraftPageFilterButton() {
         dashboardDraftPage.clickFilterButton();
+    }
+
+    @Step
+    public void openDashboardPendingPage() {
+        dashboardPendingPage.open();
+    }
+
+    @Step
+    public void clickDashboardPendingPageFilterButton() {
+        dashboardPendingPage.clickFilterButton();
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,5 +1,6 @@
 package gov.medicaid.features.general.steps;
 
+import gov.medicaid.features.general.ui.AccountSetupPage;
 import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.ForgotPasswordPage;
 import gov.medicaid.features.general.ui.LoginPage;
@@ -16,6 +17,7 @@ public class GeneralSteps {
     private ForgotPasswordPage forgotPasswordPage;
     private DashboardPage dashboardPage;
     private MyProfilePage profilePage;
+    private AccountSetupPage accountSetupPage;
     private UpdatePasswordPage updatePasswordPage;
 
     @Step
@@ -64,5 +66,10 @@ public class GeneralSteps {
     @Step
     public void openUpdatePasswordPage() {
         updatePasswordPage.open();
+    }
+
+    @Step
+    public void openAccountSetupPage() {
+        accountSetupPage.open();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -2,6 +2,7 @@ package gov.medicaid.features.general.steps;
 
 import gov.medicaid.features.general.ui.AccountSetupPage;
 import gov.medicaid.features.general.ui.DashboardApprovedPage;
+import gov.medicaid.features.general.ui.DashboardDeniedPage;
 import gov.medicaid.features.general.ui.DashboardDraftPage;
 import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.DashboardPendingPage;
@@ -22,6 +23,7 @@ public class GeneralSteps {
     private DashboardDraftPage dashboardDraftPage;
     private DashboardPendingPage dashboardPendingPage;
     private DashboardApprovedPage dashboardApprovedPage;
+    private DashboardDeniedPage dashboardDeniedPage;
     private MyProfilePage profilePage;
     private AccountSetupPage accountSetupPage;
     private UpdatePasswordPage updatePasswordPage;
@@ -77,6 +79,16 @@ public class GeneralSteps {
     @Step
     public void clickDashboardApprovedPageFilterButton() {
         dashboardApprovedPage.clickFilterButton();
+    }
+
+    @Step
+    public void openDashboardDeniedPage() {
+        dashboardDeniedPage.open();
+    }
+
+    @Step
+    public void clickDashboardDeniedPageFilterButton() {
+        dashboardDeniedPage.clickFilterButton();
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,6 +1,7 @@
 package gov.medicaid.features.general.steps;
 
 import gov.medicaid.features.general.ui.AccountSetupPage;
+import gov.medicaid.features.general.ui.AdvancedSearchPage;
 import gov.medicaid.features.general.ui.ForgotPasswordPage;
 import gov.medicaid.features.general.ui.LoginPage;
 import gov.medicaid.features.general.ui.MyProfilePage;
@@ -17,6 +18,7 @@ public class GeneralSteps {
     private MyProfilePage profilePage;
     private AccountSetupPage accountSetupPage;
     private UpdatePasswordPage updatePasswordPage;
+    private AdvancedSearchPage advancedSearchPage;
 
     @Step
     public void openRegisterNewAccountPage() {
@@ -59,5 +61,10 @@ public class GeneralSteps {
     @Step
     public void openAccountSetupPage() {
         accountSetupPage.open();
+    }
+
+    @Step
+    public void openAdvancedSearchPage() {
+        advancedSearchPage.open();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,6 +1,7 @@
 package gov.medicaid.features.general.steps;
 
 import gov.medicaid.features.general.ui.AccountSetupPage;
+import gov.medicaid.features.general.ui.DashboardDraftPage;
 import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.ForgotPasswordPage;
 import gov.medicaid.features.general.ui.LoginPage;
@@ -16,6 +17,7 @@ public class GeneralSteps {
     private RegisterNewAccountPage registerNewAccountPage;
     private ForgotPasswordPage forgotPasswordPage;
     private DashboardPage dashboardPage;
+    private DashboardDraftPage dashboardDraftPage;
     private MyProfilePage profilePage;
     private AccountSetupPage accountSetupPage;
     private UpdatePasswordPage updatePasswordPage;
@@ -41,6 +43,16 @@ public class GeneralSteps {
     @Step
     public void checkOnDashboard() {
         dashboardPage.checkOnDashboard();
+    }
+
+    @Step
+    public void openDashboardDraftPage() {
+        dashboardDraftPage.open();
+    }
+
+    @Step
+    public void clickDashboardDraftPageFilterButton() {
+        dashboardDraftPage.clickFilterButton();
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,6 +1,7 @@
 package gov.medicaid.features.general.steps;
 
 import gov.medicaid.features.general.ui.AccountSetupPage;
+import gov.medicaid.features.general.ui.DashboardApprovedPage;
 import gov.medicaid.features.general.ui.DashboardDraftPage;
 import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.DashboardPendingPage;
@@ -20,6 +21,7 @@ public class GeneralSteps {
     private DashboardPage dashboardPage;
     private DashboardDraftPage dashboardDraftPage;
     private DashboardPendingPage dashboardPendingPage;
+    private DashboardApprovedPage dashboardApprovedPage;
     private MyProfilePage profilePage;
     private AccountSetupPage accountSetupPage;
     private UpdatePasswordPage updatePasswordPage;
@@ -65,6 +67,16 @@ public class GeneralSteps {
     @Step
     public void clickDashboardPendingPageFilterButton() {
         dashboardPendingPage.clickFilterButton();
+    }
+
+    @Step
+    public void openDashboardApprovedPage() {
+        dashboardApprovedPage.open();
+    }
+
+    @Step
+    public void clickDashboardApprovedPageFilterButton() {
+        dashboardApprovedPage.clickFilterButton();
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -4,6 +4,7 @@ import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.ForgotPasswordPage;
 import gov.medicaid.features.general.ui.LoginPage;
 import gov.medicaid.features.general.ui.MyProfilePage;
+import gov.medicaid.features.general.ui.RegisterNewAccountPage;
 import gov.medicaid.features.general.ui.UpdatePasswordPage;
 import net.thucydides.core.annotations.Step;
 
@@ -11,10 +12,16 @@ import net.thucydides.core.annotations.Step;
 public class GeneralSteps {
 
     private LoginPage loginPage;
+    private RegisterNewAccountPage registerNewAccountPage;
     private ForgotPasswordPage forgotPasswordPage;
     private DashboardPage dashboardPage;
     private MyProfilePage profilePage;
     private UpdatePasswordPage updatePasswordPage;
+
+    @Step
+    public void openRegisterNewAccountPage() {
+        registerNewAccountPage.open();
+    }
 
     @Step
     public void openForgotPasswordPage() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,6 +1,7 @@
 package gov.medicaid.features.general.steps;
 
 import gov.medicaid.features.general.ui.DashboardPage;
+import gov.medicaid.features.general.ui.ForgotPasswordPage;
 import gov.medicaid.features.general.ui.LoginPage;
 import gov.medicaid.features.general.ui.MyProfilePage;
 import gov.medicaid.features.general.ui.UpdatePasswordPage;
@@ -9,10 +10,16 @@ import net.thucydides.core.annotations.Step;
 @SuppressWarnings("unused")
 public class GeneralSteps {
 
-    private DashboardPage dashboardPage;
     private LoginPage loginPage;
+    private ForgotPasswordPage forgotPasswordPage;
+    private DashboardPage dashboardPage;
     private MyProfilePage profilePage;
     private UpdatePasswordPage updatePasswordPage;
+
+    @Step
+    public void openForgotPasswordPage() {
+        forgotPasswordPage.open();
+    }
 
     @Step
     public void loginAsProvider() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,11 +1,6 @@
 package gov.medicaid.features.general.steps;
 
 import gov.medicaid.features.general.ui.AccountSetupPage;
-import gov.medicaid.features.general.ui.DashboardApprovedPage;
-import gov.medicaid.features.general.ui.DashboardDeniedPage;
-import gov.medicaid.features.general.ui.DashboardDraftPage;
-import gov.medicaid.features.general.ui.DashboardPage;
-import gov.medicaid.features.general.ui.DashboardPendingPage;
 import gov.medicaid.features.general.ui.ForgotPasswordPage;
 import gov.medicaid.features.general.ui.LoginPage;
 import gov.medicaid.features.general.ui.MyProfilePage;
@@ -19,11 +14,6 @@ public class GeneralSteps {
     private LoginPage loginPage;
     private RegisterNewAccountPage registerNewAccountPage;
     private ForgotPasswordPage forgotPasswordPage;
-    private DashboardPage dashboardPage;
-    private DashboardDraftPage dashboardDraftPage;
-    private DashboardPendingPage dashboardPendingPage;
-    private DashboardApprovedPage dashboardApprovedPage;
-    private DashboardDeniedPage dashboardDeniedPage;
     private MyProfilePage profilePage;
     private AccountSetupPage accountSetupPage;
     private UpdatePasswordPage updatePasswordPage;
@@ -44,56 +34,6 @@ public class GeneralSteps {
         loginPage.enterProviderCredentials();
         loginPage.login();
         loginPage.checkUserLoggedIn("p1");
-    }
-
-    @Step
-    public void checkOnDashboard() {
-        dashboardPage.checkOnDashboard();
-    }
-
-    @Step
-    public void openDashboardDraftPage() {
-        dashboardDraftPage.open();
-    }
-
-    @Step
-    public void clickDashboardDraftPageFilterButton() {
-        dashboardDraftPage.clickFilterButton();
-    }
-
-    @Step
-    public void openDashboardPendingPage() {
-        dashboardPendingPage.open();
-    }
-
-    @Step
-    public void clickDashboardPendingPageFilterButton() {
-        dashboardPendingPage.clickFilterButton();
-    }
-
-    @Step
-    public void openDashboardApprovedPage() {
-        dashboardApprovedPage.open();
-    }
-
-    @Step
-    public void clickDashboardApprovedPageFilterButton() {
-        dashboardApprovedPage.clickFilterButton();
-    }
-
-    @Step
-    public void openDashboardDeniedPage() {
-        dashboardDeniedPage.open();
-    }
-
-    @Step
-    public void clickDashboardDeniedPageFilterButton() {
-        dashboardDeniedPage.clickFilterButton();
-    }
-
-    @Step
-    public void clickMyProfile()  {
-        dashboardPage.clickMyProfile();
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/RegisterNewAccountStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/RegisterNewAccountStepDefinitions.java
@@ -1,0 +1,15 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class RegisterNewAccountStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Register New Account page$")
+    public void i_am_on_the_register_new_account_page() {
+        generalSteps.openRegisterNewAccountPage();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/AccountSetupPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/AccountSetupPage.java
@@ -1,0 +1,9 @@
+package gov.medicaid.features.general.ui;
+
+import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.DefaultUrl;
+
+@DefaultUrl("http://localhost:8080/cms/provider/dashboard/setup")
+public class AccountSetupPage extends PsmPage {
+
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/AdvancedSearchPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/AdvancedSearchPage.java
@@ -1,0 +1,9 @@
+package gov.medicaid.features.general.ui;
+
+import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.DefaultUrl;
+
+@DefaultUrl("http://localhost:8080/cms/provider/search/advanced")
+public class AdvancedSearchPage extends PsmPage {
+
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardApprovedPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardApprovedPage.java
@@ -1,0 +1,12 @@
+package gov.medicaid.features.general.ui;
+
+import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.DefaultUrl;
+
+@DefaultUrl("http://localhost:8080/cms/provider/dashboard/approved")
+public class DashboardApprovedPage extends PsmPage {
+
+    public void clickFilterButton() {
+        click($(".filterBtn"));
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardDeniedPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardDeniedPage.java
@@ -1,0 +1,12 @@
+package gov.medicaid.features.general.ui;
+
+import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.DefaultUrl;
+
+@DefaultUrl("http://localhost:8080/cms/provider/dashboard/rejected")
+public class DashboardDeniedPage extends PsmPage {
+
+    public void clickFilterButton() {
+        click($(".filterBtn"));
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardDraftPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardDraftPage.java
@@ -1,0 +1,12 @@
+package gov.medicaid.features.general.ui;
+
+import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.DefaultUrl;
+
+@DefaultUrl("http://localhost:8080/cms/provider/dashboard/drafts")
+public class DashboardDraftPage extends PsmPage {
+
+    public void clickFilterButton() {
+        click($(".filterBtn"));
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPage.java
@@ -26,6 +26,10 @@ public class DashboardPage extends PsmPage {
         click($("#my_profile_tab"));
     }
 
+    public void clickFilterButton() {
+        click($(".filterBtn"));
+    }
+
     public void checkOnDashboard() {
         assertThat(getTitle()).isEqualTo("Dashboard");
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPendingPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/DashboardPendingPage.java
@@ -1,0 +1,12 @@
+package gov.medicaid.features.general.ui;
+
+import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.DefaultUrl;
+
+@DefaultUrl("http://localhost:8080/cms/provider/dashboard/pending")
+public class DashboardPendingPage extends PsmPage {
+
+    public void clickFilterButton() {
+        click($(".filterBtn"));
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/ForgotPasswordPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/ForgotPasswordPage.java
@@ -1,0 +1,9 @@
+package gov.medicaid.features.general.ui;
+
+import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.DefaultUrl;
+
+@DefaultUrl("http://localhost:8080/cms/forgotpassword")
+public class ForgotPasswordPage extends PsmPage {
+
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/RegisterNewAccountPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/RegisterNewAccountPage.java
@@ -1,0 +1,9 @@
+package gov.medicaid.features.general.ui;
+
+import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.DefaultUrl;
+
+@DefaultUrl("http://localhost:8080/cms/accounts/new")
+public class RegisterNewAccountPage extends PsmPage {
+
+}

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -19,6 +19,11 @@ Feature: Accessibility Checks
     And I am on the dashboard page
     Then I should have no accessibility issues
 
+  Scenario: Dashboard Draft Page
+    Given I am on the Dashboard Draft page
+    When I open the filter panel on the Dashboard Draft page
+    Then I should have no accessibility issues
+
   Scenario: My Profile Page
     Given I am logged in
     When I click on My Profile

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -6,6 +6,10 @@ Feature: Accessibility Checks
     Given I have the application open in my browser
     Then I should have no accessibility issues
 
+  Scenario: Forgot Password Page
+    Given I am on the Forgot Password page
+    Then I should have no accessibility issues
+
   Scenario: Dashboard Page
     Given I am logged in
     And I am on the dashboard page

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -24,6 +24,11 @@ Feature: Accessibility Checks
     When I open the filter panel on the Dashboard Draft page
     Then I should have no accessibility issues
 
+  Scenario: Dashboard Pending Page
+    Given I am on the Dashboard Pending page
+    When I open the filter panel on the Dashboard Pending page
+    Then I should have no accessibility issues
+
   Scenario: My Profile Page
     Given I am logged in
     When I click on My Profile

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -16,7 +16,7 @@ Feature: Accessibility Checks
 
   Scenario: Dashboard Page
     Given I am logged in
-    And I am on the dashboard page
+    When I open the filter panel on the Dashboard page
     Then I should have no accessibility issues
 
   Scenario: Dashboard Draft Page

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -29,6 +29,11 @@ Feature: Accessibility Checks
     When I open the filter panel on the Dashboard Pending page
     Then I should have no accessibility issues
 
+  Scenario: Dashboard Approved Page
+    Given I am on the Dashboard Approved page
+    When I open the filter panel on the Dashboard Approved page
+    Then I should have no accessibility issues
+
   Scenario: My Profile Page
     Given I am logged in
     When I click on My Profile

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -34,6 +34,11 @@ Feature: Accessibility Checks
     When I open the filter panel on the Dashboard Approved page
     Then I should have no accessibility issues
 
+  Scenario: Dashboard Denied Page
+    Given I am on the Dashboard Denied page
+    When I open the filter panel on the Dashboard Denied page
+    Then I should have no accessibility issues
+
   Scenario: My Profile Page
     Given I am logged in
     When I click on My Profile

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -51,3 +51,7 @@ Feature: Accessibility Checks
   Scenario: Account Setup Page
     Given I am on the Account Setup page
     Then I should have no accessibility issues
+
+  Scenario: Advanced Search Page
+    Given I am on the Advanced Search page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -27,3 +27,7 @@ Feature: Accessibility Checks
   Scenario: Update Password Page
     Given I am on the Update Password page
     Then I should have no accessibility issues
+
+  Scenario: Account Setup Page
+    Given I am on the Account Setup page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -6,6 +6,10 @@ Feature: Accessibility Checks
     Given I have the application open in my browser
     Then I should have no accessibility issues
 
+  Scenario: Register New Account Page
+    Given I am on the Register New Account page
+    Then I should have no accessibility issues
+
   Scenario: Forgot Password Page
     Given I am on the Forgot Password page
     Then I should have no accessibility issues


### PR DESCRIPTION
These tests cover the pages that can be accessed (1) without logging in, or (2) by logging in as a provider that aren't (a) part of the enrollment steps, (b) the help documentation, or (c) the quick search results page.

There are a lot of commits here but most are quite similar.  (I could not find a way to reduce the repetition and still do things in the Serenity BDD way.  I'd be glad to know if I'm missing something.)

Tested by running the accessibility tests, and they all pass.

Issue #518 Implement accessibility checking in CI