### PR TITLE
Add 'View' link to Actions column in admin tables

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -124,7 +124,7 @@
                     <input type="checkbox" title="Enrollment ${item.ticketId}" class="enrollmentRowCheckBox" value="${item.ticketId}" />
                 </td>
                 <td>
-                    <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">${item.npi}</a>
+                  ${item.npi}
                 </td>
                 <td><fmt:formatDate value="${item.submissionDate}" pattern="MM/dd/yyyy"/></td>
                 <td>${item.providerType}</td>
@@ -159,8 +159,12 @@
                 <td class="alignCenter nopad">
                     <c:choose>
                         <c:when test="${fn:toLowerCase(item.status)=='pending'}">
+                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+                            View
+                          </a>
+                          <span class="sep">|</span>
+                          <a href="${ctx}/provider/enrollment/reopen?id=${item.ticketId}">Edit</a><span class="sep">|</span>
                         	<a href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">COS</a><span class="sep">|</span>
-                            <a href="${ctx}/provider/enrollment/reopen?id=${item.ticketId}">Edit</a><span class="sep">|</span>
                             <c:forEach var="task" items="${tasks}">
                                 <c:if test="${task.processInstanceId == item.processInstanceId}">
                                     <a href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}">Review</a><span class="sep">|</span>
@@ -168,14 +172,24 @@
                             </c:forEach>
                         </c:when>
                         <c:when test="${fn:toLowerCase(item.status)=='draft'}">
+                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">Edit</a><span class="sep">|</span>
                         	<a href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">COS</a><span class="sep">|</span>
-                            <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">Edit</a><span class="sep">|</span>
                         </c:when>
                         <c:when test="${fn:toLowerCase(item.status)=='approved'}">
+                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+                            View
+                          </a>
+                          <span class="sep">|</span>
+                          <a href="${ctx}/provider/profile/edit?profileId=${item.profileReferenceId}">Edit</a><span class="sep">|</span>
                         	<a href="${ctx}/agent/enrollment/cos?id=${item.profileReferenceId}">COS</a><span class="sep">|</span>
-                            <a href="${ctx}/provider/profile/edit?profileId=${item.profileReferenceId}">Edit</a><span class="sep">|</span>
                             <a href="${ctx}/provider/profile/renew?profileId=${item.profileReferenceId}">Renew</a><span class="sep">|</span>
                         </c:when>
+                        <c:otherwise>
+                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+                            View
+                          </a>
+                          <span class="sep">|</span>
+                        </c:otherwise>
                     </c:choose>
                     <a rel="${item.ticketId}" class="printEnrollment" href="javascript:;">Print</a><span class="sep">|</span>
                     <a href="${ctx}/provider/enrollment/exportTicket?id=${item.ticketId}">Export</a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -6,195 +6,282 @@
   - Description: it is used to render the enrollment search filter panel section.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
