### PR TITLE
Add user help modals for private/group practice questions

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
@@ -91,9 +91,9 @@
       <%@include file="/WEB-INF/pages/provider/enrollment/steps/modal/print_modal.jsp" %>
       <%@include file="/WEB-INF/pages/provider/enrollment/steps/modal/definitions_modal.jsp" %>
 
-      <c:set var="userHelpModalId" value="modal-what-is-an-npi"/>
+      <c:set var="userHelpModalId" value="user-help-modal"/>
       <h:handlebars template="includes/userhelp/user_help_modal" context="${pageContext}" />
-      <!-- /#saveAsDraftModal-->
+
     </div>
     <c:if test="${not empty requestScope['flash_popup']}">
       <input type="hidden" id="flashPopUp" value="${requestScope['flash_popup']}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/practice_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/practice_type.jsp
@@ -14,7 +14,10 @@
     <div class="section">
         <input type="hidden" name="formNames" value="<%= ViewStatics.PRACTICE_TYPE_FORM %>">
         <div id="RadioWrapper" class="row">
-            <label>Do you maintain your own private practice?</label>
+            <label>
+              Do you maintain your own private practice?
+              <a href="javascript:" class="userHelpLink maintainOwnPrivatePractice">?</a>
+            </label>
             <div>
                 <c:set var="formName" value="_04_maintainsOwnPrivatePractice"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -30,7 +33,10 @@
             </div>
         </div>
         <div id="switchRadioWrapper" class="row">
