### PR TITLE
Remove colons from organization provider enrollment step pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
@@ -29,7 +29,6 @@
                 <c:set var="formName" value="_16_npi_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">NPI/UMPI<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="umpiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
                 <a href="javascript:;" class="purpleBtn NPILook"><span class="icon">
                 <c:choose>
@@ -49,7 +48,6 @@
                 <c:set var="formName" value="_16_providerType_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Individual Provider Type<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" name="${formName}">
                     <c:choose>
                         <c:when test="${onlyPharmacist}">
@@ -70,7 +68,6 @@
                 <label for="${formIdPrefix}_${formName}">Date of Birth<span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -81,7 +78,6 @@
                 <label for="${formIdPrefix}_${formName}">Start Date<span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -93,14 +89,12 @@
                 <c:set var="formName" value="_16_name_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="">Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_16_ssn_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="">Social Security Number<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
             <c:if test="${askBGSInfo == true}">
@@ -108,7 +102,6 @@
                     <c:set var="formName" value="_16_bgsStudyId_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}" class="">BGS Study ID<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="75"/>
                 </div>
                 <div class="row requireField">
@@ -117,7 +110,6 @@
                     <label for="${formIdPrefix}_${formName}">BGS Clearance Date<span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                         <span class="dateWrapper floatL">
                         <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                     </span>
@@ -149,7 +141,6 @@
                 <c:set var="formName" value="_16_npi"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">NPI/UMPI<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="umpiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
                 <a href="javascript:;" class="purpleBtn NPILook"><span class="icon"></span>
                 <c:choose>
@@ -169,7 +160,6 @@
                 <c:set var="formName" value="_16_providerType"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Individual Provider Type<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" name="${formName}">
                     <c:choose>
                         <c:when test="${onlyPharmacist}">
@@ -190,7 +180,6 @@
                 <label for="${formIdPrefix}_${formName}">Date of Birth<span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -201,7 +190,6 @@
                 <label for="${formIdPrefix}_${formName}">Start Date<span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -213,14 +201,12 @@
                 <c:set var="formName" value="_16_name"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_16_ssn"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Social Security Number<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
             <c:if test="${askBGSInfo == true}">
@@ -228,7 +214,6 @@
                     <c:set var="formName" value="_16_bgsStudyId"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">BGS Study ID<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="75"/>
                 </div>
                 <div class="row requireField">
@@ -237,7 +222,6 @@
                     <label for="${formIdPrefix}_${formName}">BGS Clearance Date<span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                     <span class="dateWrapper floatL">
                         <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                     </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
@@ -32,7 +32,6 @@
                         <c:set var="formName" value="_15_name"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="${formIdPrefix}_${formName}">Name of Facility<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                     </div>
 
@@ -44,7 +43,6 @@
                           <span class="required">*</span>
                           <a href="javascript:" class="userHelpLink NPIdefinition">?</a>
                         </label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
@@ -52,29 +50,26 @@
                         <c:set var="formName" value="_15_addressLine1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">Street Address<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" title="Street Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                     </div>
                     <div class="row inlineBox addressline2">
                         <c:set var="formName" value="_15_addressLine2"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <span class="label">(Practice location cannot be a<br />PO Box)</span>
-                        <span class="floatL"><b>&nbsp;</b></span>
                         <input type="text" title="Street Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                     </div>
 
                     <div class="row inlineBox">
                         <span class="label">&nbsp;</span>
-                        <span class="floatL"><b>&nbsp;</b></span>
 
                         <c:set var="formName" value="_15_city"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span> : </label>
+                        <label for="{formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span></label>
                         <input id="{formIdPrefix}_${formName}" type="text"  class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                         <c:set var="formName" value="_15_state"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}">State<span class="required">*</span> : </label>
+                        <label for="{formIdPrefix}_${formName}">State<span class="required">*</span></label>
                         <select id="{formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                             <option value="">Please select</option>
                             <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -84,12 +79,12 @@
 
                         <c:set var="formName" value="_15_zip"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}">ZIP Code<span class="required">*</span> : </label>
+                        <label for="{formIdPrefix}_${formName}">ZIP Code<span class="required">*</span></label>
                         <input id="{formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                         <c:set var="formName" value="_15_orgCountyName"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}">County<span class="required">*</span> : </label>
+                        <label for="{formIdPrefix}_${formName}">County<span class="required">*</span></label>
                         <select id="{formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                             <option value="">Please select</option>
                             <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -102,7 +97,6 @@
                         <c:set var="formName" value="_15_fein"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">Federal Employer ID<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
