### PR TITLE
Fix a11y color contrast issue with red error text

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -39,7 +39,7 @@
               </div>
               <c:choose>
               <c:when test="${empty profiles}">
-                <div style="color: red" class="noData">No matched data found.</div>
+                <div class="noData">No matched data found.</div>
               </c:when>
               <c:otherwise>
                 <table cellpadding="0" cellspacing="0" class="generalTable fixedWidthTable">
@@ -103,7 +103,7 @@
                 <div class="panelSection">
                   <c:choose>
                   <c:when test="${empty notifications}">
-                    <div style="color: red" class="noData">No matched data found.</div>
+                    <div class="noData">No matched data found.</div>
                   </c:when>
                   <c:otherwise>
                     <ul>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/error.jsp
@@ -25,7 +25,7 @@
           </div>
           <div class="clearFixed"></div>
           <div class="dashboardPanel">
-            <p style="color: red">This is a generic error page. If you are seeing this, the PSM controller
+            <p class="red">This is a generic error page. If you are seeing this, the PSM controller
             experienced an error while processing this request. The detailed error message will be present
             in the log files for debugging purposes.</p>
           </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -100,7 +100,7 @@
                     <div class="tableContainer"></div>
                     <div class="tabFoot">
                       <div class="tabR">
-                        <div class="tabM" style="color: red">
+                        <div class="tabM red">
                           No matched data found.
                         </div>
                       </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -81,7 +81,7 @@
                   <div class="tableContainer"></div>
                   <div class="tabFoot">
                     <div class="tabR">
-                      <div class="tabM" style="color: red">
+                      <div class="tabM red">
                         No matched data found.
                       </div>
                     </div>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -513,7 +513,7 @@ input.date{
   margin:0 5px;
 }
 .red{
-  color:#ff1010;
+  color: #d00;
 }
 .tabContent .tabFoot{
   background:url(../i/tab-bottom.png) no-repeat left top;
@@ -3660,9 +3660,6 @@ a.okBtn {
   padding:20px 0 30px 0;
   text-align:center;
 }
-.red{
-  color: red;
-}
 #approveModal .buttons .saveBtn,#rejectOKModal .buttons .saveBtn,#screenModal .buttons .saveBtn{
   margin:0 10px 0 210px;
 }
@@ -3986,6 +3983,7 @@ input.text{
 }
 .noData{
   padding: 3px;
+  color: #d00;
 }
 .disabledBtn{
   color: gray;
@@ -4014,7 +4012,7 @@ input.text{
   width: 110px;
 }
 form .error{
-  color: red;
+  color: #d00;
 }
 
 /* END OF SERVICE ADMIN STYLES -------------------------------------------------- */
@@ -4954,7 +4952,7 @@ select.stateSelect, select.stateSelectFor {
 }
 
 .legacyInfo {
-  color: red;
+  color: #d00;
 }
 
 .checkboxLabel,


### PR DESCRIPTION
A red of `#ee0000` ("red") is too light on a white background, per the WCAG2AA a11y standard, so use `#dd0000` a slightly darker one.  It's a subtle difference, but does the trick.

Before:

![screenshot-2018-2-22 dashboard](https://user-images.githubusercontent.com/1091693/36560534-fb5dd44c-17de-11e8-9a23-d9e4a4e0ca7b.png)

After:

![screenshot-2018-2-22 dashboard 1](https://user-images.githubusercontent.com/1091693/36560541-fea963aa-17de-11e8-9a70-2bf72f147c76.png)


Tested by running the axe-core browser add-on on the admin dashboard page with an empty database and confirming that the darker red solves the contrast issue.

Issue #467 Improve ADA compliance