### PR TITLE
Reorder names for user account registration: #375

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -50,18 +50,7 @@
                       </spring:bind>
                       <form:input id="registerUsername" path="username" cssClass="normalInput ${errorCls}"/>
                     </div>
-                    <div class="row">
-                      <label for="registerLastName">Last Name<span class="required">*</span></label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
 
-                      <c:set var="errorCls" value=""/>
-                      <spring:bind path="lastName">
-                        <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
-                      </spring:bind>
-                      <form:input id="registerLastName" path="lastName" cssClass="normalInput ${errorCls}"/>
-                    </div>
                     <div class="row">
                       <label for="registerFirstName">First Name<span class="required">*</span></label>
                       <span class="floatL">
@@ -85,6 +74,19 @@
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
                       </spring:bind>
                       <form:input id="registerMiddleName" path="middleName" cssClass="normalInput ${errorCls}"/>
+                    </div>
+                    
+                    <div class="row">
+                      <label for="registerLastName">Last Name<span class="required">*</span></label>
+                      <span class="floatL">
+                        <b>:</b>
+                      </span>
+
+                      <c:set var="errorCls" value=""/>
+                      <spring:bind path="lastName">
+                        <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
+                      </spring:bind>
+                      <form:input id="registerLastName" path="lastName" cssClass="normalInput ${errorCls}"/>
                     </div>
                     <div class="row">
                       <label for="registerEmail">Email<span class="required">*</span></label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
@@ -49,11 +49,6 @@
                     <span>********</span>
                   </div>
                   <div class="row">
-                    <label>Last Name</label>
-                    <span class="floatL"><b>:</b></span>
-                    <span>${user.lastName}</span>
-                  </div>
-                  <div class="row">
                     <label>First Name</label>
                     <span class="floatL"><b>:</b></span>
                     <span>${user.firstName}</span>
@@ -62,6 +57,11 @@
                     <label>Middle Name</label>
                     <span class="floatL"><b>:</b></span>
                     <span>${user.middleName}</span>
+                  </div>
+                  <div class="row">
+                    <label>Last Name</label>
+                    <span class="floatL"><b>:</b></span>
+                    <span>${user.lastName}</span>
                   </div>
                   <div class="row">
                     <label>Email</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
@@ -96,11 +96,6 @@
                       <input type="password" id="newConfirmPassword" class="passwordNormalInput" value="" name="password2"/>
                     </div>
                     <div class="row">
-                      <label for="lastName">Last Name</label>
-                      <span class="floatL"><b>:</b></span>
-                      <form:input id="lastName" cssClass="normalInput" path="lastName" />
-                    </div>
-                    <div class="row">
                       <label for="firstName">First Name</label>
                       <span class="floatL"><b>:</b></span>
                       <form:input id="firstName" cssClass="normalInput" path="firstName" />
@@ -109,6 +104,11 @@
                       <label for="middleName">Middle Name</label>
                       <span class="floatL"><b>:</b></span>
                       <form:input id="middleName" cssClass="normalInput" path="middleName" />
+                    </div>
+                    <div class="row">
+                      <label for="lastName">Last Name</label>
+                      <span class="floatL"><b>:</b></span>
+                      <form:input id="lastName" cssClass="normalInput" path="lastName" />
                     </div>
                     <div class="row">
                       <label for="email">Email</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_pca_rows.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_pca_rows.jsp
@@ -1,9 +1,4 @@
 <div class="row">
-    <label>Last Name</label>
-    <span class="floatL"><b>:</b></span>
-    <span>${requestScope['_10_lastName']}</span>
-</div>
-<div class="row">
     <label>First Name</label>
     <span class="floatL"><b>:</b></span>
     <span>${requestScope['_10_firstName']}</span>
@@ -12,6 +7,11 @@
     <label>Middle Name</label>
     <span class="floatL"><b>:</b></span>
     <span>${requestScope['_10_middleName']}</span>
+</div>
+<div class="row">
+    <label>Last Name</label>
+    <span class="floatL"><b>:</b></span>
+    <span>${requestScope['_10_lastName']}</span>
 </div>
 <div class="row">
     <label>Social Security Number</label>

--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
@@ -32,11 +32,6 @@
                     <span>{{user.username}}</span>
                   </div>
                   <div class="row">
-                    <label>Last Name</label>
-                    <span class="floatL"><b>:</b></span>
-                    <input id="lastName" name="lastName" class="normalInput" type="text" value="{{user.lastName}}" />
-                  </div>
-                  <div class="row">
                     <label>First Name</label>
                     <span class="floatL"><b>:</b></span>
                     <input id="firstName" name="firstName" class="normalInput" type="text" value="{{user.firstName}}" />
@@ -46,6 +41,11 @@
                     <span class="floatL"><b>:</b></span>
                     <input id="middleName" name="middleName" class="normalInput" type="text" value="{{user.middleName}}" />
                     <em class="grey">(optional)</em>
+                  </div>
+                  <div class="row">
+                    <label>Last Name</label>
+                    <span class="floatL"><b>:</b></span>
+                    <input id="lastName" name="lastName" class="normalInput" type="text" value="{{user.lastName}}" />
                   </div>
                   <div class="row">
                     <label>Business Phone</label>

--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
@@ -28,11 +28,6 @@
                   <span>{{user.username}}</span>
                 </div>
                 <div class="row">
-                  <label>Last Name</label>
-                  <span class="floatL"><b>:</b></span>
-                  <span>{{user.lastName}}</span>
-                </div>
-                <div class="row">
                   <label>First Name</label>
                   <span class="floatL"><b>:</b></span>
                   <span>{{user.firstName}}</span>
@@ -41,6 +36,11 @@
                   <label>Middle Name</label>
                   <span class="floatL"><b>:</b></span>
                   <span>{{user.middleName}}</span>
+                </div>
+                <div class="row">
+                  <label>Last Name</label>
+                  <span class="floatL"><b>:</b></span>
+                  <span>{{user.lastName}}</span>
                 </div>
                 <div class="row">
                   <label>Business Phone</label>


### PR DESCRIPTION
Make names display as "first, middle, last" on the registration page and everywhere users view/edit their own or other accounts.

Note that this does not change name order in places in the enrollment workflow where only the first and last names are present.  It seemed to me that having "last, first" in some places is fairly usual and could be maintained.  Let me know if you disagree, reviewers!

I did, however, reorder the name order for the print modal on the Personal Care Assistant provider type, since it includes the middle name and should be consistent with the entered order.

To test this, check the field order on the registration page and look at name order for users from the `system` role account.   Also, start an enrollment as a Personal Care Assistant, print the enrollment, and check the order in which the PCA's name is displayed.

I had hoped to pull this out into a shared jsp instead of changing it in several different places, but it did not seem easy to do so at first glance.  Let me know if you'd prefer that I do some work to DRY this.

#375 Registration Page name order is inconsistent