-<table id="${searchTableId}" cellpadding="0" cellspacing="0" class="generalTable fixedWidthTable ${active_enrollment_tab eq 'notes' ? 'table-enrollment-notes-sort' : ''}">
-    <colgroup>
-        <c:choose>
-	        <c:when test="${active_enrollment_tab=='notes'}">
-		        <col width="32">
-		        <col width="95">
-		        <col width="81">
-		        <col width="97">
-		        <col width="109">
-		        <col width="100">
-		        <col width="81">
-		        <col width="90">
-		        <col width="81">
-		        <col width="183">
-	        </c:when>
-	        <c:when test="${addStatusColumn=='yes'}">
-				<col width="27">
-				<col width="87">
-				<col width="112">
-				<col width="100">
-				<col width="115">
-				<col width="100">
-				<col width="65">
-				<col width="84">
-				<col width="90">
-				<col width="181">
-	        </c:when>
-	        <c:otherwise>
-                <col width="42">
-                <col width="109">
-                <col width="118">
-                <col width="107">
-                <col width="115">
-                <col width="106">
-                <col width="87">
-                <col width="96">
-                <col width="181">
-	        </c:otherwise>
-        </c:choose>
-    </colgroup>
-    <thead>
-        <tr>
-            <th class="alignCenter">
-                <input type="checkbox" title="Select All Enrollments" id="enrollmentSelectAll" name="enrollmentRowCheckBox" class="selectAll"/>
-                <span class="sep"></span>
-            </th>
-            <c:set var="sortFieldOfEntity" value="2"/>
-            <c:set var="sortColumnTitle" value="NPI/UMPI"/>
-            <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+<table
+  id="${searchTableId}"
+  cellpadding="0"
+  cellspacing="0"
+  class="generalTable fixedWidthTable ${active_enrollment_tab eq 'notes' ? 'table-enrollment-notes-sort' : ''}"
+  >
+  <colgroup>
+    <c:choose>
+      <c:when test="${active_enrollment_tab=='notes'}">
+        <col width="32"/>
+        <col width="95"/>
+        <col width="81"/>
+        <col width="97"/>
+        <col width="109"/>
+        <col width="100"/>
+        <col width="81"/>
+        <col width="90"/>
+        <col width="81"/>
+        <col width="183"/>
+      </c:when>
+      <c:when test="${addStatusColumn=='yes'}">
+        <col width="27"/>
+        <col width="87"/>
+        <col width="112"/>
+        <col width="100"/>
+        <col width="115"/>
+        <col width="100"/>
+        <col width="65"/>
+        <col width="84"/>
+        <col width="90"/>
+        <col width="181"/>
+      </c:when>
+      <c:otherwise>
+        <col width="42"/>
+        <col width="109"/>
+        <col width="118"/>
+        <col width="107"/>
+        <col width="115"/>
+        <col width="106"/>
+        <col width="87"/>
+        <col width="96"/>
+        <col width="181"/>
+      </c:otherwise>
+    </c:choose>
+  </colgroup>
 
+  <thead>
+    <tr>
+      <th class="alignCenter">
+        <input
+          type="checkbox"
+          title="Select All Enrollments"
+          id="enrollmentSelectAll"
+          name="enrollmentRowCheckBox"
+          class="selectAll"
+          />
+        <span class="sep"></span>
+      </th>
+      <c:set var="sortFieldOfEntity" value="2"/>
+      <c:set var="sortColumnTitle" value="NPI/UMPI"/>
+      <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+
+      <c:choose>
+        <c:when test="${active_enrollment_tab=='notes'}">
+          <th class="towline">
             <c:choose>
-                <c:when test="${active_enrollment_tab=='notes'}">
-                    <th class="towline">
-                        <c:choose>
-                            <c:when test="${searchCriteria.sortColumn == '3'}">
-                                <a class="sortable_column" rel="3" href="javascript:;"><span>Date<br />Submitted</span>
-                                    <c:choose>
-                                        <c:when test="${searchCriteria.ascending}">
-                                            <span class="sort-up"></span>
-                                        </c:when>
-                                        <c:otherwise>
-                                            <span class="sort-down"></span>
-                                        </c:otherwise>
-                                    </c:choose>
-                                </a>
-                            </c:when>
-                            <c:otherwise>
-                                <a class="sortable_column" rel="3" href="javascript:;"><span>Date<br />Submitted</span></a>
-                            </c:otherwise>
-                        </c:choose>
-                        <span class="sep"></span>
-                    </th>
-                </c:when>
-                <c:otherwise>
-                    <c:set var="sortFieldOfEntity" value="3"/>
-                    <c:set var="sortColumnTitle" value="Date Submitted"/>
-                    <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
-                </c:otherwise>
+              <c:when test="${searchCriteria.sortColumn == '3'}">
+                <a class="sortable_column" rel="3" href="javascript:;">
+                  <span>Date<br />Submitted</span>
+                  <c:choose>
+                    <c:when test="${searchCriteria.ascending}">
+                      <span class="sort-up"></span>
+                    </c:when>
+                    <c:otherwise>
+                      <span class="sort-down"></span>
+                    </c:otherwise>
+                  </c:choose>
+                </a>
+              </c:when>
+              <c:otherwise>
+                <a class="sortable_column" rel="3" href="javascript:;">
+                  <span>Date<br />Submitted</span>
+                </a>
+              </c:otherwise>
             </c:choose>
