### PR TITLE
Add user help link and modal for selecting provider type 

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
@@ -16,9 +16,6 @@
     <c:set var="formName" value="_01_providerType"></c:set>
     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
     <label for="${formIdPrefix}_${formName}">Provider Type</label>
-    <span class="floatL">
-      <b>:</b>
-    </span>
     <select id="${formIdPrefix}_${formName}" name="${formName}">
       <option value="">Please select</option>
       <c:if test="${empty individualProviderTypes or

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
@@ -11,39 +11,55 @@
 <c:set var="formIdPrefix" value="provider_type"></c:set>
 
 <div class="section">
-    <input type="hidden" name="formNames" value="<%= ViewStatics.PROVIDER_TYPE_FORM %>">
-    <div class="wholeCol">
-        <c:set var="formName" value="_01_providerType"></c:set>
-        <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-        <label for="${formIdPrefix}_${formName}">Provider Type</label>
-        <span class="floatL"><b>:</b></span>
-        <select id="${formIdPrefix}_${formName}" name="${formName}">
-            <option value="">Please select</option>
-            <c:if test="${empty individualProviderTypes or empty organizationProviderTypes}">
-                <%-- no need to group as there is only one group --%>
-                <c:if test="${empty individualProviderTypes}">
-                    <c:forEach var="opt" items="${organizationProviderTypes}">
-                        <option ${formValue == opt.description ? selectedMarkup : ''} value="${opt.description}"><c:out value="${opt.description}" /></option>
-                    </c:forEach>
-                </c:if>
-                <c:if test="${empty organizationProviderTypes}">
-                    <c:forEach var="opt" items="${individualProviderTypes}">
-                        <option ${formValue == opt.description ? selectedMarkup : ''} value="${opt.description}"><c:out value="${opt.description}" /></option>
-                    </c:forEach>
-                </c:if>
-            </c:if>
-            <c:if test="${not empty individualProviderTypes and not empty organizationProviderTypes}">
-                <optgroup label="Individual Providers">
-                    <c:forEach var="opt" items="${individualProviderTypes}">
-                        <option ${formValue == opt.description ? selectedMarkup : ''} value="${opt.description}"><c:out value="${opt.description}" /></option>
-                    </c:forEach>
-                </optgroup>
-                <optgroup label="Organization Providers">
-                    <c:forEach var="opt" items="${organizationProviderTypes}">
-                        <option ${formValue == opt.description ? selectedMarkup : ''} value="${opt.description}"><c:out value="${opt.description}" /></option>
-                    </c:forEach>
-                </optgroup>
-            </c:if>
-        </select>
-    </div>
+  <input type="hidden" name="formNames" value="<%= ViewStatics.PROVIDER_TYPE_FORM %>">
+  <div class="wholeCol">
+    <c:set var="formName" value="_01_providerType"></c:set>
+    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
+    <label for="${formIdPrefix}_${formName}">Provider Type</label>
+    <span class="floatL">
+      <b>:</b>
+    </span>
+    <select id="${formIdPrefix}_${formName}" name="${formName}">
+      <option value="">Please select</option>
+      <c:if test="${empty individualProviderTypes or
+                    empty organizationProviderTypes}">
+        <%-- no need to group as there is only one group --%>
+        <c:if test="${empty individualProviderTypes}">
+          <c:forEach var="opt" items="${organizationProviderTypes}">
+            <option ${formValue == opt.description ? selectedMarkup : ''}
+              value="${opt.description}">
+              <c:out value="${opt.description}" />
+            </option>
+          </c:forEach>
+        </c:if>
+        <c:if test="${empty organizationProviderTypes}">
+          <c:forEach var="opt" items="${individualProviderTypes}">
+            <option ${formValue == opt.description ? selectedMarkup : ''}
+              value="${opt.description}">
+              <c:out value="${opt.description}" />
+            </option>
+          </c:forEach>
+        </c:if>
+      </c:if>
+      <c:if test="${not empty individualProviderTypes and not
+                    empty organizationProviderTypes}">
+        <optgroup label="Individual Providers">
+          <c:forEach var="opt" items="${individualProviderTypes}">
+            <option ${formValue == opt.description ? selectedMarkup : ''}
+              value="${opt.description}">
+              <c:out value="${opt.description}" />
+            </option>
+          </c:forEach>
+        </optgroup>
+        <optgroup label="Organization Providers">
+          <c:forEach var="opt" items="${organizationProviderTypes}">
+            <option ${formValue == opt.description ? selectedMarkup : ''}
+              value="${opt.description}">
+              <c:out value="${opt.description}" />
+            </option>
+          </c:forEach>
+        </optgroup>
+      </c:if>
+    </select>
+  </div>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
@@ -15,7 +15,10 @@
   <div class="wholeCol">
     <c:set var="formName" value="_01_providerType"></c:set>
     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-    <label for="${formIdPrefix}_${formName}">Provider Type</label>
+    <label for="${formIdPrefix}_${formName}">
+      Provider Type
+      <a href="javascript:" class="userHelpLink providerTypeHelpLink">?</a>
+    </label>
     <select id="${formIdPrefix}_${formName}" name="${formName}">
       <option value="">Please select</option>
       <c:if test="${empty individualProviderTypes or

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1905,6 +1905,16 @@ $(document).ready(function () {
     "Questions About Editing an Enrollment"
   );
 
+  addUserHelpClickHandler(
+    'a.providerTypeHelpLink',
+    '/help/enrollment.html',
+    [
+      'how-do-i-input-an-enrollment-for-an-organization-with-several-individual-providers-e-g-a-clinic-employing-several-physicians',
+      'what-do-i-do-if-none-of-the-provider-types-seem-to-describe-what-i-do-what-this-provider-does'
+    ],
+    'Questions About Selecting a Provider Type'
+  );
+
   //$('.inline input[type=radio]').removeAttr('checked');
   //    $('.inline input[name=civilMoney]').click(function(){
   //        if($(this).val()=="yes"){


### PR DESCRIPTION
Add contextual user help link and modal for selecting provider type, on the "Select Provider Type" page when starting a new enrollment application.  Includes removing the extraneous colon on that page.

Changes are based on those in PR #706. No review needed until 706 lands and this is rebased.

Tested by starting an enrollment application and checking that the link/modal worked as expected.

Screenshot:

![screenshot-2018-3-13 provider type page](https://user-images.githubusercontent.com/1091693/37353811-8355e7a0-26b6-11e8-8d6a-e952fa50a138.png)

Issue #422 Review documentation to add [...] help links
Issue #376 Remove colons between form labels and fields