### PR TITLE
Remove colons from individual provider enrollment step pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
@@ -134,7 +134,6 @@
             <div class="row">
                 <label>Provider Name<span
                     class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName"
                     value="_08_name"></c:set>
                 <c:set var="formValue"
@@ -149,8 +148,6 @@
             <div class="row titleRow">
                 <label>Provider Title<span
                     class="required">*</span></label>
-                <span
-                    class="floatL"><b>:</b></span>
                 <c:set var="formName"
                     value="_08_title"></c:set>
                 <c:set var="formValue"
@@ -220,7 +217,6 @@
             <div class="row">
                 <label>Date<span
                     class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper">
                     <c:set var="formName"
                         value="_08_date"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
@@ -19,60 +19,62 @@
             <div class="row requireField">
                 <c:set var="formName" value="_02_firstName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="firstName">First Name</label>
-                <span class="floatL"><b>:</b></span>
+                <label for="firstName">
+                  First Name
+                  <span class="required">*</span>
+                </label>
                 <input type="text" class="normalInput" id="firstName" name="${formName}" value="${formValue}" maxlength="45"/>
-                <span class="required">*</span>
             </div>
             <div class="row">
                 <c:set var="formName" value="_02_middleName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="middleName">Middle Name</label>
-                <span class="floatL"><b>:</b></span>
                 <input type="text" class="normalInput" id="middleName" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_02_lastName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">Last Name</label>
-                <span class="floatL"><b>:</b></span>
+                <label for="${formIdPrefix}_${formName}">
+                  Last Name
+                  <span class="required">*</span>
+                </label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
-                <span class="required">*</span>
             </div>
             <div class="row requireField">
                 <%-- BUGR-9673 (optional NPI for some provider types) --%>
                 <c:set var="formName" value="_02_npi"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}"><abbr title="National Provider Identifier">NPI</abbr>
-                       <span><a href="javascript:" class="NPIdefinition">?</a></span>
+                <label for="${formIdPrefix}_${formName}">
+                  <abbr title="National Provider Identifier">NPI</abbr>
+                  <span class="required">${requireNPI ? '*' : ''}</span>
+                  <span><a href="javascript:" class="NPIdefinition">?</a></span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
-                <span class="required">${requireNPI ? '*' : ''}</span>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_02_ssn"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">Social Security Number</label>
-                <span class="floatL"><b>:</b></span>
+                <label for="${formIdPrefix}_${formName}">
+                  Social Security Number
+                  <span class="required">*</span>
+                </label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
-                <span class="required">*</span>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_02_dob"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">Date of Birth</label>
-                <span class="floatL"><b>:</b></span>
+                <label for="${formIdPrefix}_${formName}">
+                  Date of Birth
+                  <span class="required">*</span>
+                </label>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}" maxlength="10"/>
-                    <span class="required">*</span>
                 </span>
             </div>
             <div class="row">
                 <c:set var="formName" value="_02_email"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="emailAddress">Email Address</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="emailAddress" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="50"/>
             </div>
             <div class="clearFixed"></div>
@@ -97,23 +99,22 @@
             <div class="row requireField">
                 <c:set var="formName" value="_02_contactName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="contactName">Contact Name</label>
-                <span class="floatL"><b>:</b></span>
+                <label for="contactName">
+                  Contact Name
+                  <span class="required">*</span>
+                </label>
                 <input id="contactName" ${disableContact} type="text" class="${disableContact} normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
-                <span class="required">*</span>
             </div>
             <div class="row">
                 <c:set var="formName" value="_02_contactEmail"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="contactEmail">Contact Email Address</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="contactEmail" ${disableContact} type="text" class="${disableContact} normalInput" name="${formName}" value="${formValue}" maxlength="50"/>
             </div>
             <div class="row">
                 <c:set var="formName" value="_02_contactPhone1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label>Contact Phone Number</label>
-                <span class="floatL"><b>:</b></span>
                 <input ${disableContact}
                     id="contactPhone1"
                     type="text"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
@@ -52,14 +52,12 @@
                     <c:set var="formName" value="_06_name"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Primary Practice Name<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                 </div>
                 <div class="row">
                     <c:set var="formName" value="_06_npi"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Group NPI / UMPI<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                     <input id="unlinkPracticeButton" type="button" value="Remove Reference" onclick="unlinkPractice('_06_')" style="display: ${isLinked ? 'inline' : 'none'}"/>
                 </div>