@@ -110,7 +104,6 @@
                         <c:set var="formName" value="_15_legalName"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">TaxPayer Name<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="normalInput" id="legalName" name="${formName}" value="${formValue}" maxlength="100"/>
                     </div>
 
@@ -118,13 +111,11 @@
                         <c:set var="formName" value="_15_stateTaxId"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">MN Tax ID</label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="normalInput taxIdMasked" id="stateTaxId" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
                     <div class="row requiredField">
                         <label>Fiscal Year End<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_15_fye1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <input type="text" title="Fiscal Year End Month" class="fiscalMonthInput smallInput" name="${formName}" value="${formValue}" maxlength="2"/>
@@ -137,7 +128,6 @@
 
                     <div class="row">
                         <label>Office Phone Number<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_15_phone1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <input type="text" title="Office Phone Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -157,7 +147,6 @@
 
                     <div class="row">
                         <label>Office Fax Number</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_15_fax1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <input type="text" title="Office Fax Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -176,7 +165,6 @@
                         <c:set var="formName" value="_15_name"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">Complete Provider Name<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="normalInput" id="legalName" name="${formName}" value="${formValue}" maxlength="100"/>
                         <span class="fldInfo">(number of the independent school district or complete name of regional cooperative or charter school)</span>
                     </div>
@@ -189,7 +177,6 @@
                           <span class="required">*</span>
                           <a href="javascript:" class="userHelpLink NPIdefinition">?</a>
                         </label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
@@ -197,12 +184,10 @@
                         <c:set var="formName" value="_15_addressLine1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">Actual Street Address<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" title="Actual Street Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                     </div>
                     <div class="row inlineBox addressline2">
                         <span class="label">(Practice location cannot be a<br />PO Box)</span>
-                        <span class="floatL"><b>&nbsp;</b></span>
                         <c:set var="formName" value="_15_addressLine2"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <input type="text" title="Actual Street Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
@@ -210,16 +195,15 @@
 
                     <div class="row inlineBox">
                         <span class="label">&nbsp;</span>
-                        <span class="floatL"><b>&nbsp;</b></span>
 
                         <c:set var="formName" value="_15_city"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span> : </label>
+                        <label for="{formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span></label>
                         <input id="{formIdPrefix}_${formName}" type="text"  class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                         <c:set var="formName" value="_15_state"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}">State<span class="required">*</span> : </label>
