### PR TITLE
Add accessibility tests for organization enrollment steps

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -331,7 +331,7 @@
 </div>
 
 <div class="tableBottom">
-    <a href="javascript:;" id="addOwnership">+ Add Another Individual Person Ownership or Control Interest</a>
+    <a href="javascript:;" id="addIndividualOwnership">+ Add Another Individual Person Ownership or Control Interest</a>
 </div>
 
 

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4323,7 +4323,7 @@ input.passwordNormalInput{
   padding-left: 30px;
   padding-top: 0;
 }
-#addMember, #addOwnership, #addBusinessOwnership{
+#addMember, #addIndividualOwnership, #addBusinessOwnership{
   display: inline-block;
   line-height: 20px;
   padding-bottom: 5px;

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -1388,7 +1388,7 @@ input.date{
   width:20%;
   float:left;
   display:inline;
-  color:#999999;
+  color:#737373;
   line-height:14px;
 }
 

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1862,7 +1862,7 @@ $(document).ready(function () {
   }
 
   /*add ownership*/
-  $('#addOwnership').live('click', function () {
+  $('#addIndividualOwnership').live('click', function () {
     var html = $('#ownerTemplate').clone();
     html.attr('id', '');
     html.find('[type=text]').val('');

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
@@ -83,11 +83,6 @@ public class DataCoverageStepDefinitions {
         enrollmentSteps.uploadLicense();
     }
 
-    @When("^I move to the organization page$")
-    public void i_move_to_the_organization_page() {
-        enrollmentSteps.selectOrganizationalProviderType();
-    }
-
     @When("^I enter a valid private practice$")
     public void enter_valid_private_practice_information() {
         enrollmentSteps.enterIndividualPrivatePracticeInfo();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -49,6 +49,11 @@ public class EnrollmentStepDefinitions {
         enrollmentPage.clickNext();
     }
 
+    @When("^I open the add a license panel$")
+    public void i_open_the_add_a_license_panel() {
+        enrollmentSteps.clickAddLicense();
+    }
+
     @When("^I am on the individual member info page$")
     public void i_am_on_the_individual_member_info_page() throws IOException {
         i_am_on_the_facility_credentials_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -6,6 +6,7 @@ import cucumber.api.java.en.When;
 import gov.medicaid.features.enrollment.ui.EnrollmentPage;
 import gov.medicaid.features.enrollment.ui.LicenseInfoPage;
 import gov.medicaid.features.enrollment.ui.OwnershipInfoPage;
+import gov.medicaid.features.general.steps.GeneralSteps;
 import net.thucydides.core.annotations.Steps;
 
 import java.io.IOException;
@@ -16,14 +17,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class EnrollmentStepDefinitions {
     @Steps
     EnrollmentSteps enrollmentSteps;
+    @Steps
+    GeneralSteps generalSteps;
 
     private EnrollmentPage enrollmentPage;
     private OwnershipInfoPage ownershipInfoPage;
     private LicenseInfoPage licenseInfoPage;
 
+    @Given("^I have started an enrollment$")
+    public void i_have_started_an_enrollment() {
+        generalSteps.loginAsProvider();
+        enrollmentSteps.createEnrollment();
+    }
+
+    @Given("^I am on the organization page$")
+    public void i_am_on_the_organization_page() {
+        enrollmentSteps.selectOrganizationalProviderType();
+    }
+
+    @Given("^I am on the personal info page$")
+    public void i_am_on_the_personal_info_page() {
+        i_have_started_an_enrollment();
+        enrollmentSteps.selectIndividualProviderType();
+    }
+
     @When("^I am on the facility credentials page$")
     public void i_am_on_the_facility_credentials_page() {
-        enrollmentSteps.selectOrganizationalProviderType();
+        i_am_on_the_organization_page();
         enrollmentSteps.enterOrganizationInfo();
         enrollmentSteps.enterContactInfo();
         enrollmentPage.clickNext();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -21,32 +21,58 @@ public class EnrollmentStepDefinitions {
     private OwnershipInfoPage ownershipInfoPage;
     private LicenseInfoPage licenseInfoPage;
 
-    @Given("^I am entering ownership information$")
-    public void i_am_entering_ownership_information() throws IOException {
+    @When("^I move to the facility credentials page$")
+    public void i_move_to_the_facility_credentials_page() {
         enrollmentSteps.selectOrganizationalProviderType();
         enrollmentSteps.enterOrganizationInfo();
         enrollmentSteps.enterContactInfo();
         enrollmentPage.clickNext();
+    }
+
+    @When("^I move to the individual member info page$")
+    public void i_move_to_the_individual_member_info_page() throws IOException {
+        i_move_to_the_facility_credentials_page();
         enrollmentSteps.enterLicenseInfo();
         enrollmentSteps.uploadLicense();
         enrollmentPage.clickNext();
+    }
+
+    @When("^I open an individual member panel")
+    public void i_open_an_individual_member_panel() {
+        enrollmentSteps.openIndividualMemberPanel();
+    }
+
+    @When("^I move to the ownership info page$")
+    public void i_move_to_the_ownership_info_page() throws IOException {
+        i_move_to_the_individual_member_info_page();
         enrollmentSteps.enterIndividualMember();
         enrollmentPage.clickNext();
+    }
 
-        ownershipInfoPage.selectEntityType("Sole Proprietorship");
-        ownershipInfoPage.addOwnership();
-        ownershipInfoPage.selectOwnershipType("Managing Employee");
-        ownershipInfoPage.setOwnershipFirstName("First");
-        ownershipInfoPage.setOwnershipMiddleName("Middle");
-        ownershipInfoPage.setOwnershipLastName("Last");
-        ownershipInfoPage.setOwnershipSoSec("123456789");
-        ownershipInfoPage.setOwnershipAddr1("OwnerAddr1");
-        ownershipInfoPage.setOwnershipDOB("01011970");
-        ownershipInfoPage.setOwnershipHireDate("01012000");
-        ownershipInfoPage.setOwnershipCity("Ownertown");
-        ownershipInfoPage.selectOwnershipState("Texas");
-        ownershipInfoPage.setOwnershipZip("77706");
-        ownershipInfoPage.selectOwnershipCounty("Beltrami");
+    @When("^I open individual and business owner panels$")
+    public void i_open_individual_and_business_owner_panels() {
+        ownershipInfoPage.addIndividualOwnership();
+        ownershipInfoPage.addBusinessOwnership();
+    }
+
+    @When("^I move to the summary page$")
+    public void i_move_to_the_summary_page() throws IOException {
+        i_move_to_the_ownership_info_page();
+        enrollmentSteps.enterOrganizationOwnershipInfo();
+        enrollmentSteps.setNoToAllDisclosures();
+        ownershipInfoPage.clickNext();
+    }
+
+    @When("^I move to the provider statement page$")
+    public void i_move_to_the_provider_statement_page() throws IOException {
+        i_move_to_the_summary_page();
+        enrollmentPage.clickNext();
+    }
+
+    @When("^I am entering ownership information$")
+    public void i_am_entering_ownership_information() throws IOException {
+        i_move_to_the_ownership_info_page();
+        enrollmentSteps.enterOrganizationOwnershipInfo();
     }
 
     @Given("^I have indicated that the owner has an interest in another Medicaid disclosing entity$")
@@ -69,7 +95,6 @@ public class EnrollmentStepDefinitions {
     public void i_click_next_on_the_Ownership_Info_Page() {
         ownershipInfoPage.setNoToAllDisclosures();
         ownershipInfoPage.clickNext();
-
     }
 
     @When("^I click 'next' on the license info page$")

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -21,17 +21,17 @@ public class EnrollmentStepDefinitions {
     private OwnershipInfoPage ownershipInfoPage;
     private LicenseInfoPage licenseInfoPage;
 
-    @When("^I move to the facility credentials page$")
-    public void i_move_to_the_facility_credentials_page() {
+    @When("^I am on the facility credentials page$")
+    public void i_am_on_the_facility_credentials_page() {
         enrollmentSteps.selectOrganizationalProviderType();
         enrollmentSteps.enterOrganizationInfo();
         enrollmentSteps.enterContactInfo();
         enrollmentPage.clickNext();
     }
 
-    @When("^I move to the individual member info page$")
-    public void i_move_to_the_individual_member_info_page() throws IOException {
-        i_move_to_the_facility_credentials_page();
+    @When("^I am on the individual member info page$")
+    public void i_am_on_the_individual_member_info_page() throws IOException {
+        i_am_on_the_facility_credentials_page();
         enrollmentSteps.enterLicenseInfo();
         enrollmentSteps.uploadLicense();
         enrollmentPage.clickNext();
@@ -42,9 +42,9 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.openIndividualMemberPanel();
     }
 
-    @When("^I move to the ownership info page$")
-    public void i_move_to_the_ownership_info_page() throws IOException {
-        i_move_to_the_individual_member_info_page();
+    @When("^I am on the ownership info page$")
+    public void i_am_on_the_ownership_info_page() throws IOException {
+        i_am_on_the_individual_member_info_page();
         enrollmentSteps.enterIndividualMember();
         enrollmentPage.clickNext();
     }
@@ -55,23 +55,23 @@ public class EnrollmentStepDefinitions {
         ownershipInfoPage.addBusinessOwnership();
     }
 
-    @When("^I move to the summary page$")
-    public void i_move_to_the_summary_page() throws IOException {
-        i_move_to_the_ownership_info_page();
+    @When("^I am on the summary page$")
+    public void i_am_on_the_summary_page() throws IOException {
+        i_am_on_the_ownership_info_page();
         enrollmentSteps.enterOrganizationOwnershipInfo();
         enrollmentSteps.setNoToAllDisclosures();
         ownershipInfoPage.clickNext();
     }
 
-    @When("^I move to the provider statement page$")
-    public void i_move_to_the_provider_statement_page() throws IOException {
-        i_move_to_the_summary_page();
+    @When("^I am on the provider statement page$")
+    public void i_am_on_the_provider_statement_page() throws IOException {
+        i_am_on_the_summary_page();
         enrollmentPage.clickNext();
     }
 
     @When("^I am entering ownership information$")
     public void i_am_entering_ownership_information() throws IOException {
-        i_move_to_the_ownership_info_page();
+        i_am_on_the_ownership_info_page();
         enrollmentSteps.enterOrganizationOwnershipInfo();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -46,7 +46,7 @@ public class EnrollmentStepDefinitions {
         i_am_on_the_organization_page();
         enrollmentSteps.enterOrganizationInfo();
         enrollmentSteps.enterContactInfo();
-        enrollmentPage.clickNext();
+        enrollmentSteps.advanceFromOrganizationInfoToLicenseInfo();
     }
 
     @When("^I open the add a license panel$")
@@ -59,7 +59,7 @@ public class EnrollmentStepDefinitions {
         i_am_on_the_facility_credentials_page();
         enrollmentSteps.enterLicenseInfo();
         enrollmentSteps.uploadLicense();
-        enrollmentPage.clickNext();
+        enrollmentSteps.advanceFromOrganizationLicenseInfoToIndividualMemberInfo();
     }
 
     @When("^I open an individual member panel")
@@ -71,7 +71,7 @@ public class EnrollmentStepDefinitions {
     public void i_am_on_the_ownership_info_page() throws IOException {
         i_am_on_the_individual_member_info_page();
         enrollmentSteps.enterIndividualMember();
-        enrollmentPage.clickNext();
+        enrollmentSteps.advanceFromOrganizationIndividualMemberInfoToOwnershipInfo();
     }
 
     @When("^I open the individual owner panel$")
@@ -89,13 +89,13 @@ public class EnrollmentStepDefinitions {
         i_am_on_the_ownership_info_page();
         enrollmentSteps.enterOrganizationOwnershipInfo();
         enrollmentSteps.setNoToAllDisclosures();
-        ownershipInfoPage.clickNext();
+        enrollmentSteps.advanceFromOrganizationOwnershipInfoToSummaryPage();
     }
 
     @When("^I am on the provider statement page$")
     public void i_am_on_the_provider_statement_page() throws IOException {
         i_am_on_the_summary_page();
-        enrollmentPage.clickNext();
+        enrollmentSteps.advanceFromOrganizationSummaryToProviderStatementPage();
     }
 
     @When("^I am entering ownership information$")

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -74,10 +74,14 @@ public class EnrollmentStepDefinitions {
         enrollmentPage.clickNext();
     }
 
-    @When("^I open individual and business owner panels$")
-    public void i_open_individual_and_business_owner_panels() {
-        ownershipInfoPage.addIndividualOwnership();
-        ownershipInfoPage.addBusinessOwnership();
+    @When("^I open the individual owner panel$")
+    public void i_open_the_individual_owner_panels() {
+        enrollmentSteps.addIndividualOwnership();
+    }
+
+    @When("^I open the business owner panel$")
+    public void i_open_the_business_owner_panel() {
+        enrollmentSteps.addBusinessOwnership();
     }
 
     @When("^I am on the summary page$")

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -5,6 +5,7 @@ import gov.medicaid.features.enrollment.ui.IndividualInfoPage;
 import gov.medicaid.features.enrollment.ui.IndividualSummaryPage;
 import gov.medicaid.features.enrollment.ui.LicenseInfoPage;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
+import gov.medicaid.features.enrollment.ui.OrganizationSummaryPage;
 import gov.medicaid.features.enrollment.ui.OwnershipInfoPage;
 import gov.medicaid.features.enrollment.ui.PersonalInfoPage;
 import gov.medicaid.features.enrollment.ui.PracticeInfoPage;
@@ -70,6 +71,7 @@ public class EnrollmentSteps {
     private PracticeInfoPage practiceInfoPage;
     private OwnershipInfoPage ownershipInfoPage;
     private IndividualSummaryPage individualSummaryPage;
+    private OrganizationSummaryPage organizationSummaryPage;
     private ProviderStatementPage providerStatementPage;
     private EnrollmentDetailsPage enrollmentDetailsPage;
 
@@ -208,6 +210,12 @@ public class EnrollmentSteps {
     }
 
     @Step
+    void advanceFromOrganizationLicenseInfoToIndividualMemberInfo() {
+        licenseInfoPage.clickNext();
+        assertThat(licenseInfoPage.getTitle()).contains("Member Information");
+    }
+
+    @Step
     void enterIndividualPrivatePracticeInfo() {
         practiceInfoPage.checkYesPrivatePractice();
         practiceInfoPage.checkNoGroupPractice();
@@ -250,6 +258,12 @@ public class EnrollmentSteps {
     void advanceFromIndividualPracticeInfoToSummaryPage() {
         practiceInfoPage.clickNext();
         assertThat(individualSummaryPage.getTitle()).contains("Summary Information");
+    }
+
+    @Step
+    void advanceFromOrganizationIndividualMemberInfoToOwnershipInfo() {
+        individualInfoPage.clickNext();
+        assertThat(ownershipInfoPage.getTitle()).contains("Ownership Information");
     }
 
     @Step
@@ -338,8 +352,19 @@ public class EnrollmentSteps {
     }
 
     @Step
+    void advanceFromOrganizationOwnershipInfoToSummaryPage() {
+        ownershipInfoPage.clickNext();
+        assertThat(organizationSummaryPage.getTitle()).contains("Summary Information");
+    }
+
+    @Step
     void advanceFromIndividualSummaryToProviderStatementPage() {
         individualSummaryPage.clickNext();
+    }
+
+    @Step
+    void advanceFromOrganizationSummaryToProviderStatementPage() {
+        organizationSummaryPage.clickNext();
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -115,6 +115,11 @@ public class EnrollmentSteps {
         assertThat(organizationInfoPage.getTitle()).contains("Facility Credentials");
     }
 
+    @Step
+    void clickAddLicense() {
+        licenseInfoPage.addLicense();
+    }
+
     public void enterOrganizationInfo() {
         organizationInfoPage.setNPI("1234567893");
         organizationInfoPage.setEffectiveDate(generateEffectiveDate());

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -253,7 +253,17 @@ public class EnrollmentSteps {
     }
 
     @Step
-    void setNoToAllDisclosures(){
+    void addIndividualOwnership() {
+        ownershipInfoPage.addIndividualOwnership();
+    }
+
+    @Step
+    void addBusinessOwnership() {
+        ownershipInfoPage.addBusinessOwnership();
+    }
+
+    @Step
+    void setNoToAllDisclosures() {
         ownershipInfoPage.setNoToAllDisclosures();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -5,6 +5,7 @@ import gov.medicaid.features.enrollment.ui.IndividualInfoPage;
 import gov.medicaid.features.enrollment.ui.IndividualSummaryPage;
 import gov.medicaid.features.enrollment.ui.LicenseInfoPage;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
+import gov.medicaid.features.enrollment.ui.OwnershipInfoPage;
 import gov.medicaid.features.enrollment.ui.PersonalInfoPage;
 import gov.medicaid.features.enrollment.ui.PracticeInfoPage;
 import gov.medicaid.features.enrollment.ui.ProviderStatementPage;
@@ -67,6 +68,7 @@ public class EnrollmentSteps {
     private PersonalInfoPage personalInfoPage;
     private LicenseInfoPage licenseInfoPage;
     private PracticeInfoPage practiceInfoPage;
+    private OwnershipInfoPage ownershipInfoPage;
     private IndividualSummaryPage individualSummaryPage;
     private ProviderStatementPage providerStatementPage;
     private EnrollmentDetailsPage enrollmentDetailsPage;
@@ -138,6 +140,10 @@ public class EnrollmentSteps {
         cal.add(Calendar.DAY_OF_YEAR, -6);
         String dateStr = formFieldDateFormat.format(cal.getTime());
         return dateStr;
+    }
+
+    public void openIndividualMemberPanel() {
+        individualInfoPage.enterIndividualMember();
     }
 
     public void enterIndividualMember() {
@@ -218,9 +224,32 @@ public class EnrollmentSteps {
     }
 
     @Step
+    public void enterOrganizationOwnershipInfo() {
+        ownershipInfoPage.selectEntityType("Sole Proprietorship");
+        ownershipInfoPage.addIndividualOwnership();
+        ownershipInfoPage.selectOwnershipType("Managing Employee");
+        ownershipInfoPage.setOwnershipFirstName("First");
+        ownershipInfoPage.setOwnershipMiddleName("Middle");
+        ownershipInfoPage.setOwnershipLastName("Last");
+        ownershipInfoPage.setOwnershipSoSec("123456789");
+        ownershipInfoPage.setOwnershipAddr1("OwnerAddr1");
+        ownershipInfoPage.setOwnershipDOB("01011970");
+        ownershipInfoPage.setOwnershipHireDate("01012000");
+        ownershipInfoPage.setOwnershipCity("Ownertown");
+        ownershipInfoPage.selectOwnershipState("Texas");
+        ownershipInfoPage.setOwnershipZip("77706");
+        ownershipInfoPage.selectOwnershipCounty("Beltrami");
+    }
+
+    @Step
     void advanceFromIndividualPracticeInfoToSummaryPage() {
         practiceInfoPage.clickNext();
         assertThat(individualSummaryPage.getTitle()).contains("Summary Information");
+    }
+
+    @Step
+    void setNoToAllDisclosures(){
+        ownershipInfoPage.setNoToAllDisclosures();
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
@@ -1,6 +1,5 @@
 package gov.medicaid.features.enrollment.steps;
 
-import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import gov.medicaid.features.general.steps.GeneralSteps;
@@ -23,23 +22,6 @@ public class ValidationStepDefinitions {
 
     private OrganizationInfoPage organizationInfoPage;
     private PersonalInfoPage personalInfoPage;
-
-    @Given("^I have started an enrollment$")
-    public void i_have_started_an_enrollment() {
-        generalSteps.loginAsProvider();
-        enrollmentSteps.createEnrollment();
-    }
-
-    @Given("^I am on the organization page$")
-    public void i_am_on_the_organization_page() {
-        enrollmentSteps.selectOrganizationalProviderType();
-    }
-
-    @Given("^I am on the personal info page$")
-    public void i_am_on_the_personal_info_page() {
-        i_have_started_an_enrollment();
-        enrollmentSteps.selectIndividualProviderType();
-    }
 
     @When("^when I enter an (\\d+) digit FEIN$")
     public void when_I_enter_an_digit_FEIN(int numDigits) {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationSummaryPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationSummaryPage.java
@@ -1,0 +1,10 @@
+package gov.medicaid.features.enrollment.ui;
+
+import gov.medicaid.features.PsmPage;
+
+public class OrganizationSummaryPage extends PsmPage {
+
+    public void clickNext() {
+        click($(".nextBtn"));
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
@@ -9,7 +9,7 @@ public class OwnershipInfoPage extends EnrollmentPage {
     }
 
     public void addIndividualOwnership() {
-        click($("#addOwnership"));
+        click($("#addIndividualOwnership"));
     }
 
     public void addBusinessOwnership() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
@@ -8,8 +8,12 @@ public class OwnershipInfoPage extends EnrollmentPage {
         $("#entityType").selectByVisibleText(entityType);
     }
 
-    public void addOwnership() {
+    public void addIndividualOwnership() {
         click($("#addOwnership"));
+    }
+
+    public void addBusinessOwnership() {
+        click($("#addBusinessOwnership"));
     }
 
     public void selectOwnershipType(String ownershipType) {

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -1,0 +1,40 @@
+@accessibility
+Feature: Organization Enrollment Steps Accessibility Checks
+  Users wish to access accessible pages
+
+  Scenario: Select Provider Type Page
+    Given I have started an enrollment
+    Then I should have no accessibility issues
+
+  # fails with color contrast issue
+  @ignore
+  Scenario: 1. Organization Info Page
+    Given I have started an enrollment
+    When I move to the organization page
+    Then I should have no accessibility issues
+
+  # fails with duplicate IDs and inputs without labels/titles
+  @ignore
+  Scenario: 2. Individual Member Info Page
+    Given I have started an enrollment
+    When I move to the individual member info page
+    When I open an individual member panel
+    Then I should have no accessibility issues
+
+  # fails with duplicate IDs and inputs without labels/titles
+  @ignore
+  Scenario: 3. Ownership Info Page
+    Given I have started an enrollment
+    When I move to the ownership info page
+    And I open individual and business owner panels
+    Then I should have no accessibility issues
+
+  Scenario: 4. Summary Page
+    Given I have started an enrollment
+    When I move to the summary page
+    Then I should have no accessibility issues
+
+  Scenario: 5. Provider Statement Page
+    Given I have started an enrollment
+    When I move to the provider statement page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -6,8 +6,6 @@ Feature: Organization Enrollment Steps Accessibility Checks
     Given I have started an enrollment
     Then I should have no accessibility issues
 
-  # fails with color contrast issue
-  @ignore
   Scenario: Organization Info Page
     Given I have started an enrollment
     When I am on the organization page

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -11,6 +11,14 @@ Feature: Organization Enrollment Steps Accessibility Checks
     When I am on the organization page
     Then I should have no accessibility issues
 
+  # fails with inputs without labels/titles
+  @ignore
+  Scenario: Facility Credentials Page
+    Given I have started an enrollment
+    When I am on the facility credentials page
+    And I open the add a license panel
+    Then I should have no accessibility issues
+
   # fails with duplicate IDs and inputs without labels/titles
   @ignore
   Scenario: Individual Member Info Page

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -32,7 +32,9 @@ Feature: Organization Enrollment Steps Accessibility Checks
   Scenario: Ownership Info Page
     Given I have started an enrollment
     When I am on the ownership info page
-    And I open individual and business owner panels
+    And I open the individual owner panel
+    And I open the business owner panel
+    And I have indicated that the owner has an interest in another Medicaid disclosing entity
     Then I should have no accessibility issues
 
   Scenario: Summary Page

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -10,14 +10,14 @@ Feature: Organization Enrollment Steps Accessibility Checks
   @ignore
   Scenario: 1. Organization Info Page
     Given I have started an enrollment
-    When I move to the organization page
+    When I am on the organization page
     Then I should have no accessibility issues
 
   # fails with duplicate IDs and inputs without labels/titles
   @ignore
   Scenario: 2. Individual Member Info Page
     Given I have started an enrollment
-    When I move to the individual member info page
+    When I am on the individual member info page
     When I open an individual member panel
     Then I should have no accessibility issues
 
@@ -25,16 +25,16 @@ Feature: Organization Enrollment Steps Accessibility Checks
   @ignore
   Scenario: 3. Ownership Info Page
     Given I have started an enrollment
-    When I move to the ownership info page
+    When I am on the ownership info page
     And I open individual and business owner panels
     Then I should have no accessibility issues
 
   Scenario: 4. Summary Page
     Given I have started an enrollment
-    When I move to the summary page
+    When I am on the summary page
     Then I should have no accessibility issues
 
   Scenario: 5. Provider Statement Page
     Given I have started an enrollment
-    When I move to the provider statement page
+    When I am on the provider statement page
     Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -8,14 +8,14 @@ Feature: Organization Enrollment Steps Accessibility Checks
 
   # fails with color contrast issue
   @ignore
-  Scenario: 1. Organization Info Page
+  Scenario: Organization Info Page
     Given I have started an enrollment
     When I am on the organization page
     Then I should have no accessibility issues
 
   # fails with duplicate IDs and inputs without labels/titles
   @ignore
-  Scenario: 2. Individual Member Info Page
+  Scenario: Individual Member Info Page
     Given I have started an enrollment
     When I am on the individual member info page
     When I open an individual member panel
@@ -23,18 +23,18 @@ Feature: Organization Enrollment Steps Accessibility Checks
 
   # fails with duplicate IDs and inputs without labels/titles
   @ignore
-  Scenario: 3. Ownership Info Page
+  Scenario: Ownership Info Page
     Given I have started an enrollment
     When I am on the ownership info page
     And I open individual and business owner panels
     Then I should have no accessibility issues
 
-  Scenario: 4. Summary Page
+  Scenario: Summary Page
     Given I have started an enrollment
     When I am on the summary page
     Then I should have no accessibility issues
 
-  Scenario: 5. Provider Statement Page
+  Scenario: Provider Statement Page
     Given I have started an enrollment
     When I am on the provider statement page
     Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
@@ -5,13 +5,13 @@ Feature: Data Coverage Checks
   @psm-FR-2.9
   Scenario: Captures Contact Info for Organization
     Given I have started an enrollment
-    When  I move to the organization page
+    When  I am on the organization page
     Then I should be asked to enter Applicant Name, Contact Person, Contact phone
 
   @psm-FR-2.9
   Scenario: Captures Medicaid number for Organization's contact
     Given I have started an enrollment
-    When  I move to the organization page
+    When  I am on the organization page
     Then I should be asked to enter Medicaid number
 
   @psm-FR-2.9


### PR DESCRIPTION
These accessibility tests cover the main pages of the enrollment process for organizations.  Includes an easy fix for one failing test (a color contrast issue).

Tested by running the tests.  The two that aren't `@ignore`d pass successfully.

Issue #518 Implement accessibility checking in CI