+            <span class="sep"></span>
+          </th>
+        </c:when>
+        <c:otherwise>
+          <c:set var="sortFieldOfEntity" value="3"/>
+          <c:set var="sortColumnTitle" value="Date Submitted"/>
+          <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+        </c:otherwise>
+      </c:choose>
+      <c:set var="sortFieldOfEntity" value="8"/>
+      <c:set var="sortColumnTitle" value="Provider Type"/>
+      <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
 
-            <c:set var="sortFieldOfEntity" value="8"/>
-            <c:set var="sortColumnTitle" value="Provider Type"/>
-            <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+      <c:set var="sortFieldOfEntity" value="9"/>
+      <c:set var="sortColumnTitle" value="Provider Name"/>
+      <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
 
-            <c:set var="sortFieldOfEntity" value="9"/>
-            <c:set var="sortColumnTitle" value="Provider Name"/>
-            <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+      <c:set var="sortFieldOfEntity" value="4"/>
+      <c:set var="sortColumnTitle" value="Request Type"/>
+      <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
 
-            <c:set var="sortFieldOfEntity" value="4"/>
-            <c:set var="sortColumnTitle" value="Request Type"/>
-            <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+      <c:if test="${addStatusColumn=='yes'}">
+        <c:set var="sortFieldOfEntity" value="5"/>
+        <c:set var="sortColumnTitle" value="Status"/>
+        <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+      </c:if>
 
-            <c:if test="${addStatusColumn=='yes'}">
-                <c:set var="sortFieldOfEntity" value="5"/>
-                <c:set var="sortColumnTitle" value="Status"/>
-                <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
-            </c:if>
+      <c:set var="sortFieldOfEntity" value="7"/>
+      <c:set var="sortColumnTitle" value="Risk Level"/>
+      <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
 
-            <c:set var="sortFieldOfEntity" value="7"/>
-            <c:set var="sortColumnTitle" value="Risk Level"/>
-            <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+      <c:set var="sortFieldOfEntity" value="6"/>
+      <c:set var="sortColumnTitle" value="Status Date"/>
+      <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+      <c:if test="${active_enrollment_tab=='notes'}">
+        <th class="alignCenter">Notes<span class="sep"></span></th>
+      </c:if>
+      <th class="alignCenter">Action</th>
+    </tr>
+  </thead>
 
