### PR TITLE
Add accessibility tests for individual enrollment steps

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
@@ -14,7 +14,7 @@
       <div class="right">
         <div class="middle">
           <button class="closeModal" title="Close" aria-label="Close"></button>
-          <h2>Find Practice Data in Existing Record</h2>
+          <h2 class="practiceLookupModalTitle">Find Practice Data in Existing Record</h2>
         </div>
       </div>
     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_practice.jsp
@@ -13,7 +13,7 @@
     <input type="hidden" name="formNames" value="<%= ViewStatics.ADDITIONAL_PRACTICE_FORM %>">
 
     <div class="tableHeader otherTableHeader">
-        <span>Additional Practice Locations</span>
+        <span class="additionalPracticeLocations">Additional Practice Locations</span>
         <a href="javascript:openPracticeLookup(false, false);" class="purpleSmallBtn practiceLookupModalBtn">Practice Lookup</a>
     </div>
     <!-- /.tableHeader -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
@@ -51,7 +51,7 @@
     <table cellpadding="0" cellspacing="0" class="generalTable">
         <thead>
             <tr>
-                <th>Reservation<span class="required">*</span><span class="sep"></span></th>
+                <th class="reservationTableHeader">Reservation<span class="required">*</span><span class="sep"></span></th>
                 <th>Upload License/Certification<span class="required">*</span><span class="sep"></span></th>
                 <th>License/Certification #<span class="required">*</span><span class="sep"></span></th>
                 <th>Original Issue Date<span class="required">*</span><span class="sep"></span></th>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4783,7 +4783,7 @@ p.confirm {
 }
 
 .practicePanel span.fldInfo {
-  color: #999999;
+  color: #737373;
   display: inline;
   float: left;
   line-height: 14px;
@@ -4791,7 +4791,7 @@ p.confirm {
 }
 
 .practicePanel span.shrtFldInfo {
-  color: #999999;
+  color: #737373;
   display: inline;
   float: left;
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
@@ -38,17 +38,6 @@ public class DataCoverageStepDefinitions {
         enrollmentSteps.enterIndividualPrivatePracticeInfo();
     }
 
-    @When("^I enter my provider statement$")
-    public void enter_provider_statement() {
-        enrollmentSteps.checkNoOnProviderDisclosureQuestions();
-        enrollmentSteps.signAndDateProviderStatement();
-    }
-
-    @When("^I submit the enrollment$")
-    public void submit_enrollment() {
-        enrollmentSteps.submitEnrollment();
-    }
-
     @Then("^I should be asked to enter Applicant Name, Contact Person, Contact phone$")
     public void i_should_be_asked_to_enter_Applicant_Name_Contact_Person_Contact_phone() {
         organizationInfoPage.verifyApplicantNameAccepted();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
@@ -1,6 +1,5 @@
 package gov.medicaid.features.enrollment.steps;
 
-import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
@@ -18,55 +17,6 @@ public class DataCoverageStepDefinitions {
     GeneralSteps generalSteps;
 
     private OrganizationInfoPage organizationInfoPage;
-
-    @Given("I am on the individual provider license info page")
-    public void enter_individual_provider_license_info_page() {
-        navigateToIndividualProviderLicensePage();
-    }
-
-    @Given("^I am on the organizational provider license info page$")
-    public void enter_organizational_provider_license_info_page() {
-        navigateToOrganizationalProviderLicensePage();
-    }
-
-    private void navigateToIndividualProviderLicensePage() {
-        generalSteps.loginAsProvider();
-        enrollmentSteps.createEnrollment();
-        enrollmentSteps.selectIndividualProviderType();
-        enrollmentSteps.enterIndividualPersonalInfo();
-        enrollmentSteps.advanceFromIndividualPersonalInfoToLicenseInfo();
-        enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
-    }
-
-    private void navigateToOrganizationalProviderLicensePage() {
-        generalSteps.loginAsProvider();
-        enrollmentSteps.createEnrollment();
-        enrollmentSteps.selectOrganizationalProviderType();
-        enrollmentSteps.enterOrganizationInfo();
-        enrollmentSteps.enterContactInfo();
-        enrollmentSteps.advanceFromOrganizationInfoToLicenseInfo();
-    }
-
-    @Given("^I am on the individual provider practice info page$")
-    public void enter_individual_provider_practice_info_page() throws IOException {
-        navigateToProviderPracticePage();
-    }
-
-    private void navigateToProviderPracticePage() throws IOException {
-        navigateToIndividualProviderLicensePage();
-        enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
-        enrollmentSteps.enterLicenseInfo();
-        enrollmentSteps.uploadLicense();
-        enrollmentSteps.advanceFromIndividualLicenseInfoToPracticeInfo();
-    }
-
-    @Given("^I am on the individual provider statement page$")
-    public void enter_individual_provider_statement_page() throws IOException {
-        navigateToProviderPracticePage();
-        enrollmentSteps.enterIndividualPrivatePracticeInfo();
-        enrollmentSteps.advanceFromIndividualPracticeInfoToSummaryPage();
-        enrollmentSteps.advanceFromIndividualSummaryToProviderStatementPage();
-    }
 
     @When("^I enter valid license information$")
     public void enter_valid_license_information() {
@@ -109,11 +59,6 @@ public class DataCoverageStepDefinitions {
     @Then("^I should be asked to enter Medicaid number$")
     public void i_should_be_asked_to_enter_Medicaid() {
         organizationInfoPage.verifyMedicaidNumberAccepted();
-    }
-
-    @When("^I move to the personal info page$")
-    public void i_move_to_the_personal_info_page() {
-        enrollmentSteps.selectIndividualProviderType();
     }
 
     @Then("^I should be asked to enter Applicant Name, Contact Person$")

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -35,12 +35,6 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.selectOrganizationalProviderType();
     }
 
-    @Given("^I am on the personal info page$")
-    public void i_am_on_the_personal_info_page() {
-        i_have_started_an_enrollment();
-        enrollmentSteps.selectIndividualProviderType();
-    }
-
     @When("^I am on the facility credentials page$")
     public void i_am_on_the_facility_credentials_page() {
         i_am_on_the_organization_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -92,6 +92,17 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.advanceFromOrganizationSummaryToProviderStatementPage();
     }
 
+    @When("^I enter my provider statement$")
+    public void i_enter_my_provider_statement() {
+        enrollmentSteps.checkNoOnProviderDisclosureQuestions();
+        enrollmentSteps.signAndDateProviderStatement();
+    }
+
+    @When("^I submit the enrollment$")
+    public void i_submit_the_enrollment() {
+        enrollmentSteps.submitEnrollment();
+    }
+
     @When("^I am entering ownership information$")
     public void i_am_entering_ownership_information() throws IOException {
         i_am_on_the_ownership_info_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -78,8 +78,8 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.addBusinessOwnership();
     }
 
-    @When("^I am on the summary page$")
-    public void i_am_on_the_summary_page() throws IOException {
+    @When("^I am on the organization summary page$")
+    public void i_am_on_the_organization_summary_page() throws IOException {
         i_am_on_the_ownership_info_page();
         enrollmentSteps.enterOrganizationOwnershipInfo();
         enrollmentSteps.setNoToAllDisclosures();
@@ -88,7 +88,7 @@ public class EnrollmentStepDefinitions {
 
     @When("^I am on the provider statement page$")
     public void i_am_on_the_provider_statement_page() throws IOException {
-        i_am_on_the_summary_page();
+        i_am_on_the_organization_summary_page();
         enrollmentSteps.advanceFromOrganizationSummaryToProviderStatementPage();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -86,6 +86,11 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.advanceFromOrganizationOwnershipInfoToSummaryPage();
     }
 
+    @When("^I save as draft$")
+    public void i_save_as_draft() {
+        enrollmentSteps.clickSaveAsDraft();
+    }
+
     @When("^I am on the organization provider statement page$")
     public void i_am_on_the_organization_provider_statement_page() throws IOException {
         i_am_on_the_organization_summary_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -86,8 +86,8 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.advanceFromOrganizationOwnershipInfoToSummaryPage();
     }
 
-    @When("^I am on the provider statement page$")
-    public void i_am_on_the_provider_statement_page() throws IOException {
+    @When("^I am on the organization provider statement page$")
+    public void i_am_on_the_organization_provider_statement_page() throws IOException {
         i_am_on_the_organization_summary_page();
         enrollmentSteps.advanceFromOrganizationSummaryToProviderStatementPage();
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -43,8 +43,8 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.advanceFromOrganizationInfoToLicenseInfo();
     }
 
-    @When("^I open the add a license panel$")
-    public void i_open_the_add_a_license_panel() {
+    @When("^I open an add a license panel$")
+    public void i_open_an_add_a_license_panel() {
         enrollmentSteps.clickAddLicense();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -30,7 +30,7 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.createEnrollment();
     }
 
-    @Given("^I am on the organization page$")
+    @When("^I am on the organization page$")
     public void i_am_on_the_organization_page() {
         enrollmentSteps.selectOrganizationalProviderType();
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -91,6 +91,11 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.clickSaveAsDraft();
     }
 
+    @When("^I start to print$")
+    public void i_start_to_print() {
+        enrollmentSteps.clickPrintButton();
+    }
+
     @When("^I am on the organization provider statement page$")
     public void i_am_on_the_organization_provider_statement_page() throws IOException {
         i_am_on_the_organization_summary_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -174,8 +174,8 @@ public class EnrollmentSteps {
     }
 
     @Step
-    public void enterNotAProviderAtPublicHealthServiceIndianHospital() {
-        licenseInfoPage.clickNo();
+    public void inputProviderAtPublicHealthServiceIndianHospital(boolean checkYes) {
+        licenseInfoPage.checkProviderAtPublicHealthServiceIndianHospital(checkYes);
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -231,6 +231,11 @@ public class EnrollmentSteps {
     }
 
     @Step
+    public void openPracticeLookupModal() {
+        practiceInfoPage.clickPracticeLookupButton();
+    }
+
+    @Step
     void enterIndividualPrivatePracticeInfo() {
         practiceInfoPage.checkPrivatePractice(true);
         practiceInfoPage.checkGroupPractice(false);

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -288,6 +288,11 @@ public class EnrollmentSteps {
     }
 
     @Step
+    void clickPrintButton() {
+        individualSummaryPage.clickPrintButton();
+    }
+
+    @Step
     void advanceFromOrganizationIndividualMemberInfoToOwnershipInfo() {
         individualInfoPage.clickNext();
         assertThat(ownershipInfoPage.getTitle()).contains("Ownership Information");

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -1,6 +1,7 @@
 package gov.medicaid.features.enrollment.steps;
 
 import gov.medicaid.features.enrollment.ui.EnrollmentDetailsPage;
+import gov.medicaid.features.enrollment.ui.EnrollmentPage;
 import gov.medicaid.features.enrollment.ui.IndividualInfoPage;
 import gov.medicaid.features.enrollment.ui.IndividualSummaryPage;
 import gov.medicaid.features.enrollment.ui.LicenseInfoPage;
@@ -63,6 +64,7 @@ public class EnrollmentSteps {
 
     private LoginPage loginPage;
     private DashboardPage dashboardPage;
+    private EnrollmentPage enrollmentPage;
     private SelectProviderTypePage selectProviderTypePage;
     private OrganizationInfoPage organizationInfoPage;
     private IndividualInfoPage individualInfoPage;
@@ -278,6 +280,11 @@ public class EnrollmentSteps {
     void advanceFromIndividualPracticeInfoToSummaryPage() {
         practiceInfoPage.clickNext();
         assertThat(individualSummaryPage.getTitle()).contains("Summary Information");
+    }
+
+    @Step
+    void clickSaveAsDraft() {
+        enrollmentPage.clickSaveAsDraft();
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -216,8 +216,13 @@ public class EnrollmentSteps {
     }
 
     @Step
+    public void indicateMaintainOwnPrivatePractice(boolean isPrivatePractice) {
+        practiceInfoPage.checkPrivatePractice(isPrivatePractice);
+    }
+
+    @Step
     void enterIndividualPrivatePracticeInfo() {
-        practiceInfoPage.checkYesPrivatePractice();
+        practiceInfoPage.checkPrivatePractice(true);
         practiceInfoPage.checkNoGroupPractice();
         practiceInfoPage.enterPracticeName(PRIVATE_PRACTICE_NAME);
         practiceInfoPage.enterGroupNPI(PRACTICE_GROUP_NPI);

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -221,9 +221,19 @@ public class EnrollmentSteps {
     }
 
     @Step
+    public void indicateGroupPractice(boolean isGroupPractice) {
+        practiceInfoPage.checkGroupPractice(isGroupPractice);
+    }
+
+    @Step
+    public void clickAddPracticeLocation() {
+        practiceInfoPage.clickAddPracticeLocation();
+    }
+
+    @Step
     void enterIndividualPrivatePracticeInfo() {
         practiceInfoPage.checkPrivatePractice(true);
-        practiceInfoPage.checkNoGroupPractice();
+        practiceInfoPage.checkGroupPractice(false);
         practiceInfoPage.enterPracticeName(PRIVATE_PRACTICE_NAME);
         practiceInfoPage.enterGroupNPI(PRACTICE_GROUP_NPI);
         practiceInfoPage.enterEffectiveDate(PRACTICE_EFFECTIVE_DATE);

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -65,6 +65,11 @@ public class IndividualEnrollmentStepDefinitions {
         enrollmentSteps.clickAddPracticeLocation();
     }
 
+    @When("^I open the practice lookup modal$")
+    public void i_open_the_practice_lookup_modal() {
+        enrollmentSteps.openPracticeLookupModal();
+    }
+
     @When("^I am on the individual provider statement page$")
     public void i_am_on_the_individual_provider_statement_page() throws IOException {
         i_am_on_the_individual_provider_practice_info_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -45,6 +45,16 @@ public class IndividualEnrollmentStepDefinitions {
         enrollmentSteps.advanceFromIndividualLicenseInfoToPracticeInfo();
     }
 
+    @When("^I indicate I maintain my own private practice$")
+    public void i_indicate_i_maintain_my_own_private_practice() {
+        enrollmentSteps.indicateMaintainOwnPrivatePractice(true);
+    }
+
+    @When("^I indicate I do not maintain my own private practice$")
+    public void i_indicate_i_do_not_maintain_my_own_private_practice() {
+        enrollmentSteps.indicateMaintainOwnPrivatePractice(false);
+    }
+
     @When("^I am on the individual provider statement page$")
     public void i_am_on_the_individual_provider_statement_page() throws IOException {
         i_am_on_the_individual_provider_practice_info_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -1,6 +1,5 @@
 package gov.medicaid.features.enrollment.steps;
 
-import cucumber.api.java.en.Given;
 import cucumber.api.java.en.When;
 import gov.medicaid.features.general.steps.GeneralSteps;
 import net.thucydides.core.annotations.Steps;
@@ -20,36 +19,26 @@ public class IndividualEnrollmentStepDefinitions {
         enrollmentSteps.selectIndividualProviderType();
     }
 
-    @Given("I am on the individual provider license info page")
-    public void enter_individual_provider_license_info_page() {
-        navigateToIndividualProviderLicensePage();
-    }
-
-    private void navigateToIndividualProviderLicensePage() {
-        generalSteps.loginAsProvider();
-        enrollmentSteps.createEnrollment();
-        enrollmentSteps.selectIndividualProviderType();
+    @When("I am on the individual provider license info page")
+    public void i_am_on_the_individual_provider_license_info_page() {
+        i_am_on_the_personal_info_page();
         enrollmentSteps.enterIndividualPersonalInfo();
         enrollmentSteps.advanceFromIndividualPersonalInfoToLicenseInfo();
         enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
     }
 
-    @Given("^I am on the individual provider practice info page$")
-    public void enter_individual_provider_practice_info_page() throws IOException {
-        navigateToProviderPracticePage();
-    }
-
-    private void navigateToProviderPracticePage() throws IOException {
-        navigateToIndividualProviderLicensePage();
+    @When("^I am on the individual provider practice info page$")
+    public void i_am_on_the_individual_provider_practice_info_page() throws IOException {
+        i_am_on_the_individual_provider_license_info_page();
         enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
         enrollmentSteps.enterLicenseInfo();
         enrollmentSteps.uploadLicense();
         enrollmentSteps.advanceFromIndividualLicenseInfoToPracticeInfo();
     }
 
-    @Given("^I am on the individual provider statement page$")
-    public void enter_individual_provider_statement_page() throws IOException {
-        navigateToProviderPracticePage();
+    @When("^I am on the individual provider statement page$")
+    public void i_am_on_the_individual_provider_statement_page() throws IOException {
+        i_am_on_the_individual_provider_practice_info_page();
         enrollmentSteps.enterIndividualPrivatePracticeInfo();
         enrollmentSteps.advanceFromIndividualPracticeInfoToSummaryPage();
         enrollmentSteps.advanceFromIndividualSummaryToProviderStatementPage();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -15,8 +15,8 @@ public class IndividualEnrollmentStepDefinitions {
     @Steps
     GeneralSteps generalSteps;
 
-    @When("^I move to the personal info page$")
-    public void i_move_to_the_personal_info_page() {
+    @When("^I am on the personal info page$")
+    public void i_am_on_the_personal_info_page() {
         enrollmentSteps.selectIndividualProviderType();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -55,6 +55,16 @@ public class IndividualEnrollmentStepDefinitions {
         enrollmentSteps.indicateMaintainOwnPrivatePractice(false);
     }
 
+    @When("^I indicate I am employed or independently contracted by a group practice$")
+    public void i_indicate_i_am_employed_or_independently_contracted_by_a_group_practice() {
+        enrollmentSteps.indicateGroupPractice(true);
+    }
+
+    @When("^I start to add a practice location$")
+    public void i_start_to_add_a_practice_location() {
+        enrollmentSteps.clickAddPracticeLocation();
+    }
+
     @When("^I am on the individual provider statement page$")
     public void i_am_on_the_individual_provider_statement_page() throws IOException {
         i_am_on_the_individual_provider_practice_info_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -24,13 +24,22 @@ public class IndividualEnrollmentStepDefinitions {
         i_am_on_the_personal_info_page();
         enrollmentSteps.enterIndividualPersonalInfo();
         enrollmentSteps.advanceFromIndividualPersonalInfoToLicenseInfo();
-        enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
+    }
+
+    @When("^I indicate I am a provider at a Public Health Service Indian Hospital$")
+    public void i_indicate_i_am_a_provider_at_a_public_health_service_indian_hospital() {
+        enrollmentSteps.inputProviderAtPublicHealthServiceIndianHospital(true);
+    }
+
+    @When("^I indicate I am not a provider at a Public Health Service Indian Hospital$")
+    public void i_indicate_i_am_not_a_provider_at_a_public_health_service_indian_hospital() {
+        enrollmentSteps.inputProviderAtPublicHealthServiceIndianHospital(false);
     }
 
     @When("^I am on the individual provider practice info page$")
     public void i_am_on_the_individual_provider_practice_info_page() throws IOException {
         i_am_on_the_individual_provider_license_info_page();
-        enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
+        i_indicate_i_am_not_a_provider_at_a_public_health_service_indian_hospital();
         enrollmentSteps.enterLicenseInfo();
         enrollmentSteps.uploadLicense();
         enrollmentSteps.advanceFromIndividualLicenseInfoToPracticeInfo();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -70,11 +70,16 @@ public class IndividualEnrollmentStepDefinitions {
         enrollmentSteps.openPracticeLookupModal();
     }
 
-    @When("^I am on the individual provider statement page$")
-    public void i_am_on_the_individual_provider_statement_page() throws IOException {
+    @When("^I am on the individual summary page$")
+    public void i_am_on_the_individual_summary_page() throws IOException {
         i_am_on_the_individual_provider_practice_info_page();
         enrollmentSteps.enterIndividualPrivatePracticeInfo();
         enrollmentSteps.advanceFromIndividualPracticeInfoToSummaryPage();
+    }
+
+    @When("^I am on the individual provider statement page$")
+    public void i_am_on_the_individual_provider_statement_page() throws IOException {
+        i_am_on_the_individual_summary_page();
         enrollmentSteps.advanceFromIndividualSummaryToProviderStatementPage();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -1,0 +1,57 @@
+package gov.medicaid.features.enrollment.steps;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.When;
+import gov.medicaid.features.general.steps.GeneralSteps;
+import net.thucydides.core.annotations.Steps;
+
+import java.io.IOException;
+
+@SuppressWarnings("unused")
+public class IndividualEnrollmentStepDefinitions {
+    @Steps
+    EnrollmentSteps enrollmentSteps;
+
+    @Steps
+    GeneralSteps generalSteps;
+
+    @When("^I move to the personal info page$")
+    public void i_move_to_the_personal_info_page() {
+        enrollmentSteps.selectIndividualProviderType();
+    }
+
+    @Given("I am on the individual provider license info page")
+    public void enter_individual_provider_license_info_page() {
+        navigateToIndividualProviderLicensePage();
+    }
+
+    private void navigateToIndividualProviderLicensePage() {
+        generalSteps.loginAsProvider();
+        enrollmentSteps.createEnrollment();
+        enrollmentSteps.selectIndividualProviderType();
+        enrollmentSteps.enterIndividualPersonalInfo();
+        enrollmentSteps.advanceFromIndividualPersonalInfoToLicenseInfo();
+        enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
+    }
+
+    @Given("^I am on the individual provider practice info page$")
+    public void enter_individual_provider_practice_info_page() throws IOException {
+        navigateToProviderPracticePage();
+    }
+
+    private void navigateToProviderPracticePage() throws IOException {
+        navigateToIndividualProviderLicensePage();
+        enrollmentSteps.enterNotAProviderAtPublicHealthServiceIndianHospital();
+        enrollmentSteps.enterLicenseInfo();
+        enrollmentSteps.uploadLicense();
+        enrollmentSteps.advanceFromIndividualLicenseInfoToPracticeInfo();
+    }
+
+    @Given("^I am on the individual provider statement page$")
+    public void enter_individual_provider_statement_page() throws IOException {
+        navigateToProviderPracticePage();
+        enrollmentSteps.enterIndividualPrivatePracticeInfo();
+        enrollmentSteps.advanceFromIndividualPracticeInfoToSummaryPage();
+        enrollmentSteps.advanceFromIndividualSummaryToProviderStatementPage();
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
@@ -11,6 +11,10 @@ public class EnrollmentPage extends PsmPage {
         click($(".nextBtn"));
     }
 
+    public void clickSaveAsDraft() {
+        click$("[name='save']");
+    }
+
     void setNoForRadioButton(String name) {
         List<WebElement> buttons = getDriver().findElements(By.cssSelector("[name='" + name + "']"));
         click(buttons.get(1));

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
@@ -172,6 +172,10 @@ public class IndividualSummaryPage extends PsmPage {
         return textOf("#remittanceSequence");
     }
 
+    public void clickPrintButton() {
+        click$(".printModalBtn");
+    }
+
     public void clickNext() {
         click($(".nextBtn"));
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
@@ -14,8 +14,13 @@ public class LicenseInfoPage extends PsmPage {
     private static final String RENEWAL_DATE_ERROR_MESSAGE =
             "cannot be earlier than Original Issue Date";
 
-    public void clickNo() {
-        click($("input[value='N'"));
+    public void checkProviderAtPublicHealthServiceIndianHospital(boolean checkYes) {
+        if (checkYes) {
+            click$("input[value='Y'");
+            assertThat($(".reservationTableHeader").getText().contains("Reservation"));
+        } else {
+            click$("input[value='N'");
+        }
     }
 
     public void addLicense() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
@@ -26,6 +26,11 @@ public class PracticeInfoPage extends PsmPage {
         }
     }
 
+    public void clickPracticeLookupButton() {
+        click$(".practiceLookupModalBtn");
+        assertThat($(".practiceLookupModalTitle").getText().contains("Find Practice Data in Existing Record"));
+    }
+
     public void enterPracticeName(String practiceName) {
         $("[name=_05_name]").type(practiceName);
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
@@ -17,12 +17,13 @@ public class PracticeInfoPage extends PsmPage {
         }
     }
 
-    public void checkNoGroupPractice() {
-        click($("[name=_04_employedOrContractedByGroup][value=N]"));
-    }
-
-    public void checkYesGroupPractice() {
-        click($("[name=_04_employedOrContractedByGroup][value=Y]"));
+    public void checkGroupPractice(boolean isGroupPractice) {
+        if (isGroupPractice) {
+            click$("[name=_04_employedOrContractedByGroup][value=Y]");
+            assertThat($(".additionalPracticeLocations").getText().contains("Additional Practice Locations"));
+        } else {
+            click$("[name=_04_employedOrContractedByGroup][value=N]");
+        }
     }
 
     public void enterPracticeName(String practiceName) {
@@ -95,6 +96,10 @@ public class PracticeInfoPage extends PsmPage {
 
     public void checkFirstRemittanceSequence() {
         click($("input[value='PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER'"));
+    }
+
+    public void clickAddPracticeLocation() {
+        click$("#addPractice");
     }
 
     public void clickNext() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
@@ -7,13 +7,14 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PracticeInfoPage extends PsmPage {
-    public void checkNoPrivatePractice() {
-        click($("[name=_04_maintainsOwnPrivatePractice][value=N]"));
-        assertThat($("#privatePracitce > div").getText().contains("Private Practice"));
-    }
 
-    public void checkYesPrivatePractice() {
-        click($("[name=_04_maintainsOwnPrivatePractice][value=Y]"));
+    public void checkPrivatePractice(boolean isPrivatePractice) {
+        if (isPrivatePractice) {
+            click$("[name=_04_maintainsOwnPrivatePractice][value=Y]");
+            assertThat($("#privatePractice > div").getText().contains("Private Practice"));
+        } else {
+            click$("[name=_04_maintainsOwnPrivatePractice][value=N]");
+        }
     }
 
     public void checkNoGroupPractice() {

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -22,3 +22,14 @@ Feature: Individual Enrollment Steps Accessibility Checks
     And I am on the individual provider practice info page
     When I indicate I maintain my own private practice
     Then I should have no accessibility issues
+
+  # fails: additional practice location 'effective date' input needs a label or title
+  @ignore
+  Scenario: Practice Info Page (Group Practice)
+    Given I have started an enrollment
+    And I am on the individual provider practice info page
+    And I indicate I do not maintain my own private practice
+    And I indicate I am employed or independently contracted by a group practice
+    And I start to add a practice location
+    And I start to add a practice location
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -1,0 +1,8 @@
+@accessibility
+Feature: Individual Enrollment Steps Accessibility Checks
+  Users wish to access accessible pages
+
+  Scenario: Personal Info Page
+    Given I have started an enrollment
+    When I am on the personal info page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -39,3 +39,10 @@ Feature: Individual Enrollment Steps Accessibility Checks
     Given I have started an enrollment
     When I am on the individual summary page
     Then I should have no accessibility issues
+
+  # fails: form input elements missing labels or titles
+  @ignore
+  Scenario: Individual Provider Statement Page
+    Given I have started an enrollment
+    And I am on the individual provider statement page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -41,6 +41,14 @@ Feature: Individual Enrollment Steps Accessibility Checks
     And I save as draft
     Then I should have no accessibility issues
 
+  # fails: duplicated IDs
+  @ignore
+  Scenario: Individual Print Modal
+      Given I have started an enrollment
+      When I am on the individual summary page
+      And I start to print
+      Then I should have no accessibility issues
+
   # fails: form input elements missing labels or titles
   @ignore
   Scenario: Individual Provider Statement Page

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -21,6 +21,7 @@ Feature: Individual Enrollment Steps Accessibility Checks
     Given I have started an enrollment
     And I am on the individual provider practice info page
     When I indicate I maintain my own private practice
+    And I open the practice lookup modal
     Then I should have no accessibility issues
 
   # fails: additional practice location 'effective date' input needs a label or title

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -16,3 +16,9 @@ Feature: Individual Enrollment Steps Accessibility Checks
     And I open an add a license panel
     And I open an add a license panel
     Then I should have no accessibility issues
+
+  Scenario: Practice Info Page (Own Private Practice)
+    Given I have started an enrollment
+    And I am on the individual provider practice info page
+    When I indicate I maintain my own private practice
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -38,6 +38,7 @@ Feature: Individual Enrollment Steps Accessibility Checks
   Scenario: Individual Summary Page
     Given I have started an enrollment
     When I am on the individual summary page
+    And I save as draft
     Then I should have no accessibility issues
 
   # fails: form input elements missing labels or titles

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -6,3 +6,13 @@ Feature: Individual Enrollment Steps Accessibility Checks
     Given I have started an enrollment
     When I am on the personal info page
     Then I should have no accessibility issues
+
+  # fails: date inputs on second license need labels or titles
+  @ignore
+  Scenario: License Info Page
+    Given I have started an enrollment
+    And I am on the individual provider license info page
+    When I indicate I am a provider at a Public Health Service Indian Hospital
+    And I open an add a license panel
+    And I open an add a license panel
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -46,3 +46,10 @@ Feature: Individual Enrollment Steps Accessibility Checks
     Given I have started an enrollment
     And I am on the individual provider statement page
     Then I should have no accessibility issues
+
+  Scenario: Submit Enrollment Modal
+    Given I have started an enrollment
+    And I am on the individual provider statement page
+    When I enter my provider statement
+    And I submit the enrollment
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -34,3 +34,8 @@ Feature: Individual Enrollment Steps Accessibility Checks
     And I start to add a practice location
     And I start to add a practice location
     Then I should have no accessibility issues
+
+  Scenario: Individual Summary Page
+    Given I have started an enrollment
+    When I am on the individual summary page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -40,6 +40,7 @@ Feature: Organization Enrollment Steps Accessibility Checks
   Scenario: Organization Summary Page
     Given I have started an enrollment
     When I am on the organization summary page
+    And I save as draft
     Then I should have no accessibility issues
 
   Scenario: Organization Provider Statement Page

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -16,7 +16,7 @@ Feature: Organization Enrollment Steps Accessibility Checks
   Scenario: Facility Credentials Page
     Given I have started an enrollment
     When I am on the facility credentials page
-    And I open the add a license panel
+    And I open an add a license panel
     Then I should have no accessibility issues
 
   # fails with duplicate IDs and inputs without labels/titles

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -42,7 +42,7 @@ Feature: Organization Enrollment Steps Accessibility Checks
     When I am on the organization summary page
     Then I should have no accessibility issues
 
-  Scenario: Provider Statement Page
+  Scenario: Organization Provider Statement Page
     Given I have started an enrollment
-    When I am on the provider statement page
+    When I am on the organization provider statement page
     Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -37,9 +37,9 @@ Feature: Organization Enrollment Steps Accessibility Checks
     And I have indicated that the owner has an interest in another Medicaid disclosing entity
     Then I should have no accessibility issues
 
-  Scenario: Summary Page
+  Scenario: Organization Summary Page
     Given I have started an enrollment
-    When I am on the summary page
+    When I am on the organization summary page
     Then I should have no accessibility issues
 
   Scenario: Provider Statement Page

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
@@ -17,13 +17,13 @@ Feature: Data Coverage Checks
   @psm-FR-2.9
   Scenario: Captures Contact Info for Individual
     Given I have started an enrollment
-    When  I move to the personal info page
+    When I am on the personal info page
     Then I should be asked to enter Applicant Name, Contact Person
 
   @psm-FR-2.9
   Scenario: Captures Phone number and Medicaid number for Individual
     Given I have started an enrollment
-    When  I move to the personal info page
+    When I am on the personal info page
     Then I should be asked to enter Contact phone, Medicaid number
 
   @issue-362
@@ -37,7 +37,8 @@ Feature: Data Coverage Checks
 
   @psm-FR-2.6
   Scenario: Accepts valid individual provider personal information
-    Given I am on the personal info page
+    Given I have started an enrollment
+    When I am on the personal info page
     When I enter valid personal information
     Then I can move on from the personal info page with no errors
 

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
@@ -44,19 +44,22 @@ Feature: Data Coverage Checks
 
   @psm-FR-2.4
   Scenario: Accepts license
-    Given I am on the individual provider license info page
+    Given I have started an enrollment
+    And I am on the individual provider license info page
     When I enter valid license information
     And I upload a valid license
     Then the license is accepted
 
   Scenario: Accepts practice information
-    Given I am on the individual provider practice info page
+    Given I have started an enrollment
+    And I am on the individual provider practice info page
     When I enter a valid private practice
     Then the practice information is accepted
     And the summary page shows expected information
 
   Scenario: Completes an application
-    Given I am on the individual provider statement page
+    Given I have started an enrollment
+    And I am on the individual provider statement page
     When I enter my provider statement
     And I submit the enrollment
     Then the enrollment is successfully submitted

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
@@ -46,6 +46,7 @@ Feature: Data Coverage Checks
   Scenario: Accepts license
     Given I have started an enrollment
     And I am on the individual provider license info page
+    And I indicate I am not a provider at a Public Health Service Indian Hospital
     When I enter valid license information
     And I upload a valid license
     Then the license is accepted

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
@@ -21,6 +21,7 @@ Feature: Form and Field Validations
   Scenario: Validate individual provider license renewal date
     Given I have started an enrollment
     And I am on the individual provider license info page
+    And I indicate I am not a provider at a Public Health Service Indian Hospital
     When I enter license info where renewal date is before issue date
     And I click 'next' on the license info page
     Then I should get a renewal date error

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
@@ -19,7 +19,8 @@ Feature: Form and Field Validations
 
   @issue_352
   Scenario: Validate individual provider license renewal date
-    Given I am on the individual provider license info page
+    Given I have started an enrollment
+    And I am on the individual provider license info page
     When I enter license info where renewal date is before issue date
     And I click 'next' on the license info page
     Then I should get a renewal date error

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
@@ -11,7 +11,8 @@ Feature: Form and Field Validations
     Then It should be rejected
 
   Scenario: Validate minimum age
-    Given I am on the personal info page
+    Given I have started an enrollment
+    And I am on the personal info page
     When I enter a date of birth less than eighteen years ago
     And I click 'next' on the personal info page
     Then I should get a provider too young error

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
@@ -25,7 +25,8 @@ Feature: Form and Field Validations
 
   @issue_352
   Scenario: Validate organizational provider license renewal date
-    Given I am on the organizational provider license info page
+    Given I have started an enrollment
+    When I am on the facility credentials page
     When I enter license info where renewal date is before issue date
     And I click 'next' on the license info page
     Then I should get a renewal date error

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -14,26 +14,36 @@ Feature: General Accessibility Checks
     Given I am on the Forgot Password page
     Then I should have no accessibility issues
 
+  # issue #672
+  @ignore
   Scenario: Dashboard Page
     Given I am logged in
     When I open the filter panel
     Then I should have no accessibility issues
 
+  # issue #672
+  @ignore
   Scenario: Dashboard Draft Page
     Given I am on the Dashboard Draft page
     When I open the filter panel
     Then I should have no accessibility issues
 
+  # issue #672
+  @ignore
   Scenario: Dashboard Pending Page
     Given I am on the Dashboard Pending page
     When I open the filter panel
     Then I should have no accessibility issues
 
+  # issue #672
+  @ignore
   Scenario: Dashboard Approved Page
     Given I am on the Dashboard Approved page
     When I open the filter panel
     Then I should have no accessibility issues
 
+  # issue #672
+  @ignore
   Scenario: Dashboard Denied Page
     Given I am on the Dashboard Denied page
     When I open the filter panel
@@ -52,6 +62,8 @@ Feature: General Accessibility Checks
     Given I am on the Account Setup page
     Then I should have no accessibility issues
 
+  # issue #687 sometimes fails, 'no submit button for form'
+  @ignore
   Scenario: Advanced Search Page
     Given I am on the Advanced Search page
     Then I should have no accessibility issues


### PR DESCRIPTION
Add accessibility tests for the pages of the enrollment process for individuals. Includes some refactoring and an easy fix for one failing test (a color contrast issue).  

The changes in this PR are on top of those in the current version of PR #673.  The new commits start with "Move basic step definitions out of 'DataCoverageStepDefinitions'".

Tested by running the tests.  Those that are not `@ignore`d pass successfully.

Issue #518 Implement accessibility checking in CI