### PR TITLE
Add more general accessibility tests, take two

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -72,7 +72,7 @@
                       <spring:bind path="firstName">
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
                       </spring:bind>
-                      <form:input id="registerFirstname" path="firstName" cssClass="normalInput ${errorCls}"/>
+                      <form:input id="registerFirstName" path="firstName" cssClass="normalInput ${errorCls}"/>
                     </div>
                     <div class="row">
                       <label for="registerMiddleName">Middle Name</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -125,7 +125,7 @@
                     <label class="label">&nbsp;</label>
                     <input id="remember" type="checkbox" name="keepUserSignedIn"/>
                     <label for="remember">Remember Me</label>
-                    <a href="<c:url value="/forgotpassword" />">Forgot Password?</a>
+                    <a class="forgotPasswordLink" href="<c:url value="/forgotpassword" />">Forgot Password?</a>
                   </div>
                   <div class="buttons">
                     <button id="btnLogin" class="purpleBtn" type="submit">Login</button>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -129,7 +129,7 @@
                   </div>
                   <div class="buttons">
                     <button id="btnLogin" class="purpleBtn" type="submit">Login</button>
-                    <a href="<c:url value="/accounts/new" />" class="">Register New Account</a>
+                    <a class="registerNewAccountLink" href="<c:url value="/accounts/new" />">Register New Account</a>
                   </div>
 
                   <div class="tl"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -55,7 +55,7 @@
                 <label class="label">&nbsp;</label>
                 <input id="remember" type="checkbox" name="keepUserSignedIn"/>
                 <label for="remember">Remember Me</label>
-                <a href="<c:url value="/forgotpassword" />">Forgot Password?</a>
+                <a class="forgotPasswordLink" href="<c:url value="/forgotpassword" />">Forgot Password?</a>
               </div>
               <div class="buttons">
                 <button id="btnLogin" class="purpleBtn" type="submit">Login</button>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -59,7 +59,7 @@
               </div>
               <div class="buttons">
                 <button id="btnLogin" class="purpleBtn" type="submit">Login</button>
-                <a href="<c:url value="/accounts/new" />" class="">Register New Account</a>
+                <a class="registerNewAccountLink" href="<c:url value="/accounts/new" />">Register New Account</a>
               </div>
 
               <div class="tl"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -32,22 +32,22 @@
                 <div class="tabM">
                   <a class="tab ${statusFilter eq 'Draft' ? 'active' : ''}" href="<c:url value="/provider/dashboard/drafts" />">
                     <span class="aR">
-                      <span class="aM">Draft</span>
+                      <span class="draftTab aM">Draft</span>
                     </span>
                   </a>
                   <a class="tab ${statusFilter eq 'Pending' ? 'active' : ''}" href="<c:url value="/provider/dashboard/pending" />">
                     <span class="aR">
-                      <span class="aM">Pending</span>
+                      <span class="pendingTab aM">Pending</span>
                     </span>
                   </a>
                   <a class="tab ${statusFilter eq 'Approved' ? 'active' : ''}" href="<c:url value="/provider/dashboard/approved" />">
                     <span class="aR">
-                      <span class="aM">Approved</span>
+                      <span class="approvedTab aM">Approved</span>
                     </span>
                   </a>
                   <a class="tab ${statusFilter eq 'Rejected' ? 'active' : ''}" href="<c:url value="/provider/dashboard/rejected" />">
                     <span class="aR">
-                      <span class="aM">Denied</span>
+                      <span class="deniedTab aM">Denied</span>
                     </span>
                   </a>
                   <h:create-enrollment-button cssClass="purpleBtn"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
@@ -19,7 +19,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value="/provider/dashboard/setup" />">Account Setup</a>
+            <a class="accountSetupLink" href="<c:url value="/provider/dashboard/setup" />">Account Setup</a>
             <span class="text">Account Details</span>
           </div>
           <div class="head">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -20,7 +20,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value="/provider/dashboard/setup" />">Account Setup</a>
+            <a class="accountSetupLink" href="<c:url value="/provider/dashboard/setup" />">Account Setup</a>
             <span class="text">Import Profiles</span>
           </div>
           <div class="head">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -85,7 +85,7 @@
                   <ul>
                     <li>
                       <p>
-                        <a href="<c:url value="/provider/dashboard/setup" />">Account Setup</a>
+                        <a class="accountSetupLink" href="<c:url value="/provider/dashboard/setup" />">Account Setup</a>
                         <br/>
                         Create new or import existing profiles
                       </p>

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -14,7 +14,7 @@
           </li>
 
           <li class="{{#if activeTab2 }} active {{/if}}">