+                        <label for="{formIdPrefix}_${formName}">State<span class="required">*</span></label>
                         <select id="{formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                             <option value="">Please select</option>
                             <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -237,7 +221,6 @@
                         <c:set var="formName" value="_15_orgCountyName"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">County<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <select id="{formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                             <option value="">Please select</option>
                             <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -251,7 +234,6 @@
                         <c:set var="formName" value="_15_fein"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">Federal Employer ID<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
@@ -259,7 +241,6 @@
                         <c:set var="formName" value="_15_legalName"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">Legal Name According to the IRS<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="normalInput" id="legalName" name="${formName}" value="${formValue}" maxlength="100"/>
                     </div>
 
@@ -267,13 +248,11 @@
                         <c:set var="formName" value="_15_stateTaxId"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">MN Tax ID</label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="normalInput taxIdMasked" id="stateTaxId" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
                     <div class="row requiredField">
                         <label>Fiscal Year End<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_15_fye1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <input type="text" title="Fiscal Year End Month" class="fiscalMonthInput smallInput" name="${formName}" value="${formValue}" maxlength="2"/>
@@ -286,7 +265,6 @@
 
                     <div class="row">
                         <label>Office Phone Number<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_15_phone1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <input type="text" title="Office Phone Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -306,7 +284,6 @@
 
                     <div class="row">
                         <label>Office Fax Number</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_15_fax1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <input type="text" title="Office Fax Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -324,7 +301,6 @@
                         <c:set var="formName" value="_15_effectiveDate"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">Requested Enrollment Date<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <span class="dateWrapper floatL">
                             <input id="{formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                         </span>
@@ -335,7 +311,6 @@
                       <c:if test="${showInitialChoices}">
                     <div class="row requireField">
                         <label>Please Select<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_15_subType"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label class="radioLabel">
@@ -357,7 +332,6 @@
                     </div>
                     <div class="row requireField">
                         <label>&nbsp;</label>
-                        <span class="floatL"><b>&nbsp;</b></span>
                         <label class="radioLabel">
                           <input type="radio" ${formValue eq 'Medicare Carrier' ? 'checked' : ''} value="Medicare Carrier" name="${formName}"/>
                           Medicare Carrier
@@ -376,14 +350,12 @@
                         <c:set var="formName" value="_15_name"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="legalName">Organization Name<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input type="text" class="normalInput" id="legalName" name="${formName}" value="${formValue}" maxlength="100"/>
                     </div>
                     <div class="row requireField">
                         <c:set var="formName" value="_15_effectiveDate"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">Effective Date<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <span class="dateWrapper floatL">
                             <input id="{formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                         </span>
@@ -393,7 +365,6 @@
                         <c:set var="formName" value="_15_fein"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="fein">Federal Employer ID<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
@@ -401,7 +372,6 @@
                         <c:set var="formName" value="_15_stateTaxId"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="stateTaxId">MN Tax ID</label>
-                        <span class="floatL"><b>:</b></span>
                         <input type="text" class="normalInput taxIdMasked" id="stateTaxId" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
@@ -409,7 +379,6 @@
                         <c:set var="formName" value="_15_legalName"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="legalName">Legal Name<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input type="text" class="normalInput" id="legalName" name="${formName}" value="${formValue}" maxlength="100"/>
                     </div>
 
@@ -417,29 +386,26 @@
                         <c:set var="formName" value="_15_addressLine1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">Address<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" title="Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                     </div>
                     <div class="row inlineBox addressline2">
                         <c:set var="formName" value="_15_addressLine2"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <span class="label">(Practice location cannot be a<br />PO Box)</span>
-                        <span class="floatL"><b>&nbsp;</b></span>
                         <input type="text" title="Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                     </div>
 
                     <div class="row inlineBox">
                         <span class="label">&nbsp;</span>
-                        <span class="floatL"><b>&nbsp;</b></span>
 
                         <c:set var="formName" value="_15_city"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span> : </label>
+                        <label for="{formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span></label>
                         <input id="{formIdPrefix}_${formName}" type="text" class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                         <c:set var="formName" value="_15_state"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}">State<span class="required">*</span> : </label>
+                        <label for="{formIdPrefix}_${formName}">State<span class="required">*</span></label>
                         <select id="{formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                             <option value="">Please select</option>
                             <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -449,7 +415,7 @@
 
                         <c:set var="formName" value="_15_zip"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}">ZIP Code<span class="required">*</span> : </label>
+                        <label for="{formIdPrefix}_${formName}">ZIP Code<span class="required">*</span></label>
                         <input id="{formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                         <c:set var="formName" value="_15_county"></c:set>
@@ -465,7 +431,6 @@
 
                     <div class="row">
                         <label>Phone Number<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_15_phone1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <input type="text" title="Phone Number Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -485,7 +450,6 @@
 
                     <div class="row">
                         <label>Fax Number<span class="required">*</span></label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_15_fax1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <input type="text" title="Fax Number Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -503,7 +467,6 @@
                         <c:set var="formName" value="_15_npi"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                         <label for="{formIdPrefix}_${formName}">UMPI</label>
-                        <span class="floatL"><b>:</b></span>
                         <input id="{formIdPrefix}_${formName}" type="text" class="umpiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
                     <c:if test="${showNameOfPersonFillingTheForm}">
@@ -511,7 +474,6 @@
                             <c:set var="formName" value="_15_personCompletingForm"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                             <label for="{formIdPrefix}_${formName}">Name of person completing this form</label>
-                            <span class="floatL"><b>:</b></span>
                             <input id="{formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                         </div>
                     </c:if>
@@ -523,14 +485,12 @@
                             <c:set var="formName" value="_15_npi"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                             <label for="{formIdPrefix}_${formName}">UMPI</label>
-                            <span class="floatL"><b>:</b></span>
                             <input id="{formIdPrefix}_${formName}" type="text" class="umpiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                         </c:when>
                         <c:when test="${askUMPIorNPI}">
                             <c:set var="formName" value="_15_npi"></c:set>
                             <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                             <label for="{formIdPrefix}_${formName}">NPI / UMPI</label>
-                            <span class="floatL"><b>:</b></span>
                             <input id="{formIdPrefix}_${formName}" type="text" class="umpiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                         </c:when>
                         <c:otherwise>
@@ -541,7 +501,6 @@
                               <c:if test="${requireNPI}"><span class="required">*</span></c:if>
                               <a href="javascript:" class="userHelpLink NPIdefinition">?</a>
                             </label>