-            <c:set var="sortFieldOfEntity" value="6"/>
-            <c:set var="sortColumnTitle" value="Status Date"/>
-            <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
-            <c:if test="${active_enrollment_tab=='notes'}">
-                <th class="alignCenter">Notes<span class="sep"></span></th>
-            </c:if>
-            <th class="alignCenter">Action</th>
-        </tr>
-    </thead>
-    <tbody>
-        <c:forEach var="item" items="${searchResult.items}">
-            <tr>
-                <td class="alignCenter">
-                    <input type="checkbox" title="Enrollment ${item.ticketId}" class="enrollmentRowCheckBox" value="${item.ticketId}" />
-                </td>
-                <td>
-                  ${item.npi}
-                </td>
-                <td><fmt:formatDate value="${item.submissionDate}" pattern="MM/dd/yyyy"/></td>
-                <td>${item.providerType}</td>
-                <td>${item.providerName}</td>
-                <td>${item.requestType}</td>
-                <c:if test="${addStatusColumn=='yes'}">
-                    <td>
-                        <c:choose>
-                            <c:when test="${fn:toLowerCase(item.status)=='approved'}"><span class="green">Approved</span></c:when>
-                            <c:when test="${fn:toLowerCase(item.status)=='rejected'}"><span class="red">Denied</span></c:when>
-                            <c:otherwise>${item.status}</c:otherwise>
-                         </c:choose>
-                    </td>
+  <tbody>
+    <c:forEach var="item" items="${searchResult.items}">
+      <tr>
+        <td class="alignCenter">
+          <input
+            type="checkbox"
+            title="Enrollment ${item.ticketId}"
+            class="enrollmentRowCheckBox"
+            value="${item.ticketId}"
+            />
+        </td>
+        <td>
+          ${item.npi}
+        </td>
+        <td>
+          <fmt:formatDate value="${item.submissionDate}" pattern="MM/dd/yyyy"/>
+        </td>
+        <td>${item.providerType}</td>
+        <td>${item.providerName}</td>
+        <td>${item.requestType}</td>
+        <c:if test="${addStatusColumn=='yes'}">
+          <td>
+            <c:choose>
+              <c:when test="${fn:toLowerCase(item.status)=='approved'}">
+                <span class="green">
+                  Approved
+                </span>
+              </c:when>
+              <c:when test="${fn:toLowerCase(item.status)=='rejected'}">
+                <span class="red">
+                  Denied
+                </span>
+              </c:when>
+              <c:otherwise>
+                ${item.status}
+              </c:otherwise>
+            </c:choose>
+          </td>
+        </c:if>
+        <c:choose>
+          <c:when test="${fn:toLowerCase(item.riskLevel)=='limited'}">
+            <td class="green">
+              Low
+            </td>
+          </c:when>
+          <c:when test="${fn:toLowerCase(item.riskLevel)=='high'}">
+            <td class="red">
+              High
+            </td>
+          </c:when>
+          <c:otherwise><td>${item.riskLevel}</td></c:otherwise>
+        </c:choose>
+        <td><fmt:formatDate value="${item.statusDate}" pattern="MM/dd/yyyy"/></td>
+        <c:if test="${active_enrollment_tab=='notes'}">
+          <td class="alignCenter">
+            <a
+              href="javascript:;"
+              rel="${item.ticketId}"
+              class="writeNotes"
+              >
+              Write
+            </a>
+            <span class="sep <c:if test="${!(fn:length(item.notes)>0)}">hide</c:if>">|</span>
+            <a
+              href="javascript:;"
+              rel="${item.ticketId}"
+              class='viewNotes<c:if test="${!(fn:length(item.notes)>0)}"> hide disabledLink</c:if>'
+              >
+              View
+            </a>
+            <div id="notesSection" class="hide">
+              <c:forEach var="noteItem" items="${item.notes}" varStatus="noteStatus">
+                <span
+                  class="note_${item.ticketId}"
+                  id="note_${item.ticketId}_${noteStatus.count}"
+                  >
+                  ${noteItem.text}
+                </span>
+              </c:forEach>
+            </div>
+          </td>
+        </c:if>
+        <td class="alignCenter nopad">
+          <c:choose>
+            <c:when test="${fn:toLowerCase(item.status)=='pending'}">
+              <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+                View
+              </a>
+              <span class="sep">|</span>
+              <a href="${ctx}/provider/enrollment/reopen?id=${item.ticketId}">
+                Edit
+              </a>
+              <span class="sep">|</span>
+              <a href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
+                COS
+              </a>
+              <span class="sep">|</span>
+              <c:forEach var="task" items="${tasks}">
+                <c:if test="${task.processInstanceId == item.processInstanceId}">
+                    <a href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}">
+                      Review
+                    </a>
+                    <span class="sep">|</span>
                 </c:if>
