### PR TITLE
Add NPI user help link to organizational provider form

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
@@ -39,7 +39,11 @@
                     <div class="row requireField">
                         <c:set var="formName" value="_15_npi"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="${formIdPrefix}_${formName}">NPI<span class="required">*</span></label>
+                        <label for="${formIdPrefix}_${formName}">
+                          <abbr title="National Provider Identifier">NPI</abbr>
+                          <span class="required">*</span>
+                          <a href="javascript:" class="userHelpLink NPIdefinition">?</a>
+                        </label>
                         <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
@@ -180,7 +184,11 @@
                     <div class="row requireField">
                         <c:set var="formName" value="_15_npi"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}">NPI<span class="required">*</span></label>
+                        <label for="{formIdPrefix}_${formName}">
+                          <abbr title="National Provider Identifier">NPI</abbr>
+                          <span class="required">*</span>
+                          <a href="javascript:" class="userHelpLink NPIdefinition">?</a>
+                        </label>
                         <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
@@ -528,7 +536,11 @@
                         <c:otherwise>
                             <c:set var="formName" value="_15_npi"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <label for="{formIdPrefix}_${formName}">NPI <c:if test="${requireNPI}"><span class="required">*</span></c:if></label>
+                            <label for="{formIdPrefix}_${formName}">
+                              <abbr title="National Provider Identifier">NPI</abbr>
+                              <c:if test="${requireNPI}"><span class="required">*</span></c:if>
+                              <a href="javascript:" class="userHelpLink NPIdefinition">?</a>
+                            </label>
                             <span class="floatL"><b>:</b></span>
                             <input id="{formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                         </c:otherwise>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -80,7 +80,7 @@
                 <label for="${formIdPrefix}_${formName}">
                   Type
                   <span class="required">*</span>
-                  <a href="javascript:" class="definition">?</a>
+                  <a href="javascript:" class="userHelpLink ownershipTypeDefinition">?</a>
                 </label>
                 <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="ownershipType" name="${formName}">
@@ -357,7 +357,7 @@
                 <label for="${formIdPrefix}_${formName}">
                   Type
                   <span class="required">*</span>
-                  <a href="javascript:" class="definition">?</a>
+                  <a href="javascript:" class="userHelpLink ownershipTypeDefinition">?</a>
                 </label>
                 <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="businessOwnershipType" name="${formName}">
@@ -576,7 +576,7 @@
                 <label for="${formIdPrefix}_${formName}">
                   Type
                   <span class="required">*</span>
-                  <a href="javascript:" class="definition">?</a>
+                  <a href="javascript:" class="userHelpLink ownershipTypeDefinition">?</a>
                 </label>
                 <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="businessOwnershipType" name="${formName}">
@@ -783,7 +783,7 @@
                 <label for="${formIdPrefix}_${formName}">
                   Type
                   <span class="required">*</span>
-                  <a href="javascript:" class="definition">?</a>
+                  <a href="javascript:" class="userHelpLink ownershipTypeDefinition">?</a>
                 </label>
                 <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="ownershipType" name="${formName}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -77,7 +77,11 @@
             <div class="row requireField">
                 <c:set var="formName" value="_17_iboType_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">Type<span class="required">*</span><span><a href="javascript:" class="definition">?</a></span></label>
+                <label for="${formIdPrefix}_${formName}">
+                  Type
+                  <span class="required">*</span>
+                  <a href="javascript:" class="definition">?</a>
+                </label>
                 <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="ownershipType" name="${formName}">
                     <option value="">Please select</option>
@@ -350,7 +354,11 @@
             <div class="row requireField">
                 <c:set var="formName" value="_17_cboType_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">Type<span class="required">*</span><span><a href="javascript:" class="definition">?</a></span></label>
+                <label for="${formIdPrefix}_${formName}">
+                  Type
+                  <span class="required">*</span>
+                  <a href="javascript:" class="definition">?</a>
+                </label>
                 <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="businessOwnershipType" name="${formName}">
                     <option value="">Please select</option>
@@ -565,7 +573,11 @@
             <div class="row requireField">
                 <c:set var="formName" value="_17_cboType"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">Type<span class="required">*</span><span><a href="javascript:" class="definition">?</a></span></label>
+                <label for="${formIdPrefix}_${formName}">
+                  Type
+                  <span class="required">*</span>
+                  <a href="javascript:" class="definition">?</a>
+                </label>
                 <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="businessOwnershipType" name="${formName}">
                     <option value="">Please select</option>
@@ -768,7 +780,11 @@
             <div class="row requireField">
                 <c:set var="formName" value="_17_iboType"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">Type<span class="required">*</span><span><a href="javascript:" class="definition">?</a></span></label>
+                <label for="${formIdPrefix}_${formName}">
+                  Type
+                  <span class="required">*</span>
+                  <a href="javascript:" class="definition">?</a>
+                </label>
                 <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="ownershipType" name="${formName}">
                     <option value="">Please select</option>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
@@ -47,7 +47,7 @@
                 <label for="${formIdPrefix}_${formName}">
                   <abbr title="National Provider Identifier">NPI</abbr>
                   <span class="required">${requireNPI ? '*' : ''}</span>
-                  <span><a href="javascript:" class="NPIdefinition">?</a></span>
+                  <a href="javascript:" class="userHelpLink NPIdefinition">?</a>
                 </label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4334,7 +4334,7 @@ input.passwordNormalInput{
   padding-bottom: 10px;
 }
 
-a.definition{
+.userHelpLink {
   padding-left: 5px;
   cursor: help;
 }

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1952,8 +1952,8 @@ $(document).ready(function () {
     $(html).attr('alt', '').attr('title', '');
   });
 
-  /*show definitions modal*/
-  $('a.definition').live('click', function () {
+  /*show ownership type definitions modal*/
+  $('a.ownershipTypeDefinition').click(function () {
     addressLoadModal('#definitionsModal');
   });
 

--- a/psm-app/userhelp/source/enrollment.rst
+++ b/psm-app/userhelp/source/enrollment.rst
@@ -31,7 +31,8 @@ An application includes:
 What is an NPI?
 ---------------
 An *NPI* is a National Provider Identifier number.
-You can search NPIs or register for an NPI at |nppes_link| (link opens in a new tab).
+You can search for an NPI, register for an NPI, and check whether an NPI's
+status is active at |nppes_link| (link opens in a new tab).
 
 .. |nppes_link| raw:: html
 


### PR DESCRIPTION
Add the "What is an NPI?" user help link to the organizational provider form (on the "organization info" page).  

Also make these NPI help links have a "help" cursor when the user hovers their cursor over it, to match the existing "ownership type definitions" modal.  Refactor the CSS classes to make it possible to reuse a single class for this help cursor behavior.  

Also add wording to the NPI modal to indicate that you can check the active status of an NPI on the NPPES website (which is something we suggest providers do in order to not delay the enrollment process elsewhere in the user docs).

Note: these changes are made on top of those in PR #697 and do not need to be reviewed until those land.

Tested by checking the NPI link for functionality, cursor change on hover, and change in wording in modal -- both on the "organization info" page for organizational providers, and the "personal info" page for individual providers.  Checked that the ownership type definition help link still works as usual on the organizational provider "ownership info" page. 

Issue #422 Review documentation to add [...] help links