-                            <span class="floatL"><b>:</b></span>
                             <input id="{formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                         </c:otherwise>
                     </c:choose>
@@ -551,7 +510,7 @@
                     <c:set var="formName" value="_15_effectiveDate"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="{formIdPrefix}_${formName}">Effective Date<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
+
                     <span class="dateWrapper floatL">
                         <input id="{formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                     </span>
@@ -563,7 +522,6 @@
                     <c:set var="formName" value="_15_legalName"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="legalName">Provide Taxpayer Name<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input type="text" class="normalInput" id="legalName" name="${formName}" value="${formValue}" maxlength="100"/>
                 </div>
                 </c:if>
@@ -572,7 +530,6 @@
                     <c:set var="formName" value="_15_name"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="name">${askDBAName ? 'DBA Name' : 'Doing Business As'}<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input type="text" class="normalInput" id="name" name="${formName}" value="${formValue}" maxlength="100"/>
                 </div>
 
@@ -581,7 +538,6 @@
                     <c:set var="formName" value="_15_legalName"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="legalName">Legal Name<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input type="text" class="normalInput" id="legalName" name="${formName}" value="${formValue}" maxlength="100"/>
                 </div>
                 </c:if>
@@ -590,28 +546,25 @@
                     <c:set var="formName" value="_15_addressLine1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="{formIdPrefix}_${formName}">Practice Address<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="{formIdPrefix}_${formName}" type="text" title="Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                 </div>
                 <div class="row inlineBox addressline2">
                     <c:set var="formName" value="_15_addressLine2"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <span class="label">(Practice location cannot be a<br />PO Box)</span>
-                    <span class="floatL"><b>&nbsp;</b></span>
                     <input type="text" title="Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                 </div>
 
                 <div class="row inlineBox">
                     <span class="label">&nbsp;</span>
-                    <span class="floatL"><b>&nbsp;</b></span>
                     <c:set var="formName" value="_15_city"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="{formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span> : </label>
+                    <label for="{formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span></label>
                     <input id="{formIdPrefix}_${formName}" type="text"  class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                     <c:set var="formName" value="_15_state"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="{formIdPrefix}_${formName}">State<span class="required">*</span> : </label>
+                    <label for="{formIdPrefix}_${formName}">State<span class="required">*</span></label>
                     <select id="{formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                         <option value="">Please select</option>
                         <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -621,12 +574,12 @@
 
                     <c:set var="formName" value="_15_zip"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="{formIdPrefix}_${formName}">ZIP Code<span class="required">*</span> : </label>
+                    <label for="{formIdPrefix}_${formName}">ZIP Code<span class="required">*</span></label>
                     <input id="{formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                     <c:set var="formName" value="_15_county"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="{formIdPrefix}_${formName}">County : </label>
+                    <label for="{formIdPrefix}_${formName}">County</label>
                     <select id="{formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                         <option value="">Please select</option>
                         <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -637,7 +590,6 @@
 
                 <div class="row">
                     <label>Office Phone Number<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <c:set var="formName" value="_15_phone1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input type="text" title="Office Phone Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -657,7 +609,6 @@
 
                 <div class="row">
                     <label>Office Fax Number</label>
-                    <span class="floatL"><b>:</b></span>
                     <c:set var="formName" value="_15_fax1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <input type="text" title="Office Fax Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -675,7 +626,6 @@
                     <c:set var="formName" value="_15_fein"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="fein">Federal Employer ID<span class="required">*</span></label>
-                    <span class="floatL"><b>:</b></span>
                     <input type="text" class="normalInput feinMasked" id="fein" name="${formName}" value="${formValue}" maxlength="10"/>
                 </div>
 
@@ -683,7 +633,6 @@
                     <c:set var="formName" value="_15_stateTaxId"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="stateTaxId">MN Tax ID</label>
-                    <span class="floatL"><b>:</b></span>
                     <input type="text" class="normalInput taxIdMasked" id="stateTaxId" name="${formName}" value="${formValue}" maxlength="10"/>
                 </div>
 
@@ -692,7 +641,6 @@
                     <c:set var="formName" value="_15_fye1"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label>Fiscal Year End</label>
-                    <span class="floatL"><b>:</b></span>
                     <input type="text" title="Fiscal Year End Month" class="fiscalMonthInput smallInput" name="${formName}" value="${formValue}" maxlength="2"/>
                     <span class="sep">/</span>
                     <c:set var="formName" value="_15_fye2"></c:set>