-                <c:choose>
-                    <c:when test="${fn:toLowerCase(item.riskLevel)=='limited'}"><td class="green">Low</td></c:when>
-                    <c:when test="${fn:toLowerCase(item.riskLevel)=='high'}"><td class="red">High</td></c:when>
-                    <c:otherwise><td>${item.riskLevel}</td></c:otherwise>
-                </c:choose>
-                <td><fmt:formatDate value="${item.statusDate}" pattern="MM/dd/yyyy"/></td>
-                <c:if test="${active_enrollment_tab=='notes'}">
-                    <td class="alignCenter">
-                        <a href="javascript:;" rel="${item.ticketId}" class="writeNotes">Write</a><span class="sep <c:if test="${!(fn:length(item.notes)>0)}">hide</c:if>">|</span>
-                        <a href="javascript:;" rel="${item.ticketId}" class='viewNotes<c:if test="${!(fn:length(item.notes)>0)}"> hide disabledLink</c:if>'>View</a>
-                        <div id="notesSection" class="hide">
-                            <c:forEach var="noteItem" items="${item.notes}" varStatus="noteStatus">
-                                <span class="note_${item.ticketId}" id="note_${item.ticketId}_${noteStatus.count}">${noteItem.text}</span>
-                            </c:forEach>
-                        </div>
-                    </td>
-                </c:if>
-                <td class="alignCenter nopad">
-                    <c:choose>
-                        <c:when test="${fn:toLowerCase(item.status)=='pending'}">
-                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
-                            View
-                          </a>
-                          <span class="sep">|</span>
-                          <a href="${ctx}/provider/enrollment/reopen?id=${item.ticketId}">Edit</a><span class="sep">|</span>
-                        	<a href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">COS</a><span class="sep">|</span>
-                            <c:forEach var="task" items="${tasks}">
-                                <c:if test="${task.processInstanceId == item.processInstanceId}">
-                                    <a href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}">Review</a><span class="sep">|</span>
-                                </c:if>
-                            </c:forEach>
-                        </c:when>
-                        <c:when test="${fn:toLowerCase(item.status)=='draft'}">
-                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">Edit</a><span class="sep">|</span>
-                        	<a href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">COS</a><span class="sep">|</span>
-                        </c:when>
-                        <c:when test="${fn:toLowerCase(item.status)=='approved'}">
-                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
-                            View
-                          </a>
-                          <span class="sep">|</span>
-                          <a href="${ctx}/provider/profile/edit?profileId=${item.profileReferenceId}">Edit</a><span class="sep">|</span>
-                        	<a href="${ctx}/agent/enrollment/cos?id=${item.profileReferenceId}">COS</a><span class="sep">|</span>
-                            <a href="${ctx}/provider/profile/renew?profileId=${item.profileReferenceId}">Renew</a><span class="sep">|</span>
-                        </c:when>
-                        <c:otherwise>
-                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
-                            View
-                          </a>
-                          <span class="sep">|</span>
-                        </c:otherwise>
-                    </c:choose>
-                    <a rel="${item.ticketId}" class="printEnrollment" href="javascript:;">Print</a><span class="sep">|</span>
-                    <a href="${ctx}/provider/enrollment/exportTicket?id=${item.ticketId}">Export</a>
-                </td>
-            </tr>
-        </c:forEach>
-    </tbody>
+              </c:forEach>
+            </c:when>
+            <c:when test="${fn:toLowerCase(item.status)=='draft'}">
+              <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+                Edit
+              </a>
+              <span class="sep">|</span>
+              <a href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
+                COS
+              </a>
+              <span class="sep">|</span>
+            </c:when>
+            <c:when test="${fn:toLowerCase(item.status)=='approved'}">
+              <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+                View
+              </a>
+              <span class="sep">|</span>
+              <a href="${ctx}/provider/profile/edit?profileId=${item.profileReferenceId}">
+                Edit
+              </a>
+              <span class="sep">|</span>
+              <a href="${ctx}/agent/enrollment/cos?id=${item.profileReferenceId}">
+                COS
+              </a>
+              <span class="sep">|</span>
+              <a href="${ctx}/provider/profile/renew?profileId=${item.profileReferenceId}">
+                Renew
+              </a>
+              <span class="sep">|</span>
+            </c:when>
+            <c:otherwise>
+              <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+                View
+              </a>
+              <span class="sep">|</span>
+            </c:otherwise>
+          </c:choose>
+          <a rel="${item.ticketId}" class="printEnrollment" href="javascript:;">
+            Print
+          </a>
+          <span class="sep">|</span>
+          <a href="${ctx}/provider/enrollment/exportTicket?id=${item.ticketId}">
+            Export
+          </a>
+        </td>
+      </tr>
+    </c:forEach>
+  </tbody>
 </table>

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -14,39 +14,29 @@ Feature: General Accessibility Checks
     Given I am on the Forgot Password page
     Then I should have no accessibility issues
 
