### PR TITLE
Remove colons from general pages and filter panels

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -40,10 +40,6 @@
                   <div class="wholeCol">
                     <div class="row">
                       <label for="registerUsername">Username<span class="required">*</span></label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
-
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="username">
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
@@ -53,10 +49,6 @@
 
                     <div class="row">
                       <label for="registerFirstName">First Name<span class="required">*</span></label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
-
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="firstName">
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
@@ -65,10 +57,6 @@
                     </div>
                     <div class="row">
                       <label for="registerMiddleName">Middle Name</label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
-
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="middleName">
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
@@ -78,10 +66,6 @@
                     
                     <div class="row">
                       <label for="registerLastName">Last Name<span class="required">*</span></label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
-
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="lastName">
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
@@ -90,10 +74,6 @@
                     </div>
                     <div class="row">
                       <label for="registerEmail">Email<span class="required">*</span></label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
-
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="email">
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_filter_panel.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_filter_panel.jsp
@@ -1,9 +1,5 @@
 <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
-  - Description: it is used to render the enrollment search filter panel section.
+  The filter panel for: admin user login > Enrollments > Draft (Pending, Approved, Denied, etc.) pages.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <div id="enrollmentFilterPanel" <c:choose><c:when test="${searchCriteria.showFilterPanel}">style="display: block"</c:when><c:otherwise>style="display: none"</c:otherwise></c:choose> class="filterPanel">
@@ -11,12 +7,10 @@
         <div class="leftCol">
             <div class="row">
                 <label for="enrollmentSearchFilterNpiInput">NPI/UMPI</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="enrollmentSearchFilterNpiInput" type="text" class="normalInput" value="${searchCriteria.npi}"/>
             </div>
             <div class="row">
                 <label>Date Submitted</label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="submissionDateStartInput" title="Submission Date Start" value='<fmt:formatDate value="${searchCriteria.submissionDateStart}" pattern="MM/dd/yyyy"/>' class="date" type="text" readonly="readonly"/>
                 </span>
@@ -27,7 +21,6 @@
             </div>
             <div class="row">
                 <label for="enrollmentSearchFilterProviderTypeInput">Provider Type</label>
-                <span class="floatL"><b>:</b></span>
                 <select id="enrollmentSearchFilterProviderTypeInput" class="longSelect">
                     <option value="">All</option>
                     <c:forEach var="item" items="${providerTypesLookup}">
@@ -39,12 +32,10 @@
         <div class="rightCol">
             <div class="row">
                 <label for="enrollmentSearchFilterProviderNameInput">Provider Name</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="enrollmentSearchFilterProviderNameInput" value="${searchCriteria.providerName}" type="text" class="normalInput"/>
             </div>
             <div class="row">
                 <label for="enrollmentSearchFilterRequestTypeInput">Request Type</label>
-                <span class="floatL"><b>:</b></span>
                 <select id="enrollmentSearchFilterRequestTypeInput" class="longSelect">
                     <option value="">All</option>
                     <c:forEach var="item" items="${requestTypesLookup}">
@@ -54,7 +45,6 @@
             </div>
             <div class="row">
                 <label for="enrollmentSearchFilterRiskLevelInput">Risk Level</label>
-                <span class="floatL"><b>:</b></span>
                 <select id="enrollmentSearchFilterRiskLevelInput" class="longSelect">
                     <option value="">All</option>
                     <c:forEach var="item" items="${riskLevelsLookup}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/filter-panel.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/filter-panel.jsp
@@ -1,10 +1,5 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
- @author TCSASSEMBLER
- @version 1.0
-
- The filter panel jsp page.
+  The filter panel for the system admin login > User Accounts pages (Providers, Service Agents, etc.).
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <c:set var="cssClz" value="filterPanel show" />
@@ -16,24 +11,20 @@
         <div class="leftCol">
             <div class="row">
                 <label for="filterPanelUsername">Username</label>
-                <span class="floatL"><b>:</b></span>
                 <form:input id="filterPanelUsername" cssClass="normalInput" path="username" />
             </div>
             <div class="row">
                 <label for="filterPanelEmail">Email</label>
-                <span class="floatL"><b>:</b></span>
                 <form:input id="filterPanelEmail" cssClass="normalInput" path="email"/>
             </div>
         </div>
         <div class="rightCol">
             <div class="row">
                 <label for="filterPanelLastName">Last Name</label>
-                <span class="floatL"><b>:</b></span>
                 <form:input id="filterPanelLastName" cssClass="normalInput" path="lastName" />
             </div>
             <div class="row">
                 <label for="filterPanelFirstName">First Name</label>
-                <span class="floatL"><b>:</b></span>
                 <form:input id="filterPanelFirstName" cssClass="normalInput" path="firstName" />
             </div>
         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
@@ -42,10 +42,6 @@
                   <div class="wholeCol">
                     <div class="row">
                       <label for="forgotPasswordUsername">Username<span class="required">*</span></label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
-
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="username">
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>
@@ -54,10 +50,6 @@
                     </div>
                     <div class="row">
                       <label for="forgotPasswordEmail">Email<span class="required">*</span></label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