@@ -67,14 +65,12 @@
                     <c:set var="formName" value="_06_stateMedicaidId"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">State Medicaid ID</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                 </div>
                 <div class="row">
                     <c:set var="formName" value="_06_effectiveDate"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Effective Date<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <span class="dateWrapper floatL">
                         <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}" maxlength="10"/>
                     </span>
@@ -83,27 +79,30 @@
                     <c:set var="formName" value="_06_addressLine1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Practice Address<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" title="Practice Address, Line 1" class="normalInput" name="${formName}" value="${formValue}" maxlength="28"/>
                 </div>
                 <div class="row inlineBox addressline2">
                     <span class="label">(Practice location cannot be<br />a PO Box)</span>
-                    <span class="floatL"><b>&nbsp;</b></span>
                     <c:set var="formName" value="_06_addressLine2"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input ${disableLinkedFields} type="text" title="Practice Address, Line 2" class="normalInput" name="${formName}" value="${formValue}" maxlength="28"/>
                 </div>
                 <div class="row inlineBox">
                     <span class="label">&nbsp;</span>
-                    <span class="floatL"><b>&nbsp;</b></span>
                     <c:set var="formName" value="_06_city"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span> : </label>
+                    <label for="${formIdPrefix}_${formName}" class="cityLabel">
+                      City
+                      <span class="required">*</span>
+                    </label>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text"  class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                     <c:set var="formName" value="_06_state"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">State<span class="required">*</span> : </label>
+                    <label for="${formIdPrefix}_${formName}">
+                      State
+                      <span class="required">*</span>
+                    </label>
                     <select id="${formIdPrefix}_${formName}" ${disableLinkedFields} class="stateSelectFor" name="${formName}">
                         <option value="">Please select</option>
                         <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -113,12 +112,17 @@
 
                     <c:set var="formName" value="_06_zip"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">ZIP Code<span class="required">*</span> : </label>
+                    <label for="${formIdPrefix}_${formName}">
+                      ZIP Code
+                      <span class="required">*</span>
+                    </label>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                     <c:set var="formName" value="_06_county"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">County : </label>
+                    <label for="${formIdPrefix}_${formName}">
+                      County
+                    </label>
                     <select id="${formIdPrefix}_${formName}" ${disableLinkedFields} class="countySelectFor" name="${formName}">
                         <option value="">Please select</option>
                         <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -128,7 +132,6 @@
                 </div>
                 <div class="row">
                     <label>Practice Phone Number<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <c:set var="formName" value="_06_phone1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input ${disableLinkedFields} type="text" title="Practice Phone Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -147,7 +150,6 @@
                 </div>
                 <div class="row">
                     <label>Practice Fax Number</label>
-                    <span class="floatL"><b>:</b></span>
                     <c:set var="formName" value="_06_fax1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input ${disableLinkedFields} type="text" title="Practice Fax Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -162,7 +164,6 @@
                 </div>
                 <div class="row reimbursementAddressRow">
                     <label>Reimbursement Address<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <div class="inputContainer">
                         <div class="checkboxWrapper">
                             <c:set var="formName" value="_06_reimbursementSameAsPrimary"></c:set>
@@ -188,12 +189,18 @@
                         <div class="addreddWrapper">
                             <c:set var="formName" value="_06_reimbursementCity"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <label for="${formIdPrefix}_${formName}" class="smallLabel">City<span class="required">*</span> : </label>
+                            <label for="${formIdPrefix}_${formName}" class="smallLabel">
+                              City
+                              <span class="required">*</span>
+                            </label>
                             <input id="${formIdPrefix}_${formName}" ${reimbursementAddressMarkup} type="text" class="${disableReimbursementAddress ? 'disabled' : '' } cityInput" name="${formName}" value="${formValue}" maxlength="20"/>
 
                             <c:set var="formName" value="_06_reimbursementState"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <label for="${formIdPrefix}_${formName}" class="smallLabel">State<span class="required">*</span> : </label>
