### PR TITLE
Add an API to get a single enrollment application by ID

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -27,7 +27,8 @@ ext.libs = [
     commons_fileupload: 'commons-fileupload:commons-fileupload:1.3.3',
     commons_io: 'commons-io:commons-io:2.6',
     commons_lang3: 'org.apache.commons:commons-lang3:3.7',
-    hapi_fhir: "ca.uhn.hapi.fhir:hapi-fhir-client-okhttp:${hapi_fhir_version}",
+    hapi_fhir_client: "ca.uhn.hapi.fhir:hapi-fhir-client-okhttp:${hapi_fhir_version}",
+    hapi_fhir_server: "ca.uhn.hapi.fhir:hapi-fhir-server:${hapi_fhir_version}",
     hapi_fhir_structures: "ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:${hapi_fhir_version}",
     handlebars: 'com.github.jknack:handlebars:4.0.6',
     handlebars_springmvc: 'com.github.jknack:handlebars-springmvc:4.0.6',
@@ -138,7 +139,7 @@ project(':cms-business-process') {
         compile libs.commons_codec
         compile libs.commons_io
         compile libs.commons_lang3
-        compile libs.hapi_fhir
+        compile libs.hapi_fhir_client
         compile libs.hapi_fhir_structures
         compile libs.jbpm_human_task_core
         compile libs.openpdf
@@ -176,6 +177,8 @@ project(':cms-web') {
         providedCompile fileTree(dir: 'WebContent/WEB-INF/lib')
         frontend project(path: ':frontend', configuration: 'javascript')
         userdocs project(path: ':userhelp', configuration: 'html')
+        compile libs.hapi_fhir_server
+        compile libs.hapi_fhir_structures
         compile libs.spring_beans
         compile libs.spring_ldap
         compile libs.spring_security_acl
@@ -268,7 +271,8 @@ project(':cms-portal-services') {
         earlib libs.commons_fileupload
         earlib libs.commons_io
         earlib libs.commons_lang3
-        earlib libs.hapi_fhir
+        earlib libs.hapi_fhir_client
+        earlib libs.hapi_fhir_server
         earlib libs.hapi_fhir_structures
         earlib libs.jbpm_human_task_core
         earlib libs.jbpm_persistence_jpa

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -407,22 +407,27 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         return saveTicket(user, ticket, true);
     }
 
-    /**
-     * Retrieves the ticket details (full).
-     *
-     * @param user     the user getting the ticket.
-     * @param ticketId the ticket to get the details for
-     * @return the complete ticket and provider profile
-     * @throws PortalServiceException for any errors encountered
-     */
     @Override
     public Enrollment getTicketDetails(
             CMSUser user,
             long ticketId
     ) throws PortalServiceException {
         checkTicketEntitlement(user, ticketId);
+
         Enrollment ticket = getEm().find(Enrollment.class, ticketId);
-        ticket.setDetails(getProviderDetailsByTicket(ticketId, true).clone());
+        if (ticket == null) {
+            return null;
+        }
+
+        ProviderProfile providerProfile = getProviderDetailsByTicket(
+                ticketId,
+                true
+        );
+        if (providerProfile == null) {
+            return null;
+        }
+
+        ticket.setDetails(providerProfile);
         return ticket;
     }
 

--- a/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ProviderEnrollmentServiceBeanTest.groovy
+++ b/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ProviderEnrollmentServiceBeanTest.groovy
@@ -1,0 +1,73 @@
+package gov.medicaid.services.impl
+
+import gov.medicaid.entities.CMSUser
+import gov.medicaid.entities.Enrollment
+import gov.medicaid.entities.ProviderProfile
+import gov.medicaid.entities.Role
+import spock.lang.Specification
+
+import javax.persistence.EntityManager
+import javax.persistence.Query
+
+class ProviderEnrollmentServiceBeanTest extends Specification {
+    private static final long TICKET_ID = 1
+    private static final String PROFILE_QUERY =
+            "FROM ProviderProfile p WHERE ticketId = :ticketId"
+    private ProviderEnrollmentServiceBean service
+    private EntityManager entityManager
+    private CMSUser systemUser
+
+    void setup() {
+        service = new ProviderEnrollmentServiceBean()
+        entityManager = Mock(EntityManager)
+        service.em = entityManager
+        systemUser = new CMSUser()
+        systemUser.role = new Role()
+        systemUser.role.description = "System Administrator"
+    }
+
+    def "GetTicketDetails returns null on invalid ID"() {
+        when:
+        def result = service.getTicketDetails(systemUser, TICKET_ID)
+
+        then:
+        notThrown(NullPointerException)
+        result == null
+    }
+
+    def "GetTicketDetails returns null on valid ID without profile"() {
+        given:
+        entityManager.find(Enrollment.class, TICKET_ID) >> new Enrollment()
+        entityManager.createQuery(_ as String) >> mockQuery([])
+
+        when:
+        def result = service.getTicketDetails(systemUser, TICKET_ID)
+
+        then:
+        notThrown(NullPointerException)
+        result == null
+    }
+
+    def "GetTicketDetails returns enrollment with profile on valid ID"() {
+        given:
+        Enrollment enrollment = new Enrollment()
+        entityManager.find(Enrollment.class, TICKET_ID) >> enrollment
+        entityManager.createQuery(PROFILE_QUERY) >>
+                mockQuery([new ProviderProfile()])
+        entityManager.createQuery(_ as String) >> mockQuery([])
+
+
+        when:
+        def result = service.getTicketDetails(systemUser, TICKET_ID)
+
+        then:
+        notThrown(NullPointerException)
+        result == enrollment
+    }
+
+    private <T> Query mockQuery(List<T> returnValue) {
+        def query = Mock(Query)
+        query.getResultList() >> returnValue
+        return query
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/PsmApiServlet.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/PsmApiServlet.java
@@ -3,6 +3,9 @@ package gov.medicaid.api;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.RestfulServer;
+import gov.medicaid.services.ProviderEnrollmentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -12,9 +15,23 @@ import java.util.Collections;
 public class PsmApiServlet extends RestfulServer {
     private static final long serialVersionUID = 1L;
 
+    @Autowired
+    private ProviderEnrollmentService providerEnrollmentService;
+
     @Override
     protected void initialize() throws ServletException {
+        initializeSpring();
         initializeHapiFhir();
+    }
+
+    private void initializeSpring() throws ServletException {
+        SpringBeanAutowiringSupport.processInjectionBasedOnServletContext(
+                this,
+                getServletContext()
+        );
+        if (providerEnrollmentService == null) {
+            throw new ServletException("Not initialized!");
+        }
     }
 
     private void initializeHapiFhir() {
@@ -22,6 +39,13 @@ public class PsmApiServlet extends RestfulServer {
         this.setDefaultPrettyPrint(true);
         this.setDefaultResponseEncoding(EncodingEnum.JSON);
 
-        setResourceProviders(Collections.emptyList());
+        setResourceProviders(Collections.singletonList(
+                new TaskResourceProvider(providerEnrollmentService)
+        ));
+    }
+
+    @SuppressWarnings("unused") // reflectively called by Spring
+    public void setProviderEnrollmentService(ProviderEnrollmentService providerEnrollmentService) {
+        this.providerEnrollmentService = providerEnrollmentService;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/PsmApiServlet.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/PsmApiServlet.java
@@ -1,0 +1,27 @@
+package gov.medicaid.api;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.rest.server.RestfulServer;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import java.util.Collections;
+
+@WebServlet(urlPatterns = {"/fhir/*"}, displayName = "PSM FHIR Server")
+public class PsmApiServlet extends RestfulServer {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void initialize() throws ServletException {
+        initializeHapiFhir();
+    }
+
+    private void initializeHapiFhir() {
+        this.setFhirContext(FhirContext.forDstu3());
+        this.setDefaultPrettyPrint(true);
+        this.setDefaultResponseEncoding(EncodingEnum.JSON);
+
+        setResourceProviders(Collections.emptyList());
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/TaskResourceProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/TaskResourceProvider.java
@@ -1,0 +1,39 @@
+package gov.medicaid.api;
+
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Read;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import gov.medicaid.api.transformers.EnrollmentToFhir;
+import gov.medicaid.entities.Enrollment;
+import gov.medicaid.services.CMSConfigurator;
+import gov.medicaid.services.PortalServiceException;
+import gov.medicaid.services.ProviderEnrollmentService;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Task;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+public class TaskResourceProvider implements IResourceProvider {
+    private final ProviderEnrollmentService providerEnrollmentService;
+
+    TaskResourceProvider(ProviderEnrollmentService providerEnrollmentService) {
+        this.providerEnrollmentService = providerEnrollmentService;
+    }
+
+    @Override
+    public Class<? extends IBaseResource> getResourceType() {
+        return Task.class;
+    }
+
+    @Read
+    public Task getResourceById(@IdParam IdType id) throws PortalServiceException {
+        Enrollment enrollment = providerEnrollmentService.getTicketDetails(
+                new CMSConfigurator().getSystemUser(),
+                id.getIdPartAsLong()
+        );
+        if (enrollment == null) {
+            return null;
+        }
+
+        return new EnrollmentToFhir().apply(enrollment);
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentStatusToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentStatusToFhir.java
@@ -1,0 +1,28 @@
+package gov.medicaid.api.transformers;
+
+import gov.medicaid.entities.EnrollmentStatus;
+import org.hl7.fhir.dstu3.model.Task;
+
+import java.util.function.Function;
+
+public class EnrollmentStatusToFhir
+        implements Function<EnrollmentStatus, Task.TaskStatus> {
+    @Override
+    public Task.TaskStatus apply(EnrollmentStatus enrollmentStatus) {
+        if (enrollmentStatus == null) {
+            return Task.TaskStatus.NULL;
+        }
+
+        if ("Draft".equals(enrollmentStatus.getDescription())) {
+            return Task.TaskStatus.DRAFT;
+        } else if ("Pending".equals(enrollmentStatus.getDescription())) {
+            return Task.TaskStatus.REQUESTED;
+        } else if ("Rejected".equals(enrollmentStatus.getDescription())) {
+            return Task.TaskStatus.REJECTED;
+        } else if ("Approved".equals(enrollmentStatus.getDescription())) {
+            return Task.TaskStatus.ACCEPTED;
+        } else {
+            return Task.TaskStatus.NULL;
+        }
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
@@ -1,0 +1,39 @@
+package gov.medicaid.api.transformers;
+
+import gov.medicaid.entities.Enrollment;
+import org.hl7.fhir.dstu3.model.DomainResource;
+import org.hl7.fhir.dstu3.model.Identifier;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.Task;
+
+import java.util.function.Function;
+
+public class EnrollmentToFhir implements Function<Enrollment, Task> {
+    @Override
+    public Task apply(Enrollment enrollment) {
+        DomainResource requester = new EntityToFhir().apply(
+                enrollment.getDetails().getEntity()
+        );
+
+        Task task = new Task();
+        task.addIdentifier(getIdentifier(enrollment));
+        task.setStatus(
+                new EnrollmentStatusToFhir().apply(enrollment.getStatus())
+        );
+        task.setIntent(Task.TaskIntent.PROPOSAL);
+        task.setRequester(new Task.TaskRequesterComponent(new Reference(requester)));
+        task.addInput(
+                new ProviderTypeToFhir().apply(
+                        enrollment.getDetails().getEntity().getProviderType()
+                )
+        );
+        task.addContained(requester);
+
+        return task;
+    }
+
+    private Identifier getIdentifier(Enrollment enrollment) {
+        return new Identifier()
+                .setValue(Long.toString(enrollment.getTicketId()));
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityToFhir.java
@@ -1,0 +1,97 @@
+package gov.medicaid.api.transformers;
+
+import gov.medicaid.entities.Entity;
+import gov.medicaid.entities.Organization;
+import gov.medicaid.entities.Person;
+import org.hl7.fhir.dstu3.model.DomainResource;
+import org.hl7.fhir.dstu3.model.HumanName;
+import org.hl7.fhir.dstu3.model.Identifier;
+import org.hl7.fhir.dstu3.model.Practitioner;
+
+import java.util.function.Function;
+
+public class EntityToFhir implements Function<Entity, DomainResource> {
+    /**
+     * @see <a href="https://www.hl7.org/oid/index.cfm?Comp_OID=2.16.840.1.113883.4.4">
+     * EIN OID in HL7 OID registry</a>
+     */
+    static final String EIN_OID = "2.16.840.1.113883.4.4";
+
+    @Override
+    public DomainResource apply(Entity entity) {
+        if (entity instanceof Person) {
+            return personToPractitioner((Person) entity);
+        } else if (entity instanceof Organization) {
+            return organizationToFhirOrganization((Organization) entity);
+        } else {
+            throw new IllegalArgumentException(
+                    "Unrecognized Entity subclass: " +
+                            entity.getClass().getCanonicalName()
+            );
+        }
+    }
+
+    private Practitioner personToPractitioner(Person person) {
+        Practitioner practitioner = new Practitioner();
+        practitioner.setId("#" + Long.toString(person.getId()));
+        practitioner.addIdentifier(ssn(person));
+        practitioner.addIdentifier(npi(person));
+        practitioner.addName(name(person));
+        return practitioner;
+    }
+
+    private org.hl7.fhir.dstu3.model.Organization organizationToFhirOrganization(
+            Organization organization
+    ) {
+        org.hl7.fhir.dstu3.model.Organization fhirOrg =
+                new org.hl7.fhir.dstu3.model.Organization();
+        fhirOrg.setId("#" + Long.toString(organization.getId()));
+        fhirOrg.addIdentifier(npi(organization));
+        fhirOrg.addIdentifier(ein(organization));
+        fhirOrg.setName(organization.getName());
+        return fhirOrg;
+    }
+
+    private HumanName name(Person person) {
+        HumanName humanName = new HumanName()
+                .addPrefix(person.getPrefix())
+                .setFamily(person.getLastName())
+                .addSuffix(person.getSuffix());
+        if (null != person.getFirstName()) {
+            humanName.addGiven(person.getFirstName());
+        }
+        if (null != person.getMiddleName()) {
+            humanName.addGiven(person.getMiddleName());
+        }
+
+        return humanName;
+    }
+
+    private Identifier ssn(Person person) {
+        return createIdentifier(
+                "http://hl7.org/fhir/sid/us-ssn",
+                person.getSsn()
+        );
+    }
+
+    private Identifier npi(Entity entity) {
+        return createIdentifier(
+                "http://hl7.org/fhir/sid/us-npi",
+                entity.getNpi()
+        );
+    }
+
+    private Identifier ein(Organization organization) {
+        return createIdentifier(EIN_OID, organization.getFein());
+    }
+
+    private Identifier createIdentifier(String system, String value) {
+        if (value == null) {
+            return null;
+        } else {
+            return new Identifier()
+                    .setSystem(system)
+                    .setValue(value);
+        }
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/ProviderTypeToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/ProviderTypeToFhir.java
@@ -1,0 +1,19 @@
+package gov.medicaid.api.transformers;
+
+import gov.medicaid.entities.ProviderType;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.StringType;
+import org.hl7.fhir.dstu3.model.Task;
+
+import java.util.function.Function;
+
+public class ProviderTypeToFhir
+        implements Function<ProviderType, Task.ParameterComponent> {
+    @Override
+    public Task.ParameterComponent apply(ProviderType providerType) {
+        return new Task.ParameterComponent(
+                new CodeableConcept().setText("Provider Type"),
+                new StringType(providerType.getDescription())
+        );
+    }
+}

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
@@ -1,0 +1,69 @@
+package gov.medicaid.api
+
+import gov.medicaid.entities.Enrollment
+import gov.medicaid.entities.Organization
+import gov.medicaid.entities.ProviderProfile
+import gov.medicaid.entities.ProviderType
+import gov.medicaid.services.ProviderEnrollmentService
+import org.hl7.fhir.dstu3.model.IdType
+import org.hl7.fhir.dstu3.model.Task
+import spock.lang.Specification
+
+class TaskResourceProviderTest extends Specification {
+    TaskResourceProvider provider
+    ProviderEnrollmentService mockEnrollmentService
+    long ticketId = 123
+    IdType id
+
+    def setup() {
+        mockEnrollmentService = Mock(ProviderEnrollmentService)
+        provider = new TaskResourceProvider(mockEnrollmentService)
+        id = new IdType(ticketId)
+    }
+
+    def "GetResourceById queries with system user"() {
+        when:
+        provider.getResourceById(id)
+
+        then:
+        1 * mockEnrollmentService.getTicketDetails(
+                {it.role.description == "System Administrator"},
+                _
+        )
+    }
+
+    def "GetResourceById queries with expected ID"() {
+        when:
+        provider.getResourceById(id)
+
+        then:
+        1 * mockEnrollmentService.getTicketDetails(_, ticketId)
+    }
+
+    def "GetResourceById returns null for unknown enrollment ID"() {
+        when:
+        def result = provider.getResourceById(id)
+
+        then:
+        result == null
+    }
+
+    def "GetResourceById returns Task for valid enrollment ID"() {
+        given:
+        Enrollment enrollment = new Enrollment()
+        enrollment.ticketId = 123
+        enrollment.details = new ProviderProfile()
+        enrollment.details.entity = new Organization()
+        enrollment.details.entity.providerType = new ProviderType()
+
+        mockEnrollmentService.getTicketDetails(_, ticketId) >> enrollment
+
+        when:
+        def result = provider.getResourceById(id)
+
+        then:
+        result instanceof Task
+        result.identifier.size() == 1
+        result.identifier.first().value == Long.toString(ticketId)
+    }
+}

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentStatusToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentStatusToFhirTest.groovy
@@ -1,0 +1,45 @@
+package gov.medicaid.api.transformers
+
+import gov.medicaid.entities.EnrollmentStatus
+import org.hl7.fhir.dstu3.model.Task
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class EnrollmentStatusToFhirTest extends Specification {
+    @Unroll
+    def "Transforms status #statusDescription to #expectedTaskStatusCode"(
+            String statusCode,
+            String statusDescription,
+            String expectedTaskStatusCode
+    ) {
+        given:
+        def transformer = new EnrollmentStatusToFhir()
+        EnrollmentStatus input = new EnrollmentStatus()
+        input.setCode(statusCode)
+        input.setDescription(statusDescription)
+
+        when:
+        def result = transformer.apply(input)
+
+        then:
+        result == Task.TaskStatus.fromCode(expectedTaskStatusCode)
+
+        where:
+        statusCode | statusDescription || expectedTaskStatusCode
+        "01"       | "Draft"           || "draft"
+        "02"       | "Pending"         || "requested"
+        "03"       | "Rejected"        || "rejected"
+        "04"       | "Approved"        || "accepted"
+    }
+
+    def "Transforms null status to null data"() {
+        given:
+        def transformer = new EnrollmentStatusToFhir()
+
+        when:
+        def result = transformer.apply(null)
+
+        then:
+        result == Task.TaskStatus.NULL
+    }
+}

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentToFhirTest.groovy
@@ -1,0 +1,76 @@
+package gov.medicaid.api.transformers
+
+import gov.medicaid.entities.Enrollment
+import gov.medicaid.entities.EnrollmentStatus
+import gov.medicaid.entities.Person
+import gov.medicaid.entities.ProviderProfile
+import gov.medicaid.entities.ProviderType
+import org.hl7.fhir.dstu3.model.Task
+import spock.lang.Specification
+
+class EnrollmentToFhirTest extends Specification {
+    EnrollmentToFhir transformer
+    Enrollment enrollment
+
+    def setup() {
+        transformer = new EnrollmentToFhir()
+
+        enrollment = new Enrollment()
+        enrollment.ticketId = 123
+        enrollment.status = new EnrollmentStatus()
+        enrollment.status.description = "Pending"
+        enrollment.details = new ProviderProfile()
+        enrollment.details.entity = new Person()
+        enrollment.details.entity.id = 456
+        enrollment.details.entity.providerType = new ProviderType()
+        enrollment.details.entity.providerType.description = "Audiologist"
+    }
+
+    def "Entity is included as a contained resource"() {
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.hasContained()
+        result.getContained().size() == 1
+        result.getContained().first().id == "#456"
+    }
+
+    def "Status is set"() {
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.hasStatus()
+        result.getStatus() == Task.TaskStatus.REQUESTED
+    }
+
+    def "Intent is set"() {
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.hasIntent()
+        result.getIntent() == Task.TaskIntent.PROPOSAL
+    }
+
+    def "Provider type is set as input"() {
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.hasInput()
+        result.input.size() == 1
+        result.input.first().value.toString() == "Audiologist"
+    }
+
+    def "Enrollment ID is set as identifier"() {
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.hasIdentifier()
+        result.identifier.size() == 1
+        result.identifier.first().value == "123"
+    }
+}

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EntityToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EntityToFhirTest.groovy
@@ -1,0 +1,241 @@
+package gov.medicaid.api.transformers
+
+import gov.medicaid.entities.Entity
+import gov.medicaid.entities.Organization
+import gov.medicaid.entities.Person
+import org.hl7.fhir.dstu3.model.Practitioner
+import spock.lang.Specification
+
+class EntityToFhirTest extends Specification {
+    EntityToFhir transformer
+    Person individual
+    Organization organization
+
+    def setup() {
+        transformer = new EntityToFhir()
+        individual = new Person()
+        organization = new Organization()
+    }
+
+    def "Individual without ID gets ID 0"() {
+        when:
+        def result = transformer.apply(individual)
+
+        then:
+        result.getId() == "#0"
+    }
+
+    def "Individual without SSN does not have SSN identifier"() {
+        given:
+        individual.setNpi("1234567893")
+
+        when:
+        def result = transformer.apply(individual) as Practitioner
+
+        then:
+        result.getIdentifier().stream().noneMatch({
+            i -> i.getSystem() == "http://hl7.org/fhir/sid/us-ssn"
+        })
+    }
+
+    def "Individual without NPI does not have NPI identifier"() {
+        given:
+        individual.setSsn("333224444")
+
+        when:
+        def result = transformer.apply(individual) as Practitioner
+
+        then:
+        result.getIdentifier().stream().noneMatch({
+            i -> i.getSystem() == "http://hl7.org/fhir/sid/us-npi"
+        })
+    }
+
+    def "Individual with both NPI and SSN has both identifiers"() {
+        given:
+        individual.setNpi("1234567893")
+        individual.setSsn("333224444")
+
+        when:
+        def result = transformer.apply(individual) as Practitioner
+
+        then:
+        result.getIdentifier().stream().anyMatch({
+            i -> i.getSystem() == "http://hl7.org/fhir/sid/us-npi"
+        })
+        result.getIdentifier().stream().anyMatch({
+            i -> i.getSystem() == "http://hl7.org/fhir/sid/us-ssn"
+        })
+        result.getIdentifier().size() == 2
+    }
+
+    def "Individual's first + last name is transformed correctly"() {
+        given:
+        individual.setFirstName("First")
+        individual.setLastName("Last")
+
+        when:
+        def result = transformer.apply(individual) as Practitioner
+
+        then:
+        result.getName().size() == 1
+        def name = result.getName().first()
+
+        !name.hasPrefix()
+
+        name.hasGiven()
+        name.getGiven().size() == 1
+        name.getGiven().first().value == "First"
+
+        name.hasFamily()
+        name.getFamily() == "Last"
+
+        !name.hasSuffix()
+
+        !name.hasPeriod()
+    }
+
+    def "Individual's first, middle, last name is transformed correctly"() {
+        given:
+        individual.setFirstName("First")
+        individual.setMiddleName("Middle")
+        individual.setLastName("Last")
+
+        when:
+        def result = transformer.apply(individual) as Practitioner
+
+        then:
+        result.getName().size() == 1
+        def name = result.getName().first()
+
+        !name.hasPrefix()
+
+        name.hasGiven()
+        name.getGiven().size() == 2
+        name.getGiven().first().value == "First"
+        name.getGiven().last().value == "Middle"
+
+        name.hasFamily()
+        name.getFamily() == "Last"
+
+        !name.hasSuffix()
+
+        !name.hasPeriod()
+    }
+
+    def "Individual's full name is transformed correctly"() {
+        given:
+        individual.setPrefix("Dr.")
+        individual.setFirstName("First")
+        individual.setMiddleName("Middle")
+        individual.setLastName("Last")
+        individual.setSuffix("I")
+
+        when:
+        def result = transformer.apply(individual) as Practitioner
+
+        then:
+        result.getName().size() == 1
+        def name = result.getName().first()
+
+        name.hasPrefix()
+        name.getPrefix().size() == 1
+        name.getPrefix().first().value == "Dr."
+
+        name.hasGiven()
+        name.getGiven().size() == 2
+        name.getGiven().first().value == "First"
+        name.getGiven().last().value == "Middle"
+
+        name.hasFamily()
+        name.getFamily() == "Last"
+
+        name.hasSuffix()
+        name.getSuffix().size() == 1
+        name.getSuffix().first().value == "I"
+
+        !name.hasPeriod()
+    }
+
+    def "Organization without ID gets ID 0"() {
+        when:
+        def result = transformer.apply(organization)
+
+        then:
+        result.getId() == "#0"
+    }
+
+    def "Organization has NPI identifier"() {
+        given:
+        organization.setNpi("1234567893")
+
+        when:
+        def result = transformer.apply(organization) as org.hl7.fhir.dstu3.model.Organization
+
+        then:
+        result.getIdentifier().size() == 1
+        result.getIdentifier().first().system == "http://hl7.org/fhir/sid/us-npi"
+        result.getIdentifier().first().value == "1234567893"
+    }
+
+    def "Organization has FEIN identifier"() {
+        given:
+        organization.setFein("00-1234567")
+
+        when:
+        def result = transformer.apply(organization) as org.hl7.fhir.dstu3.model.Organization
+
+        then:
+        result.getIdentifier().size() == 1
+        result.getIdentifier().first().system == EntityToFhir.EIN_OID
+        result.getIdentifier().first().value == "00-1234567"
+    }
+
+    def "Organization with NPI and FEIN has both identifiers"() {
+        given:
+        organization.setNpi("1234567893")
+        organization.setFein("00-1234567")
+
+        when:
+        def result = transformer.apply(organization) as org.hl7.fhir.dstu3.model.Organization
+
+        then:
+        result.getIdentifier().stream().anyMatch({
+            i -> i.getSystem() == "http://hl7.org/fhir/sid/us-npi"
+        })
+        result.getIdentifier().stream().anyMatch({
+            i -> i.getSystem() == EntityToFhir.EIN_OID
+        })
+        result.getIdentifier().size() == 2
+    }
+
+    def "Organization has name"() {
+        given:
+        organization.setName("Organization Name")
+
+        when:
+        def result = transformer.apply(organization) as org.hl7.fhir.dstu3.model.Organization
+
+        then:
+        result.getName() == "Organization Name"
+    }
+
+    def "Transforming an unexpected class throws"() {
+        given:
+        Entity entity = new Entity() {}
+
+        when:
+        transformer.apply(entity)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "Transforming null throws"() {
+        when:
+        transformer.apply(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+}

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/ProviderTypeToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/ProviderTypeToFhirTest.groovy
@@ -1,0 +1,34 @@
+package gov.medicaid.api.transformers
+
+import gov.medicaid.domain.model.ApplicantType
+import gov.medicaid.entities.ProviderType
+import spock.lang.Specification
+
+class ProviderTypeToFhirTest extends Specification {
+    def "Transforms provider type to expected structure"() {
+        given:
+        def transformer = new ProviderTypeToFhir()
+        def input = new ProviderType()
+        input.setCode("01")
+        input.setDescription("Audiologist")
+        input.setApplicantType(ApplicantType.INDIVIDUAL)
+
+        when:
+        def result = transformer.apply(input)
+
+        then:
+        result.type.text == "Provider Type"
+        result.value.toString() == "Audiologist"
+    }
+
+    def "Throws on null"() {
+        given:
+        def transformer = new ProviderTypeToFhir()
+
+        when:
+        transformer.apply(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+}

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -194,7 +194,7 @@ public interface ProviderEnrollmentService {
      *
      * @param user     the user getting the ticket.
      * @param ticketId the ticket to get the details for
-     * @return the complete ticket and provider profile
+     * @return the complete ticket and provider profile, or null if not found
      * @throws PortalServiceException for any errors encountered
      */
     Enrollment getTicketDetails(


### PR DESCRIPTION
Add an API to get a single enrollment application by ID.

This is split into three pieces:
1. fix a bug in the persistence API (cf #57)
2. add the HAPI-FHIR REST framework
3. add the new `Task` API

See the commit messages for more details.

The API currently responds to queries at `/cms/fhir/Task/<ID>`, where ID can be retrieved by examining a link in the UI to an enrollment application (_not_ to a profile; this is a subtle difference). Per the discussion in this PR and in #641, this first iteration does not include search or practice addresses; those will be a result of later work.

Here is an example result for an individual practitioner:

```json
{
  "contained": [
    {
      "id": "1584",
      "identifier": [
        {
          "system": "http://hl7.org/fhir/sid/us-ssn",
          "value": "000000000"
        },
        {
          "system": "http://hl7.org/fhir/sid/us-npi",
          "value": "0000000006"
        }
      ],
      "name": [
        {
          "family": "LastName",
          "given": [
            "FirstName",
            "MiddleName"
          ]
        }
      ],
      "resourceType": "Practitioner"
    }
  ],
  "identifier": [
    {
      "value": "1570"
    }
  ],
  "input": [
    {
      "type": {
        "text": "Provider Type"
      },
      "valueString": "Speech Language Pathologist"
    }
  ],
  "intent": "proposal",
  "requester": {
    "agent": {
      "reference": "#1584"
    }
  },
  "resourceType": "Task",
  "status": "requested"
}
```

And for an organization:

```json
{
  "resourceType": "Task",
  "contained": [
    {
      "resourceType": "Organization",
      "id": "5914",
      "identifier": [
        {
          "system": "http://hl7.org/fhir/sid/us-npi",
          "value": "1234567893"
        },
        {
          "system": "2.16.840.1.113883.4.4",
          "value": "00-0000000"
        }
      ],
      "name": "DBA, Inc"
    }
  ],
  "identifier": [
    {
      "value": "3690"
    }
  ],
  "status": "accepted",
  "intent": "proposal",
  "requester": {
    "agent": {
      "reference": "#5914"
    }
  },
  "input": [
    {
      "type": {
        "text": "Provider Type"
      },
      "valueString": "Dental Clinic"
    }
  ]
}
```

Deploying the API should be as simple as building and deploying the application; there are no additional steps!

I tested this by running the unit tests I added (:tada:), and by using curl:

```
$ curl --insecure "https://localhost:8443/cms/fhir/Task/3690"
```

I also used the browser to show me the XML version, by navigating to such a URL.

It may be helpful to find enrollment IDs; they live in the database in the `enrollments` table:

```
psm=> SELECT enrollment_id, enrollment_status_code
FROM enrollments
WHERE enrollment_status_code IN ('02', '03', '04') -- Pending, Rejected, Approved
LIMIT 5;
```

Issue #57 Improve database schema
Issue #641 Create API that returns a list of approved and/or rejected providers