-
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="email">
                         <c:if test="${status.error}"><c:set var="errorCls" value="errorInput"/></c:if>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -37,15 +37,15 @@
               </c:if>
 
               <div class="row">
-                <label for="username" class="label">Username:</label>
+                <label for="username" class="label">Username</label>
                 <input id="username" name="username" type="text" class="text" value="${LAST_USERNAME}" maxlength="50"/>
               </div>
               <div class="row">
-                <label for="password" class="label">Password:</label>
+                <label for="password" class="label">Password</label>
                 <input id="password" type="password" name="password" />
               </div>
               <div class="row">
-                <label for="domain" class="label">Domain:</label>
+                <label for="domain" class="label">Domain</label>
                 <select id="domain" name="domain" onchange="disableElement('remember', this.value != 'CMS_ONLINE')">
                   <option value="CMS_ONLINE" selected="selected">Online Portal</option>
                   <option value="MN_ITS">MN-ITS</option>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
@@ -1,9 +1,6 @@
 <%--
-    JSP Fragment for provider dashboard filter.
-
-    @author j3_guile
-    @version 1.0
- --%>
+  The filter panel for the provider login > Dashboard page.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
@@ -20,12 +17,10 @@
         <div class="leftCol">
             <div class="row">
                 <label for="dashboardFilterNpi">NPI/UMPI</label>
-                <span class="floatL"><b>:</b></span>
                 <form:input id="dashboardFilterNpi" path="npi" cssClass="normalInput"/>
             </div>
             <div class="row">
                 <label for="dashboardFilterRequestTypes">Request Type</label>
-                <span class="floatL"><b>:</b></span>
                 <form:select id="dashboardFilterRequestTypes" path="requestTypes" cssClass="longSelect" multiple="false">
                     <form:option value="">All</form:option>
                     <form:option value="Enrollment">Enrollment</form:option>
@@ -36,7 +31,6 @@
             </div>
             <div class="row">
                 <label>Date Submitted</label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <form:input title="Submission Start" path="submissionDateStart" cssClass="date" readonly=""/>
                 </span>
@@ -49,7 +43,6 @@
         <div class="rightCol">
             <div class="row">
                 <label for="dashboardFilterStatuses">Status</label>
-                <span class="floatL"><b>:</b></span>
                 <form:select id="dashboardFilterStatuses" path="statuses" cssClass="longSelect" multiple="false">
                     <form:option value="">All</form:option>
                     <form:option value="Draft">Draft</form:option>
@@ -60,7 +53,6 @@
             </div>
             <div class="row">
                 <label for="dashboardFilterRiskLevel">Risk Level</label>
-                <span class="floatL"><b>:</b></span>
                 <form:select id="dashboardFilterRiskLevel" path="riskLevel" cssClass="longSelect">
                     <form:option value="">All</form:option>
                     <form:option value="NULL">Not screened yet</form:option>
@@ -71,7 +63,6 @@
             </div>
             <div class="row">
                 <label>Status Date</label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <form:input title="Status Start" path="statusDateStart" cssClass="date" readonly=""/>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -87,16 +87,10 @@
                     <div class="leftCol">
                       <div class="row">
                         <label for="listByStatusNpi">NPI/UMPI</label>
-                        <span class="floatL">
-                          <b>:</b>
-                        </span>
                         <form:input id="listByStatusNpi" path="npi" cssClass="normalInput"/>
                       </div>
                       <div class="row">
                         <label>Date Created</label>
-                        <span class="floatL">
-                          <b>:</b>
-                        </span>
                         <span class="dateWrapper floatL">
                           <form:input title="Create Start" path="createDateStart" cssClass="date" readonly=""/>
                         </span>
@@ -111,9 +105,6 @@
                     <div class="rightCol">
                       <div class="row">
                         <label for="listByStatusRequestTypes">Request Type</label>
-                        <span class="floatL">
-                          <b>:</b>
-                        </span>
                         <form:select id="listByStatusRequestTypes" path="requestTypes" cssClass="longSelect" multiple="false">
                           <form:option value="">All</form:option>
                           <form:option value="Enrollment">Enrollment</form:option>
@@ -124,9 +115,6 @@
                       </div>
                       <div class="row">
                         <label>Status Date</label>
-                        <span class="floatL">
-                          <b>:</b>
-                        </span>
                         <span class="dateWrapper floatL">
                           <form:input title="Status Start" path="statusDateStart" cssClass="date" readonly=""/>
                         </span>


### PR DESCRIPTION
Remove extraneous colons (see issue #376) on the following pages:
Non-logged in:
- login
- register new account
- forgot password

Removed from the 'filter' panels on these page:
Provider login:
- dashboard
- enrollments (draft, pending, etc.)

Service admin:
- dashboard
- enrollments (draft, pending, etc.)

System admin:
- user accounts pages

Tested by examining these pages to confirm that the colons are gone and there are no bad layout side-effects.

Issue #376 Remove colons between form labels and fields