### PR TITLE
Test Jenkins integration tests

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
@@ -23,6 +23,6 @@ public class LoginPage extends PsmPage {
     }
 
     public void checkUserLoggedOut() {
-        assertThat(getTitle()).contains("Login");
+        assertThat(getTitle()).contains("Broken Tests");
     }
 }


### PR DESCRIPTION
We've had some trouble with the integration tests failing on Jenkins due to WildFly out of memory errors. I made some changes to how Jenkins runs the integration tests in an attempt to improve the stability and reliability of the integration tests, and reduce the number of false negatives we get.

Specifically, I reconfigured Jenkins to allow users in the `wildfly` group (including the `jenkins` user) to start, stop, and restart WildFly, and updated the integration tests job to restart WildFly before building (or start it, if it's stopped), and undeploy and stop WildFly even if the integration tests fail. Test failures should be caught by the JUnit post-build step.

Do not merge this PR; I just want a safe space for testing the updated build.

Issue #629 Use Jenkins for continuous integration