### PR TITLE
Add a11y tests for admin view enrollment pages etc

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -217,7 +217,7 @@
         <td class="alignCenter nopad">
           <c:choose>
             <c:when test="${fn:toLowerCase(item.status)=='pending'}">
-              <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+              <a class="viewLink" href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
                 View
               </a>
               <span class="sep">|</span>
@@ -249,7 +249,7 @@
               <span class="sep">|</span>
             </c:when>
             <c:when test="${fn:toLowerCase(item.status)=='approved'}">
-              <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+              <a class="viewLink" href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
                 View
               </a>
               <span class="sep">|</span>
@@ -267,7 +267,7 @@
               <span class="sep">|</span>
             </c:when>
             <c:otherwise>
-              <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+              <a class="viewLink" href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
                 View
               </a>
               <span class="sep">|</span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -225,7 +225,7 @@
                 Edit
               </a>
               <span class="sep">|</span>
-              <a href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
+              <a class="cosLink" href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
                 COS
               </a>
               <span class="sep">|</span>
@@ -243,7 +243,7 @@
                 Edit
               </a>
               <span class="sep">|</span>
-              <a href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
+              <a class="cosLink" href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
                 COS
               </a>
               <span class="sep">|</span>
@@ -257,7 +257,7 @@
                 Edit
               </a>
               <span class="sep">|</span>
-              <a href="${ctx}/agent/enrollment/cos?id=${item.profileReferenceId}">
+              <a class="cosLink" href="${ctx}/agent/enrollment/cos?id=${item.profileReferenceId}">
                 COS
               </a>
               <span class="sep">|</span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -231,7 +231,7 @@
               <span class="sep">|</span>
               <c:forEach var="task" items="${tasks}">
                 <c:if test="${task.processInstanceId == item.processInstanceId}">
-                    <a href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}">
+                    <a class="reviewLink" href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}">
                       Review
                     </a>
                     <span class="sep">|</span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screening_log.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screening_log.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Enrollment"/>
+  <c:set var="title" value="Screening Log"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Enrollment"/>
+  <c:set var="title" value="Review Enrollment"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -49,7 +49,9 @@
                       <tr>
                         <td>NPI LOOKUP</td>
                         <td>${model.enrollment.providerInformation.NPI}</td>
-                        <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI LOOKUP&id=${id}" target="_blank">
+                        <td><a class="autoScreeningResultLink"
+                              href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI LOOKUP&id=${id}"
+                              target="_blank">
                             <c:choose>
                             <c:when test="${empty verification.NPILookup}">
                               Not performed
@@ -72,7 +74,9 @@
                       <tr>
                         <td>SSN DMF VERIFICATION</td>
                         <td>${model.enrollment.providerInformation.applicantInformation.personalInformation.socialSecurityNumber}</td>
-                        <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SSN DMF VERIFICATION&id=${id}" target="_blank">
+                        <td><a class="autoScreeningResultLink"
+                              href="${ctx}/agent/enrollment/autoScreeningResult?type=SSN DMF VERIFICATION&id=${id}"
+                              target="_blank">
                             <c:choose>
                             <c:when test="${empty verification.socialSecurityNumber}">
                               Not performed
@@ -95,7 +99,9 @@
                       <tr>
                         <td>NPI PECOS VERIFICATION</td>
                         <td>${model.enrollment.providerInformation.NPI}</td>
-                        <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI PECOS VERIFICATION&id=${id}" target="_blank">
+                        <td><a class="autoScreeningResultLink"
+                              href="${ctx}/agent/enrollment/autoScreeningResult?type=NPI PECOS VERIFICATION&id=${id}"
+                              target="_blank">
                             <c:choose>
                             <c:when test="${empty verification.NPI}">
                               Not performed
@@ -118,7 +124,9 @@
                       <tr>
                         <td>EXCLUDED PROVIDER VERIFICATION IN OIG (checked means not in exclusion list)</td>
                         <td></td>
-                        <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=EXCLUDED PROVIDERS&id=${id}" target="_blank">
+                        <td><a class="autoScreeningResultLink"
+                              href="${ctx}/agent/enrollment/autoScreeningResult?type=EXCLUDED PROVIDERS&id=${id}"
+                              target="_blank">
                           <c:choose>
                           <c:when test="${empty verification.nonExclusion}">
                             Not performed
@@ -141,7 +149,9 @@
                       <tr>
                         <td>EXCLUDED PROVIDER VERIFICATION IN SAM (checked means not in exclusion list)</td>
                         <td></td>
