### PR TITLE
Hide "No file selected" message

### DIFF
--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -1267,8 +1267,9 @@ input.date{
   background:url(../i/input-bg.png) repeat-x left top #fffffe;
 }
 
-.tableData table input.fileUpload{
-  width:160px;
+input.fileUpload{
+    width:160px;
+    color: transparent;
 }
 
 .tableData table input.date{
@@ -4199,9 +4200,6 @@ input.passwordNormalInput{
   float: left;
   width: 13px;
   height: 13px;
-}
-.facility td input[type=file]{
-  width: 200px !important;
 }
 .alternateTable td:first-child span{
   line-height: 13px;


### PR DESCRIPTION
Use CSS to hide the message automatically attached to "file" type
inputs.  This might be problematic in some ways: I haven't gone through
thorough cross-browser testing, and this is likely to behave in
different ways in different browsers.  I checked in Edge and Firefox.

@PaulMorris, would you check my CSS knowledge?

Test by opening a draft enrollment, uploading a file, and saving a draft or moving to the next page.  You'll see the link to the file but not the "No file selected" text.

https://screenshots.firefox.com/YZg4kjdNdd3wfGmv/localhost (Facility license)

https://screenshots.firefox.com/6GAMAEWHS6w22BTl/localhost (Regular license)

Fixes #158