@@ -869,7 +817,6 @@
            <c:set var="formName" value="_15_contactName"></c:set>
            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
            <label for="contactName">Contact Name<span class="required">*</span></label>
-           <span class="floatL"><b>:</b></span>
            <input ${disableContact} type="text" class="normalInput" id="contactName" name="${formName}" value="${formValue}" maxlength="100"/>
        </div>
 
@@ -877,7 +824,6 @@
            <c:set var="formName" value="_15_contactPhone1"></c:set>
            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
            <label>Contact Phone Number<span class="required">*</span></label>
-           <span class="floatL"><b>:</b></span>
            <input type="text" title="Contact Phone Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
            <span class="sep">-</span>
            <c:set var="formName" value="_15_contactPhone2"></c:set>
@@ -895,7 +841,6 @@
 
        <div class="row">
            <label>Contact Fax Number</label>
-           <span class="floatL"><b>:</b></span>
            <c:set var="formName" value="_15_contactFax1"></c:set>
            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
            <input type="text" title="Contact Fax Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -913,7 +858,6 @@
            <c:set var="formName" value="_15_contactEmail"></c:set>
            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
            <label for="contactEmail">Contact Email Address</label>
-           <span class="floatL"><b>:</b></span>
            <input ${disableContact} type="text" class="normalInput" id="contactEmail" name="${formName}" value="${formValue}" maxlength="50"/>
        </div>
        <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
@@ -35,14 +35,12 @@
                 <c:set var="formName" value="_19_name"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Provider Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row titleRow">
                 <c:set var="formName" value="_19_title"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Provider Title<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <c:set var="formName" value="_19_requiredAgreementsSize"></c:set>
@@ -75,7 +73,6 @@
                 <c:set var="formName" value="_19_date"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Date<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -23,7 +23,6 @@
                 <c:set var="formName" value="_17_entityType"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="entityType">Entity Type<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <select id="entityType" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${entityStructureTypes}">
@@ -38,7 +37,6 @@
                 <c:set var="formName" value="_17_entityDescription"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Specify Type</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput ${formValue eq 'Other' ? '' : 'disabled'}" ${formValue eq 'Other' ? '' : disabledMarkup} name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="clearFixed"></div>
@@ -82,7 +80,6 @@
                   <span class="required">*</span>
                   <a href="javascript:" class="userHelpLink ownershipTypeDefinition">?</a>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="ownershipType" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${beneficialOwnerTypes}">
@@ -96,7 +93,6 @@
                     <c:set var="formName" value="_17_iboSubcontractorName_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Name Subcontractor</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                     <div class="clear"></div>
                 </div>
@@ -106,7 +102,6 @@
                     <label for="${formIdPrefix}_${formName}">List % of Ownership Interest
                         <span class="label">if 5% or more</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="6"/>
                     <div class="clear"></div>
                 </div>
@@ -114,7 +109,6 @@
                     <c:set var="formName" value="_17_iboOtherType_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Other</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                     <div class="clear"></div>
                 </div>
@@ -127,28 +121,24 @@
                 <c:set var="formName" value="_17_iboFirstName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">First Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row">
                 <c:set var="formName" value="_17_iboMiddleName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Middle Name</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_17_iboLastName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Last Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_17_iboSSN_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Social Security Number<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
             <div class="clearFixed"></div>
@@ -160,7 +150,6 @@
                 <label for="${formIdPrefix}_${formName}">Date of Birth<span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -171,7 +160,6 @@
                 <label for="${formIdPrefix}_${formName}">Hire Date<span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -180,7 +168,6 @@
                 <c:set var="formName" value="_17_iboRelationship_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label class="multiLine">Relationship to any other listed person</label>
-                <span class="floatL"><b>:</b></span>
                 <label class="inline"><input type="radio" ${formValue eq 'Spouse' ? 'checked' : ''} name="${formName}" value="Spouse"/>Spouse</label>
                 <label class="inline"><input type="radio" ${formValue eq 'Child' ? 'checked' : ''} name="${formName}" value="Child"/>Child</label>
                 <label class="inline"><input type="radio" ${formValue eq 'Parent' ? 'checked' : ''} name="${formName}" value="Parent"/>Parent</label>
@@ -193,7 +180,6 @@
                 <c:set var="formName" value="_17_iboAddressLine1_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Home Residence Address<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Home Residence Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