-                        <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=SAM EXCLUDED PROVIDERS&id=${id}" target="_blank">
+                        <td><a class="autoScreeningResultLink"
+                              href="${ctx}/agent/enrollment/autoScreeningResult?type=SAM EXCLUDED PROVIDERS&id=${id}"
+                              target="_blank">
                           <c:choose>
                           <c:when test="${empty verification.SAMNonExclusion}">
                             Not performed
@@ -187,7 +197,9 @@
                             <a href="${downloadLink}">View</a>
 
                           </td>
-                          <td><a href="${ctx}/agent/enrollment/autoScreeningResult?type=LICENSE VERIFICATION&id=${id}&licenseId=${license.objectId}" target="_blank">
+                          <td><a class="autoScreeningResultLink"
+                                href="${ctx}/agent/enrollment/autoScreeningResult?type=LICENSE VERIFICATION&id=${id}&licenseId=${license.objectId}"
+                                target="_blank">
                             <c:choose>
                             <c:when test="${empty license.verified}">
                               Not performed

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -116,6 +116,7 @@
                   <c:forEach var="tabName" items="${viewModel.tabNames}" varStatus="status">
                     <c:if test="${tabName ne 'Summary Information'}">
                       <c:set var="tabLabel" value=""></c:set>
+                      <c:set var="tabCls" value=""></c:set>
                       <c:set var="tabActiveCls" value=""></c:set>
                       <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tab_name_mapping.jsp" %>
                       <c:if test="${viewModel.currentTab eq tabName}">
@@ -124,7 +125,8 @@
                       <c:url var="tabLink" value="/provider/enrollment/jump">
                         <c:param name="page" value="${tabName}"></c:param>
                       </c:url>
-                      <a href="javascript:submitFormById('enrollmentForm', '${tabLink}')" class="tab ${tabActiveCls}">
+                      <a href="javascript:submitFormById('enrollmentForm', '${tabLink}')"
+                        class="tab ${tabCls} ${tabActiveCls}">
                         <span class="aR">
                           <span class="aM">${tabLabel}</span>
                         </span>
@@ -138,7 +140,8 @@
                   <c:url var="tabLink" value="/provider/enrollment/jump">
                     <c:param name="page" value="Notes"></c:param>
                   </c:url>
-                  <a href="javascript:submitFormById('enrollmentForm', '${tabLink}')" class="tab ${tabActiveCls}">
+                  <a href="javascript:submitFormById('enrollmentForm', '${tabLink}')"
+                    class="tab notesTab ${tabActiveCls}">
                     <span class="aR">
                       <span class="aM">Notes</span>
                     </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/readonly_profile.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/readonly_profile.jsp
@@ -5,11 +5,16 @@
             <c:forEach var="tabName" items="${viewModel.tabNames}" varStatus="status">
                 <c:if test="${tabName ne 'Summary Information'}">
                     <c:set var="tabLabel" value=""></c:set>
+                    <c:set var="tabCls" value=""></c:set>
                     <c:set var="tabActiveCls" value=""></c:set>
                     <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tab_name_mapping.jsp" %>
                     <c:if test="${viewModel.currentTab eq tabName}"><c:set var="tabActiveCls" value="active"></c:set></c:if>
                     <c:url var="tabLink" value="/provider/enrollment/jump"><c:param name="page" value="${tabName}"></c:param></c:url>
-                    <a href="${tabLink}" class="tab ${tabActiveCls}"><span class="aR"><span class="aM">${tabLabel}</span></span></a>
+                    <a href="${tabLink}" class="tab ${tabCls} ${tabActiveCls}">
+                      <span class="aR">
+                        <span class="aM">${tabLabel}</span>
+                      </span>
+                    </a>
                 </c:if>
             </c:forEach>
         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tab_name_mapping.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tab_name_mapping.jsp
@@ -1,11 +1,11 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:choose>
     <c:when test="${tabName eq 'Personal Information'}">
-        <c:set var="tabCls" value="presonal"></c:set>
+        <c:set var="tabCls" value="personal"></c:set>
         <c:set var="tabLabel" value="Personal Info"></c:set>
     </c:when>
     <c:when test="${tabName eq 'Individual PCA Information'}">
-        <c:set var="tabCls" value="presonal"></c:set>
+        <c:set var="tabCls" value="personal"></c:set>
         <c:set var="tabLabel" value="Individual PCA Info"></c:set>
     </c:when>
     <c:when test="${tabName eq 'License Information'}">
