### PR TITLE
Add a11y tests for service admin Functions pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -172,7 +172,7 @@
                                 <span class="sep">|</span>
                                 <c:choose>
                                 <c:when test="${item.canDelete}"><a rel="${item.id}" href="javascript:;" class="deleteAgreementDocumentBtn">Delete</a></c:when>
-                                <c:otherwise><a style="text-decoration: none;color: gray" href="javascript:;" class="disabledBtn">Delete</a></c:otherwise>
+                                <c:otherwise><a href="javascript:;" class="disabledBtn">Delete</a></c:otherwise>
                                 </c:choose>
                               </td>
                             </tr>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="Agreements & Addendums - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="Create Provider Type - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="Edit Agreement Document - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_help_item.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_help_item.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="Edit Help Topic - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="Edit Provider Type - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="Edit Screening Schedule - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_help_items.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_help_items.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="Help Topics - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="Provider Types - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
@@ -132,7 +132,7 @@
                               <span class="sep">|</span>
                               <c:choose>
                               <c:when test="${item.canDelete}"><a rel="${item.code}" href="javascript:;" class="deleteProviderTypeBtn">Delete</a></c:when>
-                              <c:otherwise><a style="text-decoration: none;color: gray" href="javascript:;" class="disabledBtn">Delete</a></c:otherwise>
+                              <c:otherwise><a href="javascript:;" class="disabledBtn">Delete</a></c:otherwise>
                               </c:choose>
                             </td>
                           </tr>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="View Agreement Document - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_help_item.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_help_item.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="View Help Topic - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
@@ -37,7 +37,7 @@
                   <c:choose>
                   <c:when test="${providerType.canDelete}"><a href="javascript:;" rel="${providerType.code}" class="greyBtn deleteProviderTypesOnViewBtn">Delete</a></c:when>
                   <c:otherwise>
-                  <a href="javascript:;"  style="text-decoration: none;color: gray;cursor: default;" class="greyBtn disabledBtn">Delete</a>
+                  <a href="javascript:;" class="greyBtn disabledBtn">Delete</a>
                   </c:otherwise>
                   </c:choose>
                   <a href="${ctx}/admin/beginEditProviderType?providerTypeId=${providerType.code}" class="purpleBtn editProviderLink">Edit</a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="View Provider Type - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