@@ -201,21 +187,19 @@
                 <c:set var="formName" value="_17_iboAddressLine2_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">(Practice location cannot be a<br />PO Box)</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Home Residence Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_17_iboCity_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City</label>
                 <input id="${formIdPrefix}_${formName}" type="text"  class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_17_iboState_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State : </label>
+                <label for="${formIdPrefix}_${formName}">State</label>
                 <select id="${formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -225,12 +209,12 @@
 
                 <c:set var="formName" value="_17_iboZip_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code : </label>
+                <label for="${formIdPrefix}_${formName}">Zip Code</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                 <c:set var="formName" value="_17_iboCounty_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">County : </label>
+                <label for="${formIdPrefix}_${formName}">County</label>
                 <select id="${formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -260,7 +244,6 @@
                 <c:set var="formName" value="_17_iboOtherInterestName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="multiLine">Full Legal Name of Other Provider<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
                     <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
@@ -269,7 +252,6 @@
                 <c:set var="formName" value="_17_iboOtherInterestPct_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="inlineLabel">% of Ownership Interest<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput smallInput" name="${formName}" value="${formValue}" maxlength="6"/>
                 <div class="clearFixed"></div>
             </div>
@@ -277,7 +259,6 @@
                 <c:set var="formName" value="_17_iboOtherAddressLine1_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Address of Other Provider<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Other Provider Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                 <div class="clearFixed"></div>
             </div>
@@ -285,15 +266,13 @@
                 <c:set var="formName" value="_17_iboOtherAddressLine2_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Other Provider Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_17_iboOtherCity_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_17_iboOtherCounty_${status.index - 1}"></c:set>
@@ -308,7 +287,7 @@
 
                 <c:set var="formName" value="_17_iboOtherState_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State : </label>
+                <label for="${formIdPrefix}_${formName}">State</label>
                 <select id="${formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -318,7 +297,7 @@
 
                 <c:set var="formName" value="_17_iboOtherZip_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code : </label>
+                <label for="${formIdPrefix}_${formName}">Zip Code</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>
         </div>
@@ -359,7 +338,6 @@
                   <span class="required">*</span>
                   <a href="javascript:" class="userHelpLink ownershipTypeDefinition">?</a>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="businessOwnershipType" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${beneficialOwnerTypes}">
@@ -373,7 +351,6 @@
                     <c:set var="formName" value="_17_cboSubcontractorName_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Name Subcontractor</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                     <div class="clear"></div>
                 </div>
@@ -383,7 +360,6 @@
                     <label for="${formIdPrefix}_${formName}">List % of Ownership Interest
                         <span class="label">if 5% or more</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="6"/>
                     <div class="clear"></div>
                 </div>
@@ -391,7 +367,6 @@
                     <c:set var="formName" value="_17_cboOtherType_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Other</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                     <div class="clear"></div>
                 </div>
@@ -404,7 +379,6 @@
                 <c:set var="formName" value="_17_cboLegalName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Full Legal Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
                     <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
@@ -413,7 +387,6 @@
                 <c:set var="formName" value="_17_cboFEIN_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="inlineLabel">FEIN<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput smallInput feinMasked" name="${formName}" value="${formValue}" maxlength="10"/>
                 <div class="clearFixed"></div>
             </div>
@@ -421,7 +394,6 @@
                 <c:set var="formName" value="_17_cboAddressLine1_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Business Address<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Business Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
@@ -429,21 +401,19 @@
                 <c:set var="formName" value="_17_cboAddressLine2_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Business Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_17_cboCity_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City</label>
                 <input id="${formIdPrefix}_${formName}" type="text"  class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_17_cboState_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State : </label>
+                <label for="${formIdPrefix}_${formName}">State</label>
                 <select id="${formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -453,12 +423,12 @@
 
                 <c:set var="formName" value="_17_cboZip_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code : </label>
+                <label for="${formIdPrefix}_${formName}">Zip Code</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                 <c:set var="formName" value="_17_cboCounty_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">County : </label>
+                <label for="${formIdPrefix}_${formName}">County</label>
                 <select id="${formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -487,7 +457,6 @@
                 <c:set var="formName" value="_17_cboOtherInterestName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="multiLine">Full Legal Name of Other Provider<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
                     <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
@@ -496,7 +465,6 @@
                 <c:set var="formName" value="_17_cboOtherInterestPct_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="inlineLabel">% of Ownership Interest<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput smallInput" name="${formName}" value="${formValue}" maxlength="6"/>
                 <div class="clearFixed"></div>
             </div>