@@ -33,7 +33,7 @@
         <c:set var="tabLabel" value="Provider Statement"></c:set>
     </c:when>
     <c:when test="${tabName eq 'Organization Information'}">
-        <c:set var="tabCls" value="presonal"></c:set>
+        <c:set var="tabCls" value="personal"></c:set>
         <c:set var="tabLabel" value="Organization Info"></c:set>
     </c:when>
     <c:when test="${tabName eq 'Provider Setup'}">
@@ -53,7 +53,7 @@
         <c:set var="tabLabel" value="Qualified Professional"></c:set>
     </c:when>
     <c:when test="${tabName eq 'Ownership Information'}">
-        <c:set var="tabCls" value="ownerShip"></c:set>
+        <c:set var="tabCls" value="ownership"></c:set>
         <c:set var="tabLabel" value="Ownership Info"></c:set>
     </c:when>
     <c:when test="${tabName eq 'Notes'}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp
@@ -29,7 +29,7 @@
             </c:choose>
             <c:if test="${viewModel.currentTab eq tabName}"><c:set var="tabActiveCls" value="active"></c:set></c:if>
             <c:if test="${viewModel.currentTab eq tabName and status.last}"><c:set var="isInSubmissionPage" value="${true}"></c:set></c:if>
-            <li class="${status.first ? 'firstSetp' : ''} ${status.last ? 'lastSetp' : ''} ${tabCls} ${tabActiveCls}">
+            <li class="${status.first ? 'firstStep' : ''} ${status.last ? 'lastStep' : ''} ${tabCls} ${tabActiveCls}">
                <span><strong>${status.count}. ${tabLabel}</strong></span>
             </li>
         </c:forEach>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -1029,13 +1029,13 @@ input.date{
   display:block;
 }
 