-            <a href="{{ctx}}/provider/dashboard/drafts">ENROLLMENTS</a>
+            <a class="enrollmentsLink" href="{{ctx}}/provider/dashboard/drafts">ENROLLMENTS</a>
             {{#if activeTab2 }} <span class="arrow"></span> {{/if}}
           </li>
 

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -34,7 +34,7 @@
 
       {{#if systemPage}}
         <div class="searchWidget">
-          <a href="{{ctx}}/system/advanced-search-system-admin">Advanced Search</a>
+          <a class="advancedSearchLink" href="{{ctx}}/system/advanced-search-system-admin">Advanced Search</a>
           <form id="searchBoxForm" class="inputContainer" action="{{ctx}}/system/user/search?role=Provider"  method="post">
             <input type="hidden" name="{{csrf.parameterName}}" value="{{csrf.token}}"/>
             <button class="search searchBox" title="Search" aria-label="Search" type="submit"></button>
@@ -51,7 +51,7 @@
         </div>
       {{else}}
         <div class="searchWidget">
-          <a href="{{ctx}}/provider/search/advanced">Advanced Search</a>
+          <a class="advancedSearchLink" href="{{ctx}}/provider/search/advanced">Advanced Search</a>
           <div class="inputContainer">
             <button id="enrollmentQuickSearch" class="search" title="Search" aria-label="Search"></button>
             <input id="quickSearchInput" type="text" class="hint" value="{{#if param.npi }} {{param.npi}} {{else}} Search Keyword {{/if}}" title="Search Keyword" />

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
@@ -29,6 +29,10 @@ public class PsmPage extends PageObject {
         clickOn(target);
     }
 
+    public void click$(String selector) {
+        click($(selector));
+    }
+
     public void checkAccessibility() {
         WebDriver driver = getDriver();
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AccountSetupStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AccountSetupStepDefinitions.java
@@ -1,0 +1,16 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class AccountSetupStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Account Setup page$")
+    public void i_am_on_the_account_setup_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.navigateToAccountSetupPage();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AdvancedSearchStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AdvancedSearchStepDefinitions.java
@@ -1,0 +1,16 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class AdvancedSearchStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Advanced Search page$")
+    public void i_am_on_the_advanced_search_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.navigateToAdvancedSearchPage();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
@@ -38,6 +38,6 @@ public class ChangePasswordStepDefinitions {
     @Given("^I am on the Update Password page$")
     public void i_am_on_the_update_password_page() {
         generalSteps.loginAsProvider();
-        generalSteps.openUpdatePasswordPage();
+        generalSteps.navigateToUpdatePasswordPage();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
@@ -1,0 +1,40 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.When;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class DashboardStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Dashboard Draft page$")
+    public void i_am_on_the_dashboard_draft_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.navigateToDashboardDraftPage();
+    }
+
+    @Given("^I am on the Dashboard Pending page$")
+    public void i_am_on_the_dashboard_pending_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.navigateToDashboardPendingPage();
+    }
+
+    @Given("^I am on the Dashboard Approved page$")
+    public void i_am_on_the_dashboard_approved_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.navigateToDashboardApprovedPage();
+    }
+
+    @Given("^I am on the Dashboard Denied page$")
+    public void i_am_on_the_dashboard_denied_page() {
+        generalSteps.loginAsProvider();
+        generalSteps.navigateToDashboardDeniedPage();
+    }
+
+    @When("^I open the filter panel$")
+    public void i_open_the_filter_panel() {
+        generalSteps.openFilterPanel();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ForgotPasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ForgotPasswordStepDefinitions.java
@@ -1,0 +1,15 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class ForgotPasswordStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Forgot Password page$")
+    public void i_am_on_the_forgot_password_page() {
+        generalSteps.navigateToForgotPasswordPage();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -40,6 +40,34 @@ public class GeneralSteps {
     }
 
     @Step
+    public void navigateToDashboardDraftPage() {
+        dashboardPage.click$(".enrollmentsLink");
+    }
+
+    @Step
+    public void navigateToDashboardPendingPage() {
+        navigateToDashboardDraftPage();
+        dashboardPage.click$(".pendingTab");
+    }
+
+    @Step
+    public void navigateToDashboardApprovedPage() {
+        navigateToDashboardDraftPage();
+        dashboardPage.click$(".approvedTab");
+    }
+
+    @Step
+    public void navigateToDashboardDeniedPage() {
+        navigateToDashboardDraftPage();
+        dashboardPage.click$(".deniedTab");
+    }
+
+    @Step
+    public void openFilterPanel() {
+        dashboardPage.click$(".filterBtn");
+    }
+
+    @Step
     public void clickMyProfile()  {
         dashboardPage.clickMyProfile();
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -63,4 +63,10 @@ public class GeneralSteps {
     public void openUpdatePasswordPage() {
         updatePasswordPage.open();
     }
+
+    @Step
+    public void navigateToAccountSetupPage() {
+        clickMyProfile();
+        profilePage.click$(".accountSetupLink");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -15,6 +15,12 @@ public class GeneralSteps {
     private UpdatePasswordPage updatePasswordPage;
 
     @Step
+    public void navigateToRegisterNewAccountPage() {
+        loginPage.open();
+        loginPage.click$(".registerNewAccountLink");
+    }
+
+    @Step
     public void navigateToForgotPasswordPage() {
         loginPage.open();
         loginPage.click$(".forgotPasswordLink");

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -9,10 +9,16 @@ import net.thucydides.core.annotations.Step;
 @SuppressWarnings("unused")
 public class GeneralSteps {
 
-    private DashboardPage dashboardPage;
     private LoginPage loginPage;
+    private DashboardPage dashboardPage;
     private MyProfilePage profilePage;
     private UpdatePasswordPage updatePasswordPage;
+
+    @Step
+    public void navigateToForgotPasswordPage() {
+        loginPage.open();
+        loginPage.click$(".forgotPasswordLink");
+    }
 
     @Step
     public void loginAsProvider() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -88,8 +88,9 @@ public class GeneralSteps {
     }
 
     @Step
-    public void openUpdatePasswordPage() {
-        updatePasswordPage.open();
+    public void navigateToUpdatePasswordPage() {
+        clickMyProfile();
+        profilePage.click$("#change_password_link");
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -97,4 +97,9 @@ public class GeneralSteps {
         clickMyProfile();
         profilePage.click$(".accountSetupLink");
     }
+
+    @Step
+    public void navigateToAdvancedSearchPage() {
+        dashboardPage.click$(".advancedSearchLink");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/RegisterNewAccountStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/RegisterNewAccountStepDefinitions.java
@@ -1,0 +1,15 @@
+package gov.medicaid.features.general.steps;
+
+import cucumber.api.java.en.Given;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class RegisterNewAccountStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I am on the Register New Account page$")
+    public void i_am_on_the_register_new_account_page() {
+        generalSteps.navigateToRegisterNewAccountPage();
+    }
+}

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -1,5 +1,5 @@
 @accessibility
-Feature: Accessibility Checks
+Feature: General Accessibility Checks
   Users wish to access accessible pages
 
   Scenario: Login Page

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -6,6 +6,10 @@ Feature: Accessibility Checks
     Given I have the application open in my browser
     Then I should have no accessibility issues
 
+  Scenario: Forgot Password Page
+    Given I am on the Forgot Password page
+    Then I should have no accessibility issues
+
   Scenario: Dashboard Page
     Given I am logged in
     And I am on the dashboard page

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -19,6 +19,26 @@ Feature: Accessibility Checks
     And I am on the dashboard page
     Then I should have no accessibility issues
 
+  Scenario: Dashboard Draft Page
+    Given I am on the Dashboard Draft page
+    When I open the filter panel
+    Then I should have no accessibility issues
+
+  Scenario: Dashboard Pending Page
+    Given I am on the Dashboard Pending page
+    When I open the filter panel
+    Then I should have no accessibility issues
+
+  Scenario: Dashboard Approved Page
+    Given I am on the Dashboard Approved page
+    When I open the filter panel
+    Then I should have no accessibility issues
+
+  Scenario: Dashboard Denied Page
+    Given I am on the Dashboard Denied page
+    When I open the filter panel
+    Then I should have no accessibility issues
+
   Scenario: My Profile Page
     Given I am logged in
     When I click on My Profile

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -16,7 +16,7 @@ Feature: Accessibility Checks
 
   Scenario: Dashboard Page
     Given I am logged in
-    And I am on the dashboard page
+    When I open the filter panel
     Then I should have no accessibility issues
 
   Scenario: Dashboard Draft Page

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -51,3 +51,7 @@ Feature: Accessibility Checks
   Scenario: Account Setup Page
     Given I am on the Account Setup page
     Then I should have no accessibility issues
+
+  Scenario: Advanced Search Page
+    Given I am on the Advanced Search page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -27,3 +27,7 @@ Feature: Accessibility Checks
   Scenario: Update Password Page
     Given I am on the Update Password page
     Then I should have no accessibility issues
+
+  Scenario: Account Setup Page
+    Given I am on the Account Setup page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -6,6 +6,10 @@ Feature: Accessibility Checks
     Given I have the application open in my browser
     Then I should have no accessibility issues
 
+  Scenario: Register New Account Page
+    Given I am on the Register New Account page
+    Then I should have no accessibility issues
+
   Scenario: Forgot Password Page
     Given I am on the Forgot Password page
     Then I should have no accessibility issues


### PR DESCRIPTION
This is another approach than was taken in #665.  (Making a separate pull request in case reviewers want to compare the two.)  It is better to use the "click this, click that" approach instead of "open by URL", because (1) we want to test site navigation paths anyway so better not to have two ways to get to a given page (2) opening pages by URL forces you to have a separate class/file for every page and that adds boilerplate.  

These tests cover the pages that can be accessed (1) without logging in, or (2) by logging in as a provider that aren't (a) part of the enrollment steps, (b) the help documentation, or (c) the quick search results page.

Tested by running the accessibility tests, and they all pass.

Issue #518 Implement accessibility checking in CI