@@ -504,7 +472,6 @@
                 <c:set var="formName" value="_17_cboOtherAddressLine1_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Address of Other Provider<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Other Provider Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                 <div class="clearFixed"></div>
             </div>
@@ -512,15 +479,13 @@
                 <c:set var="formName" value="_17_cboOtherAddressLine2_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Other Provider Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
             <div class="row inlineBox">
                 <c:set var="formName" value="_17_cboOtherCity_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_17_cboOtherCounty_${status.index - 1}"></c:set>
@@ -535,7 +500,7 @@
 
                 <c:set var="formName" value="_17_cboOtherState_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State : </label>
+                <label for="${formIdPrefix}_${formName}">State</label>
                 <select id="${formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -545,7 +510,7 @@
 
                 <c:set var="formName" value="_17_cboOtherZip_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code : </label>
+                <label for="${formIdPrefix}_${formName}">Zip Code</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>
         </div>
@@ -578,7 +543,6 @@
                   <span class="required">*</span>
                   <a href="javascript:" class="userHelpLink ownershipTypeDefinition">?</a>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="businessOwnershipType" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${beneficialOwnerTypes}">
@@ -592,7 +556,6 @@
                     <c:set var="formName" value="_17_cboSubcontractorName"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Name Subcontractor</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                     <div class="clear"></div>
                 </div>
@@ -602,7 +565,6 @@
                     <label for="${formIdPrefix}_${formName}">List % of Ownership Interest
                         <span class="label">if 5% or more</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="6"/>
                     <div class="clear"></div>
                 </div>
@@ -610,7 +572,6 @@
                     <c:set var="formName" value="_17_cboOtherType"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Other</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                     <div class="clear"></div>
                 </div>
@@ -623,7 +584,6 @@
                 <c:set var="formName" value="_17_cboLegalName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Full Legal Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
                     <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
@@ -632,7 +592,6 @@
                 <c:set var="formName" value="_17_cboFEIN"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="inlineLabel">FEIN<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput smallInput feinMasked" name="${formName}" value="${formValue}" maxlength="7"/>
                 <div class="clearFixed"></div>
             </div>
@@ -640,7 +599,6 @@
                 <c:set var="formName" value="_17_cboAddressLine1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Business Address<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Business Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
@@ -648,21 +606,19 @@
                 <c:set var="formName" value="_17_cboAddressLine2"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Business Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_17_cboCity"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City</label>
                 <input id="${formIdPrefix}_${formName}" type="text"  class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_17_cboState"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State : </label>
+                <label for="${formIdPrefix}_${formName}">State</label>
                 <select id="${formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -672,12 +628,12 @@
 
                 <c:set var="formName" value="_17_cboZip"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code : </label>
+                <label for="${formIdPrefix}_${formName}">Zip Code</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                 <c:set var="formName" value="_17_cboCounty"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">County : </label>
+                <label for="${formIdPrefix}_${formName}">County</label>
                 <select id="${formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -706,7 +662,6 @@
                 <c:set var="formName" value="_17_cboOtherInterestName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="multiLine">Full Legal Name of Other Provider<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
                     <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
@@ -715,7 +670,6 @@
                 <c:set var="formName" value="_17_cboOtherInterestPct"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}"class="inlineLabel">% of Ownership Interest<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput smallInput" name="${formName}" value="${formValue}" maxlength="6"/>
                 <div class="clearFixed"></div>
             </div>
@@ -723,7 +677,6 @@
                 <c:set var="formName" value="_17_cboOtherAddressLine1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Address of Other Provider<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Other Provider Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                 <div class="clearFixed"></div>
             </div>
@@ -732,16 +685,14 @@
                 <c:set var="formName" value="_17_cboOtherAddressLine2"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Other Provider Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_17_cboOtherCity"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_17_cboOtherCounty"></c:set>
@@ -756,7 +707,7 @@
 
                 <c:set var="formName" value="_17_cboOtherState"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State : </label>
+                <label for="${formIdPrefix}_${formName}">State</label>
                 <select id="${formIdPrefix}_${formName}"class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -766,7 +717,7 @@
 
                 <c:set var="formName" value="_17_cboOtherZip"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code : </label>
+                <label for="${formIdPrefix}_${formName}">Zip Code</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>
         </div>
@@ -785,7 +736,6 @@
                   <span class="required">*</span>
                   <a href="javascript:" class="userHelpLink ownershipTypeDefinition">?</a>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" class="ownershipType" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${beneficialOwnerTypes}">
