### PR TITLE
Ignore Eclipse-related files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,17 @@ psm-app/schema/
 # Ignore IntelliJ Idea files
 psm-app/.idea/
 
+# Ignore Eclipse files
+.classpath
+.project
+.settings/
+psm-app/cms-business-process/bin/
+psm-app/cms-web/bin/
+psm-app/integration-tests/bin/
+psm-app/cms-portal-services/bin/
+psm-app/cms-business-model/bin/
+psm-app/services/bin/
+
 # Output from Serenity runs
 psm-app/integration-tests/target
 


### PR DESCRIPTION
I listed each bin directory explicitly to be conservative in what's excluded.

Sidenote: importing the project works fine in Eclipse version Neon.3 Release (4.6.3)