-.stepWidget li.firstSetp span{
+.stepWidget li.firstStep span{
   background-image:url(../i/step-normal-left.png);
   background-repeat:no-repeat;
   background-position:0 0;
 }
 
-.stepWidget li.lastSetp span{
+.stepWidget li.lastStep span{
   background-image:url(../i/step-normal-right.png);
   background-repeat:no-repeat;
   background-position:right 0;
@@ -1057,7 +1057,7 @@ input.date{
   white-space: nowrap;
 }
 
-.stepWidget li.lastSetp span strong{
+.stepWidget li.lastStep span strong{
   background-image:none;
 }
 
@@ -1066,11 +1066,11 @@ input.date{
   background-image:url(../i/step-active.png);
 }
 
-.stepWidget li.firstSetp.active span{
+.stepWidget li.firstStep.active span{
   background-image:url(../i/step-active-left.png);
 }
 
-.stepWidget li.lastSetp.active span{
+.stepWidget li.lastStep.active span{
   background-image:url(../i/step-active-right.png);
 }
 
@@ -1080,7 +1080,7 @@ input.date{
   background-image:url(../i/step-active-arrow.png);
 }
 
-.stepWidget li.lastSetp.active span strong{
+.stepWidget li.lastStep.active span strong{
   background-image:none;
 }
 
@@ -1089,7 +1089,7 @@ input.date{
   background-image:url(../i/step-prev-active.png);
 }
 
-.stepWidget li.firstSetp.activePrev span{
+.stepWidget li.firstStep.activePrev span{
   background-image:url(../i/step-active-prev-left.png);
 }
 
@@ -1104,7 +1104,7 @@ input.date{
   background-image:url(../i/step-prev-active.png);
 }
 
-.stepWidget li.firstSetp.activeNear span{
+.stepWidget li.firstStep.activeNear span{
   background-image:url(../i/step-active-prev-left.png);
 }
 

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -2129,7 +2129,7 @@ input.date{
   padding:0 0 0 25px;
   font-size:12px;
   line-height:16px;
-  color:#f00;
+  color:#900;
   background-image:url(../i/icon-error.png);
   background-repeat:no-repeat;
   background-position:0 0;
@@ -2139,7 +2139,7 @@ input.date{
   margin:0 0 0 25px;
   font-size:12px;
   line-height:18px;
-  color: #c00;
+  color: #900;
 }
 
 .errorInput{

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -738,7 +738,7 @@ $(document).ready(function () {
   });
 
   //new script
-  $('.stepWidget .lastSetp').css('width', $('.stepWidget').width() - $('.stepWidget .presonal').width() - $('.stepWidget .license').width() - $('.stepWidget .practice').width() - $('.stepWidget .payment').width() - $('.stepWidget .summary').width() - 2);
+  $('.stepWidget .lastStep').css('width', $('.stepWidget').width() - $('.stepWidget .personal').width() - $('.stepWidget .license').width() - $('.stepWidget .practice').width() - $('.stepWidget .payment').width() - $('.stepWidget .summary').width() - 2);
 
   //Save As Above
   $('#sameAsAbove').live('click', function () {

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -294,7 +294,7 @@ $(document).ready(function () {
   */
 
   //new script
-  $('.stepWidget .lastSetp').css('width', $('.stepWidget').width() - $('.stepWidget .presonal').width() - $('.stepWidget .license').width() - $('.stepWidget .practice').width() - $('.stepWidget .payment').width() - $('.stepWidget .summary').width() - $('.stepWidget .ownerShip').width() - 2);
+  $('.stepWidget .lastStep').css('width', $('.stepWidget').width() - $('.stepWidget .personal').width() - $('.stepWidget .license').width() - $('.stepWidget .practice').width() - $('.stepWidget .payment').width() - $('.stepWidget .summary').width() - $('.stepWidget .ownership').width() - 2);
 
   //Save As Above
   $('#sameAsAbove').live('click', function () {

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -266,7 +266,7 @@ $(document).ready(function () {
   });
 
   //new script
-  $('.stepWidget .lastSetp').css('width', $('.stepWidget').width() - $('.stepWidget .presonal').width() - $('.stepWidget .license').width() - $('.stepWidget .practice').width() - $('.stepWidget .payment').width() - $('.stepWidget .summary').width() - 2);
+  $('.stepWidget .lastStep').css('width', $('.stepWidget').width() - $('.stepWidget .personal').width() - $('.stepWidget .license').width() - $('.stepWidget .practice').width() - $('.stepWidget .payment').width() - $('.stepWidget .summary').width() - 2);
 
   //Save As Above
   $('#sameAsAbove').live('click', function () {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
@@ -4,6 +4,7 @@ import com.deque.axe.AXE;
 import net.thucydides.core.pages.PageObject;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -31,6 +32,12 @@ public class PsmPage extends PageObject {
 
     public void click$(String selector) {
         click($(selector));
+    }
+
+    public WebElement getTableRowForProviderType(String providerType) {
+        WebElement td = $("//td[contains(text(),'" + providerType + "')]");
+        WebElement row = td.findElement(By.xpath(".."));
+        return row;
     }
 
     public void checkAccessibility() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -102,9 +102,14 @@ public class EnrollmentStepDefinitions {
         enrollmentSteps.advanceFromOrganizationSummaryToProviderStatementPage();
     }
 
-    @When("^I enter my provider statement$")
+    @When("^I enter my individual provider statement$")
     public void i_enter_my_provider_statement() {
         enrollmentSteps.checkNoOnProviderDisclosureQuestions();
+        enrollmentSteps.signAndDateProviderStatement();
+    }
+
+    @When("^I enter my organization provider statement$")
+    public void i_enter_my_organization_provider_statement() {
         enrollmentSteps.signAndDateProviderStatement();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/ProviderStatementPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/ProviderStatementPage.java
@@ -30,16 +30,16 @@ public class ProviderStatementPage extends PsmPage {
     }
 
     public void enterProviderName(String providerName) {
-        $("[name=_08_name]").type(providerName);
+        $("[name=_08_name], [name=_19_name]").type(providerName);
     }
 
     public void enterProviderTitle(String providerTitle) {
-        $("[name=_08_title]").type(providerTitle);
+        $("[name=_08_title], [name=_19_title]").type(providerTitle);
     }
 
     public void enterValidDate() {
         String currentDate = LocalDate.now().format(DATE_FORMATTER);
-        $("[name=_08_date]").type(currentDate);
+        $("[name=_08_date], [name=_19_date]").type(currentDate);
     }
 
     public void clickSubmitButton() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,18 +1,28 @@
 package gov.medicaid.features.general.steps;
 
+import gov.medicaid.features.PsmPage;
 import gov.medicaid.features.general.ui.DashboardPage;
 import gov.medicaid.features.general.ui.LoginPage;
 import gov.medicaid.features.general.ui.MyProfilePage;
 import gov.medicaid.features.general.ui.UpdatePasswordPage;
 import net.thucydides.core.annotations.Step;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SuppressWarnings("unused")
 public class GeneralSteps {
 
+    private PsmPage psmPage;
     private LoginPage loginPage;
     private DashboardPage dashboardPage;
     private MyProfilePage profilePage;
     private UpdatePasswordPage updatePasswordPage;
+
+    @Step
+    public void clickLinkAssertTitle(String selector, String title) {
+        psmPage.click$(selector);
+        assertThat(psmPage.getTitle()).contains(title);
+    }
 
     @Step
     public void navigateToRegisterNewAccountPage() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -18,6 +18,11 @@ public class AdminStepDefinitions {
         generalSteps.login("admin", "admin");
     }
 
+    @When("^I open the Write Note modal$")
+    public void i_open_the_write_note_modal() {
+        adminSteps.openWriteNoteModal();
+    }
+
     @When("^I am on the COS page$")
     public void i_am_on_the_cos_page() {
         generalSteps.navigateToDraftPage();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -48,4 +48,10 @@ public class AdminStepDefinitions {
         // assert fails because the page is opened in a separate tab
         generalSteps.clickLinkAssertTitle(".autoScreeningResultLink", "Screening Log");
     }
+
+    @When("^I am on the View Enrollment Organization Info page$")
+    public void i_am_on_the_view_enrollment_organization_info_page() {
+        generalSteps.navigateToPendingPage();
+        adminSteps.advanceFromPendingPageToViewOrganizationInfoPage();
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -48,34 +48,4 @@ public class AdminStepDefinitions {
         // assert fails because the page is opened in a separate tab
         generalSteps.clickLinkAssertTitle(".autoScreeningResultLink", "Screening Log");
     }
-
-    @When("^I am on the View Enrollment Organization Info page$")
-    public void i_am_on_the_view_enrollment_organization_info_page() {
-        generalSteps.navigateToPendingPage();
-        adminSteps.advanceFromPendingPageToViewOrganizationInfoPage();
-    }
-
-    @When("^I am on the View Enrollment Facility Credentials page$")
-    public void i_am_on_the_view_enrollment_facility_credentials_page() {
-        i_am_on_the_view_enrollment_organization_info_page();
-        generalSteps.clickLinkAssertTitle(".license", "Facility Credentials");
-    }
-
-    @When("^I am on the View Enrollment Individual Member Info page$")
-    public void i_am_on_the_view_enrollment_individual_member_info_page() {
-        i_am_on_the_view_enrollment_organization_info_page();
-        generalSteps.clickLinkAssertTitle(".practice", "Member Information");
-    }
-
-    @When("^I am on the View Enrollment Ownership Info page$")
-    public void i_am_on_the_view_enrollment_ownership_info_page() {
-        i_am_on_the_view_enrollment_organization_info_page();
-        generalSteps.clickLinkAssertTitle(".ownerShip", "Ownership Information");
-    }
-
-    @When("^I am on the View Enrollment Provider Statement page$")
-    public void i_am_on_the_view_enrollment_provider_statement_page() {
-        i_am_on_the_view_enrollment_organization_info_page();
-        generalSteps.clickLinkAssertTitle(".provider", "Provider Statement");
-    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -72,4 +72,10 @@ public class AdminStepDefinitions {
         i_am_on_the_view_enrollment_organization_info_page();
         generalSteps.clickLinkAssertTitle(".ownerShip", "Ownership Information");
     }
+
+    @When("^I am on the View Enrollment Provider Statement page$")
+    public void i_am_on_the_view_enrollment_provider_statement_page() {
+        i_am_on_the_view_enrollment_organization_info_page();
+        generalSteps.clickLinkAssertTitle(".provider", "Provider Statement");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -28,4 +28,10 @@ public class AdminStepDefinitions {
         generalSteps.navigateToDraftPage();
         generalSteps.clickLinkAssertTitle(".cosLink", "Category of Service");
     }
+
+    @When("^I am on the Review Enrollment page$")
+    public void i_am_on_the_review_enrollment_page() {
+        generalSteps.navigateToPendingPage();
+        generalSteps.clickLinkAssertTitle(".reviewLink", "Review Enrollment");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -54,4 +54,10 @@ public class AdminStepDefinitions {
         generalSteps.navigateToPendingPage();
         adminSteps.advanceFromPendingPageToViewOrganizationInfoPage();
     }
+
+    @When("^I am on the View Enrollment Facility Credentials page$")
+    public void i_am_on_the_view_enrollment_facility_credentials_page() {
+        i_am_on_the_view_enrollment_organization_info_page();
+        generalSteps.clickLinkAssertTitle(".license", "Facility Credentials");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -66,4 +66,10 @@ public class AdminStepDefinitions {
         i_am_on_the_view_enrollment_organization_info_page();
         generalSteps.clickLinkAssertTitle(".practice", "Member Information");
     }
+
+    @When("^I am on the View Enrollment Ownership Info page$")
+    public void i_am_on_the_view_enrollment_ownership_info_page() {
+        i_am_on_the_view_enrollment_organization_info_page();
+        generalSteps.clickLinkAssertTitle(".ownerShip", "Ownership Information");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -34,4 +34,11 @@ public class AdminStepDefinitions {
         generalSteps.navigateToPendingPage();
         generalSteps.clickLinkAssertTitle(".reviewLink", "Review Enrollment");
     }
+
+    @When("^I am on the Screening Log page$")
+    public void i_am_on_the_screening_log_page() {
+        i_am_on_the_review_enrollment_page();
+        // assert fails because the page is opened in a separate tab
+        generalSteps.clickLinkAssertTitle(".autoScreeningResultLink", "Screening Log");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -1,6 +1,7 @@
 package gov.medicaid.features.service_admin.steps;
 
 import cucumber.api.java.en.Given;
+import cucumber.api.java.en.When;
 import gov.medicaid.features.general.steps.GeneralSteps;
 import net.thucydides.core.annotations.Steps;
 
@@ -9,8 +10,17 @@ public class AdminStepDefinitions {
     @Steps
     GeneralSteps generalSteps;
 
+    @Steps
+    AdminSteps adminSteps;
+
     @Given("^I am logged in as an admin$")
     public void i_am_logged_in_as_an_admin() {
         generalSteps.login("admin", "admin");
+    }
+
+    @When("^I am on the COS page$")
+    public void i_am_on_the_cos_page() {
+        generalSteps.navigateToDraftPage();
+        generalSteps.clickLinkAssertTitle(".cosLink", "Category of Service");
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -60,4 +60,10 @@ public class AdminStepDefinitions {
         i_am_on_the_view_enrollment_organization_info_page();
         generalSteps.clickLinkAssertTitle(".license", "Facility Credentials");
     }
+
+    @When("^I am on the View Enrollment Individual Member Info page$")
+    public void i_am_on_the_view_enrollment_individual_member_info_page() {
+        i_am_on_the_view_enrollment_organization_info_page();
+        generalSteps.clickLinkAssertTitle(".practice", "Member Information");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -29,6 +29,13 @@ public class AdminStepDefinitions {
         generalSteps.clickLinkAssertTitle(".cosLink", "Category of Service");
     }
 
+    @When("^I am on the Print Enrollment page$")
+    public void i_am_on_the_print_enrollment_page() {
+        generalSteps.navigateToDraftPage();
+        // assert fails because print page is opened in a new window
+        generalSteps.clickLinkAssertTitle(".printEnrollment", "View Enrollment");
+    }
+
     @When("^I am on the Review Enrollment page$")
     public void i_am_on_the_review_enrollment_page() {
         generalSteps.navigateToPendingPage();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
@@ -2,6 +2,8 @@ package gov.medicaid.features.service_admin.steps;
 
 import gov.medicaid.features.PsmPage;
 import net.thucydides.core.annotations.Step;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,5 +16,13 @@ public class AdminSteps {
     public void openWriteNoteModal() {
         psmPage.click$(".writeNotes");
         assertThat(psmPage.$("#writeNotesModal h2").getText().contains("Write Notes"));
+    }
+
+    @Step
+    public void advanceFromPendingPageToViewOrganizationInfoPage() {
+        WebElement row = psmPage.getTableRowForProviderType("Head Start");
+        WebElement viewLink = row.findElement(By.className("viewLink"));
+        psmPage.click(viewLink);
+        assertThat(psmPage.getTitle().contains("Organization Information"));
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
@@ -1,0 +1,18 @@
+package gov.medicaid.features.service_admin.steps;
+
+import gov.medicaid.features.PsmPage;
+import net.thucydides.core.annotations.Step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("unused")
+public class AdminSteps {
+
+    private PsmPage psmPage;
+
+    @Step
+    public void openWriteNoteModal() {
+        psmPage.click$(".writeNotes");
+        assertThat(psmPage.$("#writeNotesModal h2").getText().contains("Write Notes"));
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ViewEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ViewEnrollmentStepDefinitions.java
@@ -1,0 +1,44 @@
+package gov.medicaid.features.service_admin.steps;
+
+import cucumber.api.java.en.When;
+import gov.medicaid.features.general.steps.GeneralSteps;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class ViewEnrollmentStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Steps
+    AdminSteps adminSteps;
+
+    @When("^I am on the View Enrollment Organization Info page$")
+    public void i_am_on_the_view_enrollment_organization_info_page() {
+        generalSteps.navigateToPendingPage();
+        adminSteps.advanceFromPendingPageToViewOrganizationInfoPage();
+    }
+
+    @When("^I am on the View Enrollment Facility Credentials page$")
+    public void i_am_on_the_view_enrollment_facility_credentials_page() {
+        i_am_on_the_view_enrollment_organization_info_page();
+        generalSteps.clickLinkAssertTitle(".license", "Facility Credentials");
+    }
+
+    @When("^I am on the View Enrollment Individual Member Info page$")
+    public void i_am_on_the_view_enrollment_individual_member_info_page() {
+        i_am_on_the_view_enrollment_organization_info_page();
+        generalSteps.clickLinkAssertTitle(".practice", "Member Information");
+    }
+
+    @When("^I am on the View Enrollment Ownership Info page$")
+    public void i_am_on_the_view_enrollment_ownership_info_page() {
+        i_am_on_the_view_enrollment_organization_info_page();
+        generalSteps.clickLinkAssertTitle(".ownerShip", "Ownership Information");
+    }
+
+    @When("^I am on the View Enrollment Provider Statement page$")
+    public void i_am_on_the_view_enrollment_provider_statement_page() {
+        i_am_on_the_view_enrollment_organization_info_page();
+        generalSteps.clickLinkAssertTitle(".provider", "Provider Statement");
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ViewEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ViewEnrollmentStepDefinitions.java
@@ -33,7 +33,7 @@ public class ViewEnrollmentStepDefinitions {
     @When("^I am on the View Enrollment Ownership Info page$")
     public void i_am_on_the_view_enrollment_ownership_info_page() {
         i_am_on_the_view_enrollment_organization_info_page();
-        generalSteps.clickLinkAssertTitle(".ownerShip", "Ownership Information");
+        generalSteps.clickLinkAssertTitle(".ownership", "Ownership Information");
     }
 
     @When("^I am on the View Enrollment Provider Statement page$")

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-individual.feature
@@ -56,9 +56,9 @@ Feature: Individual Enrollment Steps Accessibility Checks
     And I am on the individual provider statement page
     Then I should have no accessibility issues
 
-  Scenario: Submit Enrollment Modal
+  Scenario: Individual Submit Enrollment Modal
     Given I have started an enrollment
     And I am on the individual provider statement page
-    When I enter my provider statement
+    When I enter my individual provider statement
     And I submit the enrollment
     Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/accessibility-organization.feature
@@ -47,3 +47,10 @@ Feature: Organization Enrollment Steps Accessibility Checks
     Given I have started an enrollment
     When I am on the organization provider statement page
     Then I should have no accessibility issues
+
+  Scenario: Organization Submit Enrollment Modal
+    Given I have started an enrollment
+    And I am on the organization provider statement page
+    When I enter my organization provider statement
+    And I submit the enrollment
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
@@ -61,6 +61,6 @@ Feature: Data Coverage Checks
   Scenario: Completes an application
     Given I have started an enrollment
     And I am on the individual provider statement page
-    When I enter my provider statement
+    When I enter my individual provider statement
     And I submit the enrollment
     Then the enrollment is successfully submitted

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -48,6 +48,13 @@ Feature: General Accessibility Checks for Admins
     And I am on the COS page
     Then I should have no accessibility issues
 
+  # fails: print page is opened in a new window
+  @ignore
+  Scenario: Admin Print Enrollment Page
+    Given I am logged in as an admin
+    And I am on the Print Enrollment page
+    Then I should have no accessibility issues
+
   Scenario: Admin Review Enrollment Page
     Given I am logged in as an admin
     And I am on the Review Enrollment page

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -47,3 +47,8 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the COS page
     Then I should have no accessibility issues
+
+  Scenario: Admin Review Enrollment Page
+    Given I am logged in as an admin
+    And I am on the Review Enrollment page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -66,28 +66,3 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the Screening Log page
     Then I should have no accessibility issues
-
-  Scenario: Admin View Enrollment Organization Info Page
-    Given I am logged in as an admin
-    And I am on the View Enrollment Organization Info page
-    Then I should have no accessibility issues
-
-  Scenario: Admin View Enrollment Facility Credentials Page
-    Given I am logged in as an admin
-    And I am on the View Enrollment Facility Credentials page
-    Then I should have no accessibility issues
-
-  Scenario: Admin View Enrollment Individual Member Info Page
-    Given I am logged in as an admin
-    And I am on the View Enrollment Individual Member Info page
-    Then I should have no accessibility issues
-
-  Scenario: Admin View Enrollment Ownership Info Page
-    Given I am logged in as an admin
-    And I am on the View Enrollment Ownership Info page
-    Then I should have no accessibility issues
-
-  Scenario: Admin View Enrollment Provider Statement Page
-    Given I am logged in as an admin
-    And I am on the View Enrollment Provider Statement page
-    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -39,3 +39,10 @@ Feature: General Accessibility Checks for Admins
     And I am on the Notes page
     And I open the filter panel
     Then I should have no accessibility issues
+
+  # fails: COS input field needs label or title
+  @ignore
+  Scenario: Admin COS Page
+    Given I am logged in as an admin
+    And I am on the COS page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -76,3 +76,8 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the View Enrollment Facility Credentials page
     Then I should have no accessibility issues
+
+  Scenario: Admin View Enrollment Individual Member Info Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Individual Member Info page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -38,6 +38,7 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the Notes page
     And I open the filter panel
+    And I open the Write Note modal
     Then I should have no accessibility issues
 
   # fails: COS input field needs label or title

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -66,3 +66,8 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the Screening Log page
     Then I should have no accessibility issues
+
+  Scenario: Admin View Enrollment Organization Info Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Organization Info page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -86,3 +86,8 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the View Enrollment Ownership Info page
     Then I should have no accessibility issues
+
+  Scenario: Admin View Enrollment Provider Statement Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Provider Statement page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -52,3 +52,10 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the Review Enrollment page
     Then I should have no accessibility issues
+
+  # fails: page is opened in a separate tab
+  @ignore
+  Scenario: Admin Screening Log Page
+    Given I am logged in as an admin
+    And I am on the Screening Log page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -71,3 +71,8 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the View Enrollment Organization Info page
     Then I should have no accessibility issues
+
+  Scenario: Admin View Enrollment Facility Credentials Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Facility Credentials page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -81,3 +81,8 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the View Enrollment Individual Member Info page
     Then I should have no accessibility issues
+
+  Scenario: Admin View Enrollment Ownership Info Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Ownership Info page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_view_enrollment.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_view_enrollment.feature
@@ -1,0 +1,28 @@
+@accessibility
+Feature: View Enrollment Accessibility Checks for Admins
+  Users wish to access accessible pages
+    
+  Scenario: Admin View Enrollment Organization Info Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Organization Info page
+    Then I should have no accessibility issues
+
+  Scenario: Admin View Enrollment Facility Credentials Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Facility Credentials page
+    Then I should have no accessibility issues
+
+  Scenario: Admin View Enrollment Individual Member Info Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Individual Member Info page
+    Then I should have no accessibility issues
+
+  Scenario: Admin View Enrollment Ownership Info Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Ownership Info page
+    Then I should have no accessibility issues
+
+  Scenario: Admin View Enrollment Provider Statement Page
+    Given I am logged in as an admin
+    And I am on the View Enrollment Provider Statement page
+    Then I should have no accessibility issues


### PR DESCRIPTION
Add accessibility tests for the admin view enrollment pages (for organizations) and other pages including review pages.

The changes in this PR are on top of those in the current version of PR #679. No need to review until #679 lands on master and this is then rebased on master. (The new commits start with "Add a11y test for admin 'Category of Service' (COS) page".)

Tested by running the tests. Those that are not ignored (@ignore) pass successfully, and the ones that are ignored would fail with an accessibility issue.  They may fail on Jenkins until we resolve the issues raised by @jasonaowen [here](https://github.com/SolutionGuidance/psm/pull/679#issuecomment-367395675).

Here are some screenshots of the color contrast issue that was fixed (text needed to be darker in error messages).

Before:

![screenshot-2018-2-21 review enrollment 1](https://user-images.githubusercontent.com/1091693/36555503-2ef00492-17d0-11e8-995b-2a9d92f67ba7.png)

After:

![screenshot-2018-2-21 review enrollment](https://user-images.githubusercontent.com/1091693/36555492-2698467e-17d0-11e8-8796-726641135866.png)


Issue #518 Implement accessibility checking in CI