@@ -799,7 +749,6 @@
                     <c:set var="formName" value="_17_iboSubcontractorName"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Name Subcontractor</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                     <div class="clear"></div>
                 </div>
@@ -809,7 +758,6 @@
                     <label for="${formIdPrefix}_${formName}">List % of Ownership Interest
                         <span class="label">if 5% or more</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="6"/>
                     <div class="clear"></div>
                 </div>
@@ -817,7 +765,6 @@
                     <c:set var="formName" value="_17_iboOtherType"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                     <label for="${formIdPrefix}_${formName}">Other</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
                     <div class="clear"></div>
                 </div>
@@ -830,28 +777,24 @@
                 <c:set var="formName" value="_17_iboFirstName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">First Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row">
                 <c:set var="formName" value="_17_iboMiddleName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Middle Name</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_17_iboLastName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Last Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_17_iboSSN"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Social Security Number<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
             <div class="clearFixed"></div>
@@ -863,7 +806,6 @@
                 <label for="${formIdPrefix}_${formName}">Date of Birth<span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -874,7 +816,6 @@
                 <label for="${formIdPrefix}_${formName}">Hire Date<span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -883,7 +824,6 @@
                 <c:set var="formName" value="_17_iboRelationship"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label class="multiLine">Relationship to any other listed person</label>
-                <span class="floatL"><b>:</b></span>
                 <label class="inline"><input type="radio" ${formValue eq 'Spouse' ? 'checked' : ''} name="${formName}" value="Spouse"/>Spouse</label>
                 <label class="inline"><input type="radio" ${formValue eq 'Child' ? 'checked' : ''} name="${formName}" value="Child"/>Child</label>
                 <label class="inline"><input type="radio" ${formValue eq 'Parent' ? 'checked' : ''} name="${formName}" value="Parent"/>Parent</label>
@@ -896,7 +836,6 @@
                 <c:set var="formName" value="_17_iboAddressLine1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Home Residence Address<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Home Residence Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
@@ -904,21 +843,19 @@
                 <c:set var="formName" value="_17_iboAddressLine2"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">(Practice location cannot be a<br />PO Box)</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Home Residence Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_17_iboCity"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City</label>
                 <input id="${formIdPrefix}_${formName}" type="text"  class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_17_iboState"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State : </label>
+                <label for="${formIdPrefix}_${formName}">State</label>
                 <select id="${formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -928,12 +865,12 @@
 
                 <c:set var="formName" value="_17_iboZip"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code : </label>
+                <label for="${formIdPrefix}_${formName}">Zip Code</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                 <c:set var="formName" value="_17_iboCounty"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">County : </label>
+                <label for="${formIdPrefix}_${formName}">County</label>
                 <select id="${formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -963,7 +900,6 @@
                 <c:set var="formName" value="_17_iboOtherInterestName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="multiLine">Full Legal Name of Other Provider<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
                     <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
@@ -971,7 +907,6 @@
 
                 <!-- TODO: Issue #564: Why doesn't this field have a name? -->
                 <label class="inlineLabel">% of Ownership Interest<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input type="text" class="wholeInput smallInput" maxlength="6"/>
                 <div class="clearFixed"></div>
             </div>
@@ -979,7 +914,6 @@
                 <c:set var="formName" value="_17_iboOtherAddressLine1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Address of Other Provider<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Other Provider Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
                 <div class="clearFixed"></div>
             </div>
@@ -987,15 +921,13 @@
                 <c:set var="formName" value="_17_iboOtherAddressLine2"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Other Provider Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_17_iboOtherCity"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_17_iboOtherCounty"></c:set>
@@ -1010,7 +942,7 @@
 
                 <c:set var="formName" value="_17_iboOtherState"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State : </label>
+                <label for="${formIdPrefix}_${formName}">State</label>
                 <select id="${formIdPrefix}_${formName}"class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -1020,7 +952,7 @@
 
                 <c:set var="formName" value="_17_iboOtherZip"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code : </label>
+                <label for="${formIdPrefix}_${formName}">Zip Code</label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>
         </div>


### PR DESCRIPTION
Specifically, for a 'Head Start' enrollment application.  (Organization Info, Facility Credentials, Individual Member Info, Ownership Info, Provider Statement)  Does not include the 'summary' page (to be done separately).  Includes forms shown when adding additional elements to an application (e.g. "Add Another Individual Person Ownership or Control Interest").

Tested by inspecting these pages to confirm the colons were gone, and the page layout was not messed up.

Issue #376 Remove colons between form labels and fields