+                            <label for="${formIdPrefix}_${formName}" class="smallLabel">
+                              State
+                              <span class="required">*</span>
+                            </label>
                             <select id="${formIdPrefix}_${formName}" ${reimbursementAddressMarkup} class="${disableReimbursementAddress ? 'disabled' : '' } stateSelect" name="${formName}">
                                 <option value="">Please select</option>
                                 <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -203,7 +210,10 @@
 
                             <c:set var="formName" value="_06_reimbursementZip"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <label for="${formIdPrefix}_${formName}" class="smallLabel">ZIP Code<span class="required">*</span> : </label>
+                            <label for="${formIdPrefix}_${formName}" class="smallLabel">
+                              ZIP Code
+                              <span class="required">*</span>
+                            </label>
                             <input id="${formIdPrefix}_${formName}" ${reimbursementAddressMarkup} type="text" class="${disableReimbursementAddress ? 'disabled' : '' } zipInputFor" id="primaryReimbursementZip" name="${formName}" value="${formValue}" maxlength="10"/>
                         </div>
                     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
@@ -51,14 +51,12 @@
                     <c:set var="formName" value="_05_name"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Private Practice Name<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                 </div>
                 <div class="row">
                     <c:set var="formName" value="_05_npi"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Group NPI / UMPI</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                     <input id="unlinkPracticeButton" type="button" value="Remove Reference" onclick="unlinkPractice('_05_')" style="display: ${isLinked ? 'inline' : 'none'}"/>
                 </div>
@@ -66,7 +64,6 @@
                     <c:set var="formName" value="_05_effectiveDate"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Effective Date<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <span class="dateWrapper">
                         <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                     </span>
@@ -75,27 +72,24 @@
                     <c:set var="formName" value="_05_addressLine1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Practice Address<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" title="Practice Address, Line 1" class="normalInput" name="${formName}" value="${formValue}" maxlength="28"/>
                 </div>
                 <div class="row inlineBox addressline2">
                     <c:set var="formName" value="_05_addressLine2"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <span class="label">(Practice location cannot be<br />a PO Box)</span>
-                    <span class="floatL"><b>&nbsp;</b></span>
                     <input ${disableLinkedFields} type="text" title="Practice Address, Line 2" class="normalInput" name="${formName}" value="${formValue}" maxlength="28"/>
                 </div>
                 <div class="row inlineBox">
                     <span class="label">&nbsp;</span>
-                    <span class="floatL"><b>&nbsp;</b></span>
                     <c:set var="formName" value="_05_city"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span> : </label>
+                    <label for="${formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span></label>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text"  class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                     <c:set var="formName" value="_05_state"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">State<span class="required">*</span> : </label>
+                    <label for="${formIdPrefix}_${formName}">State<span class="required">*</span></label>
                     <select id="${formIdPrefix}_${formName}" ${disableLinkedFields} class="stateSelectFor" name="${formName}">
                         <option value="">Please select</option>
                         <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -105,12 +99,12 @@
 
                     <c:set var="formName" value="_05_zip"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">ZIP Code<span class="required">*</span> : </label>
+                    <label for="${formIdPrefix}_${formName}">ZIP Code<span class="required">*</span></label>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                     <c:set var="formName" value="_05_county"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">County : </label>
+                    <label for="${formIdPrefix}_${formName}">County</label>
                     <select id="${formIdPrefix}_${formName}" ${disableLinkedFields} class="countySelectFor" name="${formName}">
                         <option value="">Please select</option>
                         <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -120,7 +114,6 @@
                 </div>
                 <div class="row">
                     <label>Practice Phone Number<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <c:set var="formName" value="_05_phone1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input ${disableLinkedFields} type="text" title="Practice Phone Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -139,7 +132,6 @@
                 </div>
                 <div class="row">
                     <label>Practice Fax Number</label>
-                    <span class="floatL"><b>:</b></span>
                     <c:set var="formName" value="_05_fax1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input ${disableLinkedFields} type="text" title="Practice Fax Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -154,7 +146,6 @@
                 </div>
                 <div class="row reimbursementAddressRow">
                     <label for="${formIdPrefix}_${formName}">Billing Address<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <div class="inputContainer">
                         <div class="checkboxWrapper">
                             <c:set var="formName" value="_05_billingSameAsPrimary"></c:set>