-            <label>Are you employed and/or independently contracted by a group practice?</label>
+            <label>
+              Are you employed and/or independently contracted by a group practice?
+              <a href="javascript:" class="userHelpLink employedByGroupPractice">?</a>
+            </label>
             <div>
                 <c:set var="formName" value="_04_employedOrContractedByGroup"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1998,6 +1998,18 @@ $(document).ready(function () {
     'what-is-an-npi'
   );
 
+  addUserHelpClickHandler(
+    'a.maintainOwnPrivatePractice',
+    '/help/enrollment.html',
+    'do-i-maintain-my-own-private-practice'
+  );
+
+  addUserHelpClickHandler(
+    'a.employedByGroupPractice',
+    '/help/enrollment.html',
+    'am-i-employed-and-or-independently-contracted-by-a-group-practice'
+  );
+
   //$('.inline input[type=radio]').removeAttr('checked');
   //    $('.inline input[name=civilMoney]').click(function(){
   //        if($(this).val()=="yes"){

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -72,6 +72,18 @@ $(document).ready(function () {
   //    });
 
   /**
+  * Clears and resets the contents of the user help modal
+  * (before it gets populated with results of AJAX call).
+  */
+  resetUserHelpModal = function(modalSelector) {
+    var modal = document.querySelector(modalSelector);
+    var modalTitle = modal.querySelector('.userHelpModalTitle');
+    var modalBody = modal.querySelector('.userHelpModalBody');
+    modalTitle.innerHTML = '';
+    modalBody.innerHTML = 'Loading...';
+  }
+
+  /**
   * Populates a user help modal with content.  With the first two
   * arguments bound (using '.bind'), this is used as the callback
   * function for AJAX calls that fetch a user help page.  It extracts
@@ -1957,18 +1969,34 @@ $(document).ready(function () {
     addressLoadModal('#definitionsModal');
   });
 
-  /*show NPI definition modal*/
-  $('a.NPIdefinition').click(function () {
-    addressLoadModal('#modal-what-is-an-npi');
-    $.get(
-      ctx + "/help/enrollment.html",
-      populateUserHelpModal.bind(
-        undefined,
-        "modal-what-is-an-npi",
-        "what-is-an-npi"
-      )
-    );
-  });
+
+  /**
+  * Add a click handler function to a user help modal link.
+  *
+  * @param helpLinkSelector {string} - Selector for the help link.
+  * @param helpDocsPath {string} - Path to the help doc html file.
+  * @param helpItemId {string} - ID of the source help item.
+  */
+  addUserHelpClickHandler = function(helpLinkSelector, helpDocsPath, helpItemId) {
+    $(helpLinkSelector).click(function () {
+      resetUserHelpModal('#user-help-modal');
+      addressLoadModal('#user-help-modal');
+      $.get(
+        ctx + helpDocsPath,
+        populateUserHelpModal.bind(
+          undefined,
+          'user-help-modal',
+          helpItemId
+        )
+      );
+    });
+  };
+
+  addUserHelpClickHandler(
+    'a.NPIdefinition',
+    '/help/enrollment.html',
+    'what-is-an-npi'
+  );
 
   //$('.inline input[type=radio]').removeAttr('checked');
   //    $('.inline input[name=civilMoney]').click(function(){

--- a/psm-app/userhelp/source/enrollment.rst
+++ b/psm-app/userhelp/source/enrollment.rst
@@ -152,11 +152,15 @@ You should:
 -  Make sure your NPI number, address, and other details in the
    application are correct
 
--  Check the `NPPES (National Plan and Provider Enumeration System)
-   website <https://nppes.cms.hhs.gov/>`__ to ensure your NPI status is
-   active
+-  Check the |nppes_link| (link opens in a new tab) to ensure your NPI
+   status is active
 
 -  Check the state Medicaid provider guidelines
+
+.. |nppes_link| raw:: html
+
+   <a href="https://nppes.cms.hhs.gov" target="_blank">NPPES (the National Plan
+   and Provider Enumeration System) website</a>
 
 What is the difference between a private practice and a group practice?
 -----------------------------------------------------------------------

--- a/psm-app/userhelp/source/enrollment.rst
+++ b/psm-app/userhelp/source/enrollment.rst
@@ -162,27 +162,24 @@ You should:
    <a href="https://nppes.cms.hhs.gov" target="_blank">NPPES (the National Plan
    and Provider Enumeration System) website</a>
 
-What is the difference between a private practice and a group practice?
------------------------------------------------------------------------
+Do I maintain my own private practice?
+--------------------------------------
 
-On the "Practice Info" page of the enrollment process for individual
-providers, the site asks you:
-
-    Do you maintain your own private practice?
-
-If you have an Entity Type 1 (Individual) NPI number, say "yes". `The
-Center for Medicare and Medicaid Services website has more guidance on
-your NPI
+If you have an Individual NPI number (Entity Type 1) then you maintain
+your own private practice and should answer "yes" for this question.
+`The Center for Medicare and Medicaid Services website has more guidance
+on your NPI
 number. <https://questions.cms.gov/faq.php?id=5005&rtopic=1851&rsubtopic=8605>`__
 
-    Are you employed and/or independently contracted by a group
-    practice?
+Am I employed and/or independently contracted by a group practice?
+------------------------------------------------------------------
 
 If you are employed and/or independently contracted by an organization
-health care provider that has an Entity Type 2 (Organization) NPI
-number, say "yes". `The CMS website has more information on Type 2 NPI
-numbers and what kinds of business structures should have
-them <https://questions.cms.gov/faq.php?id=5005&faqId=1965>`__.
+health care provider that has an Organization NPI number (Entity Type 2),
+then you should answer "yes" for this question.
+`The Center for Medicare and Medicaid Services website has more
+information on Type 2 NPI numbers and what kinds of business structures
+should have them <https://questions.cms.gov/faq.php?id=5005&faqId=1965>`__.
 
 Can I create multiple enrollments for one person (e.g., if a person is licensed as two or more kinds of provider)?
 ------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add contextual user help links and modals for these questions in the individual provider enrollement "Practice Info" step/page:

- "Do you maintain your own private practice?" 
- "Are you employed and/or independently contracted by a group practice?"

Includes some refactoring for reusability/DRY, see commit messages for details.  

Also includes a commit to open the NPPES website in a separate tab in all places we link to it in the user help docs, since it hijacks the browser's back button.

Changes are based on those in PR #705.  No review needed until 705 lands and this is rebased.

Tested by editing an individual provider enrollment and checking the two new user help links on the "Practice Info" page, and the NPI user help link on the "Personal Info" page.

Screenshots:

![screenshot-2018-3-12 practice information](https://user-images.githubusercontent.com/1091693/37305819-2617caa4-260c-11e8-8a56-754344cc0017.png)

![screenshot-2018-3-12 practice information 1](https://user-images.githubusercontent.com/1091693/37305823-2a1c0eda-260c-11e8-81a5-cc2505dca97c.png)


Issue #422 Review documentation to add [...] help links
Resolves #405 Add contextual help for private versus group practice