@@ -9,7 +9,7 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-  <c:set var="title" value="Functions (Service Admin)"/>
+  <c:set var="title" value="Screening Schedules - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -3986,12 +3986,12 @@ input.text{
   color: #d00;
 }
 .disabledBtn{
-  color: gray;
+  color: #707070;
   cursor: default;
   text-decoration: none;
 }
 .pagination-page-number-disabled{
-  color: gray;
+  color: #707070;
   cursor: default;
 }
 .generalTable th span.sort-down{

--- a/psm-app/cms-web/WebContent/templates/admin/includes/functions_service_nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/includes/functions_service_nav.template.html
@@ -2,10 +2,10 @@
 <div class="tabHead">
   <div class="tabR">
     <div class="tabM">
-      <a class="tab first {{#if functionsServiceActiveMenuProviderTypes}} active {{/if}}" href="{{ctx}}/admin/viewProviderTypes"><span class="aR"><span class="aM">Provider Types</span></span></a>
-      <a class="tab {{#if functionsServiceActiveMenuScreeningSchedules}} active {{/if}}" href="{{ctx}}/admin/getScreeningSchedule"><span class="aR"><span class="aM">Screening Schedules</span></span></a>
-      <a class="tab {{#if functionsServiceActiveMenuHelpTopics}} active {{/if}}" href="{{ctx}}/admin/searchHelp"><span class="aR"><span class="aM">Help Topics</span></span></a>
-      <a class="tab {{#if functionsServiceActiveMenuAgreement}} active {{/if}}" href="{{ctx}}/admin/viewAgreementDocuments"><span class="aR"><span class="aM">Agreements &amp; Addendums</span></span></a>
+      <a class="tab providerTypesTab first {{#if functionsServiceActiveMenuProviderTypes}} active {{/if}}" href="{{ctx}}/admin/viewProviderTypes"><span class="aR"><span class="aM">Provider Types</span></span></a>
+      <a class="tab screeningSchedulesTab {{#if functionsServiceActiveMenuScreeningSchedules}} active {{/if}}" href="{{ctx}}/admin/getScreeningSchedule"><span class="aR"><span class="aM">Screening Schedules</span></span></a>
+      <a class="tab helpTopicsTab {{#if functionsServiceActiveMenuHelpTopics}} active {{/if}}" href="{{ctx}}/admin/searchHelp"><span class="aR"><span class="aM">Help Topics</span></span></a>
+      <a class="tab agreementsAddendumsTab {{#if functionsServiceActiveMenuAgreement}} active {{/if}}" href="{{ctx}}/admin/viewAgreementDocuments"><span class="aR"><span class="aM">Agreements &amp; Addendums</span></span></a>
       {{#if functionsServiceActiveMenuProviderTypes }}<a href="{{ctx}}/admin/beginCreateProviderType" class="purpleBtn addProviderBtn">Add Provider Type</a>{{/if}}
     </div>
   </div>

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -20,7 +20,7 @@
 
           {{#if isServiceAdministrator}}
           <li class="{{#if activeTab4 }} active {{/if}}">
-            <a href="{{ctx}}/admin/viewProviderTypes">FUNCTIONS</a>
+            <a class="functionsLink" href="{{ctx}}/admin/viewProviderTypes">FUNCTIONS</a>
             {{#if activeTab4 }} <span class="arrow"></span> {{/if}}
           </li>
           {{/if}}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -64,4 +64,10 @@ public class FunctionsStepDefinitions {
         i_am_on_the_functions_agreements_and_addendums_page();
         generalSteps.clickLinkAssertTitle(".editAgreementLink", "Edit Agreement Document - Functions (Service Admin)");
     }
+
+    @When("^I am on the Functions View Agreement Document page$")
+    public void i_am_on_the_functions_view_agreement_document_page() {
+        i_am_on_the_functions_agreements_and_addendums_page();
+        generalSteps.clickLinkAssertTitle(".viewAgreementLink", "View Agreement Document - Functions (Service Admin)");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -52,4 +52,10 @@ public class FunctionsStepDefinitions {
         i_am_on_the_functions_provider_types_page();
         generalSteps.clickLinkAssertTitle(".agreementsAddendumsTab", "Agreements & Addendums - Functions (Service Admin)");
     }
+
+    @When("^I am on the Functions Edit Agreement Document page$")
+    public void i_am_on_the_functions_edit_agreement_document_page() {
+        i_am_on_the_functions_agreements_and_addendums_page();
+        generalSteps.clickLinkAssertTitle(".editAgreementLink", "Edit Agreement Document - Functions (Service Admin)");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -53,6 +53,12 @@ public class FunctionsStepDefinitions {
         generalSteps.clickLinkAssertTitle(".agreementsAddendumsTab", "Agreements & Addendums - Functions (Service Admin)");
     }
 
+    @When("^I am on the Functions Add Agreement Document page$")
+    public void i_am_on_the_functions_add_agreement_document_page() {
+        i_am_on_the_functions_agreements_and_addendums_page();
+        generalSteps.clickLinkAssertTitle(".addAgreementBtn", "Edit Agreement Document - Functions (Service Admin)");
+    }
+
     @When("^I am on the Functions Edit Agreement Document page$")
     public void i_am_on_the_functions_edit_agreement_document_page() {
         i_am_on_the_functions_agreements_and_addendums_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -16,4 +16,10 @@ public class FunctionsStepDefinitions {
     public void i_am_on_the_functions_provider_types_page() {
         generalSteps.clickLinkAssertTitle(".functionsLink", "Provider Types - Functions (Service Admin)");
     }
+
+    @When("^I am on the Functions Screening Schedules page$")
+    public void i_am_on_the_functions_screening_schedules_page() {
+        i_am_on_the_functions_provider_types_page();
+        generalSteps.clickLinkAssertTitle(".screeningSchedulesTab", "Screening Schedules - Functions (Service Admin)");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -23,6 +23,12 @@ public class FunctionsStepDefinitions {
         generalSteps.clickLinkAssertTitle(".viewProviderLink", "View Provider Type - Functions (Service Admin)");
     }
 
+    @When("^I am on the Functions Edit Provider Type page$")
+    public void i_am_on_the_functions_edit_provider_type_page() {
+        i_am_on_the_functions_provider_types_page();
+        generalSteps.clickLinkAssertTitle(".editProviderLink", "Edit Provider Type - Functions (Service Admin)");
+    }
+
     @When("^I am on the Functions Screening Schedules page$")
     public void i_am_on_the_functions_screening_schedules_page() {
         i_am_on_the_functions_provider_types_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -28,4 +28,10 @@ public class FunctionsStepDefinitions {
         i_am_on_the_functions_provider_types_page();
         generalSteps.clickLinkAssertTitle(".helpTopicsTab", "Help Topics - Functions (Service Admin)");
     }
+
+    @When("^I am on the Functions Agreements and Addendums page$")
+    public void i_am_on_the_functions_agreements_and_addendums_page() {
+        i_am_on_the_functions_provider_types_page();
+        generalSteps.clickLinkAssertTitle(".agreementsAddendumsTab", "Agreements & Addendums - Functions (Service Admin)");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -17,6 +17,12 @@ public class FunctionsStepDefinitions {
         generalSteps.clickLinkAssertTitle(".functionsLink", "Provider Types - Functions (Service Admin)");
     }
 
+    @When("^I am on the Functions View Provider Type page$")
+    public void i_am_on_the_functions_view_provider_type_page() {
+        i_am_on_the_functions_provider_types_page();
+        generalSteps.clickLinkAssertTitle(".viewProviderLink", "View Provider Type - Functions (Service Admin)");
+    }
+
     @When("^I am on the Functions Screening Schedules page$")
     public void i_am_on_the_functions_screening_schedules_page() {
         i_am_on_the_functions_provider_types_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -35,6 +35,12 @@ public class FunctionsStepDefinitions {
         generalSteps.clickLinkAssertTitle(".screeningSchedulesTab", "Screening Schedules - Functions (Service Admin)");
     }
 
+    @When("^I am on the Functions Edit Screening Schedule page$")
+    public void i_am_on_the_functions_edit_screening_schedule_page() {
+        i_am_on_the_functions_screening_schedules_page();
+        generalSteps.clickLinkAssertTitle(".changeScheduleBtn", "Edit Screening Schedule - Functions (Service Admin)");
+    }
+
     @When("^I am on the Functions Help Topics page$")
     public void i_am_on_the_functions_help_topics_page() {
         i_am_on_the_functions_provider_types_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -22,4 +22,10 @@ public class FunctionsStepDefinitions {
         i_am_on_the_functions_provider_types_page();
         generalSteps.clickLinkAssertTitle(".screeningSchedulesTab", "Screening Schedules - Functions (Service Admin)");
     }
+
+    @When("^I am on the Functions Help Topics page$")
+    public void i_am_on_the_functions_help_topics_page() {
+        i_am_on_the_functions_provider_types_page();
+        generalSteps.clickLinkAssertTitle(".helpTopicsTab", "Help Topics - Functions (Service Admin)");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -1,0 +1,19 @@
+package gov.medicaid.features.service_admin.steps;
+
+import cucumber.api.java.en.When;
+import gov.medicaid.features.general.steps.GeneralSteps;
+import net.thucydides.core.annotations.Steps;
+
+@SuppressWarnings("unused")
+public class FunctionsStepDefinitions {
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Steps
+    AdminSteps adminSteps;
+
+    @When("^I am on the Functions Provider Types page$")
+    public void i_am_on_the_functions_provider_types_page() {
+        generalSteps.clickLinkAssertTitle(".functionsLink", "Provider Types - Functions (Service Admin)");
+    }
+}

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -16,3 +16,8 @@ Feature: Admin Functions Tab Pages
     Given I am logged in as an admin
     And I am on the Functions Help Topics page
     Then I should have no accessibility issues
+
+  Scenario: Admin Functions Agreements and Addendums Page
+    Given I am logged in as an admin
+    And I am on the Functions Agreements and Addendums page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -36,3 +36,10 @@ Feature: Admin Functions Tab Pages
     Given I am logged in as an admin
     And I am on the Functions Agreements and Addendums page
     Then I should have no accessibility issues
+
+  # fails: iframe elements need a title attribute
+  @ignore
+  Scenario: Admin Functions Edit Agreement Document Page
+    Given I am logged in as an admin
+    And I am on the Functions Edit Agreement Document page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -6,3 +6,8 @@ Feature: Admin Functions Tab Pages
     Given I am logged in as an admin
     And I am on the Functions Provider Types page
     Then I should have no accessibility issues
+
+  Scenario: Admin Functions Screening Schedules Page
+    Given I am logged in as an admin
+    And I am on the Functions Screening Schedules page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -22,6 +22,11 @@ Feature: Admin Functions Tab Pages
     And I am on the Functions Screening Schedules page
     Then I should have no accessibility issues
 
+  Scenario: Admin Functions Edit Screening Schedule Page
+    Given I am logged in as an admin
+    And I am on the Functions Edit Screening Schedule page
+    Then I should have no accessibility issues
+
   Scenario: Admin Functions Help Topics Page
     Given I am logged in as an admin
     And I am on the Functions Help Topics page

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -1,0 +1,8 @@
+@accessibility
+Feature: Admin Functions Tab Pages
+  Users wish to access accessible pages
+
+  Scenario: Admin Functions Provider Types Page
+    Given I am logged in as an admin
+    And I am on the Functions Provider Types page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -50,3 +50,8 @@ Feature: Admin Functions Tab Pages
     Given I am logged in as an admin
     And I am on the Functions Edit Agreement Document page
     Then I should have no accessibility issues
+
+  Scenario: Admin Functions View Agreement Document Page
+    Given I am logged in as an admin
+    And I am on the Functions View Agreement Document page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -39,6 +39,13 @@ Feature: Admin Functions Tab Pages
 
   # fails: iframe elements need a title attribute
   @ignore
+  Scenario: Admin Functions Add Agreement Document Page
+    Given I am logged in as an admin
+    And I am on the Functions Add Agreement Document page
+    Then I should have no accessibility issues
+
+  # fails: iframe elements need a title attribute
+  @ignore
   Scenario: Admin Functions Edit Agreement Document Page
     Given I am logged in as an admin
     And I am on the Functions Edit Agreement Document page

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -11,3 +11,8 @@ Feature: Admin Functions Tab Pages
     Given I am logged in as an admin
     And I am on the Functions Screening Schedules page
     Then I should have no accessibility issues
+
+  Scenario: Admin Functions Help Topics Page
+    Given I am logged in as an admin
+    And I am on the Functions Help Topics page
+    Then I should have no accessibility issues

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -12,6 +12,11 @@ Feature: Admin Functions Tab Pages
     And I am on the Functions View Provider Type page
     Then I should have no accessibility issues
 
+  Scenario: Admin Functions Edit Provider Type Page
+    Given I am logged in as an admin
+    And I am on the Functions Edit Provider Type page
+    Then I should have no accessibility issues
+
   Scenario: Admin Functions Screening Schedules Page
     Given I am logged in as an admin
     And I am on the Functions Screening Schedules page

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility_functions.feature
@@ -7,6 +7,11 @@ Feature: Admin Functions Tab Pages
     And I am on the Functions Provider Types page
     Then I should have no accessibility issues
 
+  Scenario: Admin Functions View Provider Type Page
+    Given I am logged in as an admin
+    And I am on the Functions View Provider Type page
+    Then I should have no accessibility issues
+
   Scenario: Admin Functions Screening Schedules Page
     Given I am logged in as an admin
     And I am on the Functions Screening Schedules page


### PR DESCRIPTION
Add accessibility tests for the service admin Functions pages.

The changes in this PR are on top of those in the current version of PR #684. No need to review until #684 lands on master and this is then rebased on master. (The new commits start with "
Add a11y test for admin Functions "Provider Types" page".)

Tested by running the tests. Those that are not ignored (@ignore) pass successfully, and the ones that are ignored would fail with an accessibility issue. 

Issue #518 Implement accessibility checking in CI