@@ -180,12 +171,12 @@
                         <div class="addreddWrapper">
                             <c:set var="formName" value="_05_billingCity"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <label for="${formIdPrefix}_${formName}" class="smallLabel">City<span class="required">*</span> : </label>
+                            <label for="${formIdPrefix}_${formName}" class="smallLabel">City<span class="required">*</span></label>
                             <input id="${formIdPrefix}_${formName}" ${billingAddressMarkup} type="text" class="${disableBillingAddress ? 'disabled' : '' } cityInput" name="${formName}" value="${formValue}" maxlength="20"/>
 
                             <c:set var="formName" value="_05_billingState"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <label for="${formIdPrefix}_${formName}" class="smallLabel">State<span class="required">*</span> : </label>
+                            <label for="${formIdPrefix}_${formName}" class="smallLabel">State<span class="required">*</span></label>
                             <select id="${formIdPrefix}_${formName}" ${billingAddressMarkup} class="${disableBillingAddress ? 'disabled' : '' } stateSelect" name="${formName}">
                                 <option value="">Please select</option>
                                 <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -195,12 +186,12 @@
 
                             <c:set var="formName" value="_05_billingZip"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <label for="${formIdPrefix}_${formName}" class="smallLabel">ZIP Code<span class="required">*</span> : </label>
+                            <label for="${formIdPrefix}_${formName}" class="smallLabel">ZIP Code<span class="required">*</span></label>
                             <input id="${formIdPrefix}_${formName}" ${billingAddressMarkup} type="text" class="${disableBillingAddress ? 'disabled' : '' } zipInputFor" id="privateReimbursementZip" name="${formName}" value="${formValue}" maxlength="10"/>
 
                             <c:set var="formName" value="_05_billingCounty"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <label for="${formIdPrefix}_${formName}" class="smallLabel">County : </label>
+                            <label for="${formIdPrefix}_${formName}" class="smallLabel">County</label>
                             <select id="${formIdPrefix}_${formName}" ${billingAddressMarkup} class="${disableBillingAddress ? 'disabled' : '' } stateSelect" name="${formName}">
                                 <option value="">Please select</option>
                                 <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -214,19 +205,16 @@
                     <c:set var="formName" value="_05_fein"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">FEIN</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="normalInput feinMasked" name="${formName}" value="${formValue}" maxlength="10"/>
                 </div>
                 <div class="row">
                     <c:set var="formName" value="_05_stateTaxId"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">State Tax ID</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="normalInput taxIdMasked" name="${formName}" value="${formValue}" maxlength="7"/>
                 </div>
                 <div class="row">
                     <label>Fiscal Year End<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <c:set var="formName" value="_05_fye1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input ${disableLinkedFields} type="text" title="Fiscal Year End Month" class="fiscalMonthInput smallInput" name="${formName}" value="${formValue}" maxlength="2"/>
@@ -238,7 +226,6 @@
                 </div>
                 <div class="row">
                     <label>Do you accept <abbr title="Electronic Funds Transfer">EFT</abbr>?<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <c:set var="formName" value="_05_eftAccepted"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <div class="rowWrapper">
@@ -264,7 +251,6 @@
                 </div>
                 <div class="row">
                     <label>Remittance Sequence<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <c:set var="formName" value="_05_remittanceSequence"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <div class="rowWrapper">


### PR DESCRIPTION
Specifically, for a 'Speech Language Pathologist' enrollment.  (Personal Info, License Info, Practice Info, Provider Statement)  Does not include the 'summary' page (to be done separately). 

Includes forms shown when checking yes and no for 'Do you maintain your own private practice?' on Practice Info page.

Also moves red required '*' next to the label text on the personal information page, instead of to the right of the input field, for consistency with other pages.

Before:

![screenshot-2018-3-6 personal information](https://user-images.githubusercontent.com/1091693/37103126-811bbc80-21f7-11e8-9989-e01ae4a94b2f.png)


After:

![screenshot-2018-3-6 personal information 1](https://user-images.githubusercontent.com/1091693/37103134-8425a90e-21f7-11e8-952b-217b3561e8eb.png)

Tested by inspecting these pages and running integration tests.

Issue #376 Remove colons between form labels and fields