-  # issue #672
-  @ignore
   Scenario: Provider Dashboard Page
     Given I am logged in as a provider
     When I open the filter panel
     Then I should have no accessibility issues
 
-  # issue #672
-  @ignore
   Scenario: Provider Draft Page
     Given I am logged in as a provider
     And I am on the Draft page
     When I open the filter panel
     Then I should have no accessibility issues
 
-  # issue #672
-  @ignore
   Scenario: Provider Pending Page
     Given I am logged in as a provider
     And I am on the Pending page
     When I open the filter panel
     Then I should have no accessibility issues
 
-  # issue #672
-  @ignore
   Scenario: Provider Approved Page
     Given I am logged in as a provider
     And I am on the Approved page
     When I open the filter panel
     Then I should have no accessibility issues
 
-  # issue #672
-  @ignore
   Scenario: Provider Denied Page
     Given I am logged in as a provider
     And I am on the Denied page

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -8,39 +8,31 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     Then I should have no accessibility issues
 
-  # issue #672
-  @ignore
   Scenario: Admin Draft Page
     Given I am logged in as an admin
     And I am on the Draft page
     And I open the filter panel
     Then I should have no accessibility issues
 
-  # issue #672
-  @ignore
   Scenario: Admin Pending Page
     Given I am logged in as an admin
     And I am on the Pending page
     And I open the filter panel
     Then I should have no accessibility issues
 
-  # issue #672
-  @ignore
   Scenario: Admin Approved Page
     Given I am logged in as an admin
     And I am on the Approved page
     And I open the filter panel
     Then I should have no accessibility issues
 
-  # issue #672
-  @ignore
   Scenario: Admin Denied Page
     Given I am logged in as an admin
     And I am on the Denied page
     And I open the filter panel
     Then I should have no accessibility issues
 
-  # fails: duplicate IDs and issue #672
+  # fails: duplicate IDs
   @ignore
   Scenario: Admin Notes Page
     Given I am logged in as an admin


### PR DESCRIPTION
Partially address issue #672 (e.g. the admin dashboard page is still affected).  Add a 'View' link to the Actions column in the tables on the admin Enrollments > Draft/Pending/Approved/Denied/Notes pages and the Advanced Search pages for admin and provider, and remove the links from the NPI number.

Before: 

![screenshot-2018-2-28 enrollment 3](https://user-images.githubusercontent.com/1091693/36815623-4bdd5162-1ca9-11e8-8780-17398a3f8fbc.png)


After:

![screenshot-2018-2-28 enrollment 2](https://user-images.githubusercontent.com/1091693/36815558-16b769aa-1ca9-11e8-9a7c-b7124a36b02d.png)


Tested by running the integration tests and the axe-core browser addon on those pages with a "Personal Care Assistant" (no NPI) in the database, confirming that the a11y issue was no longer present. Also checked manually that the new view links work and appear correctly.

The wrapping to two lines (which was occurring before) is tracked in issue #692 .

Issue #672 Empty link text for providers with no NPI