### PR TITLE
Specify language for accessibility of user help pages

### DIFF
--- a/psm-app/userhelp/source/conf.py
+++ b/psm-app/userhelp/source/conf.py
@@ -67,7 +67,9 @@ release = u'1.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# Setting the language here sets the 'lang' attribute of generated <html>
+# tags, which is needed for accessibility.
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Setting the language in conf.py gives the generated <html> tags a 'lang' attribute (on the user help pages), which is needed for accessibility.  

Tested by running the axe-core browser add-on on the user help pages to confirm that this accessibility issue no longer occurs.  

(Aside: there's another accessibility issue on the user help pages -- the search form is missing a label/title.  Possible fixes for that would be an upstream contribution to Sphinx or a local modification of the Sphinx theme we are using.)

Issue #467 Improve ADA Compliance