### PR TITLE
Add user help modals for agreements and addendums

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -47,8 +47,14 @@
 
                 <div class="pagination">
                   <div class="right">
-                    <a href="${ctx}/admin/editAgreementDocument?agreementId=0&agreementDocumentType=ADDENDUM" class="purpleBtn addAgreementBtn">Add Agreement Addendum</a>
-                    <a href="${ctx}/admin/editAgreementDocument?agreementId=0&agreementDocumentType=AGREEMENT" class="purpleBtn addAgreementBtn">Add Agreement</a>
+                    <a href="${ctx}/admin/editAgreementDocument?agreementId=0&agreementDocumentType=AGREEMENT"
+                      class="purpleBtn addAgreementBtn">
+                      Add Agreement
+                    </a>
+                    <a href="${ctx}/admin/editAgreementDocument?agreementId=0&agreementDocumentType=ADDENDUM"
+                      class="purpleBtn addAgreementBtn">
+                      Add Addendum
+                    </a>
                   </div>
                 </div>
                 <div class="pagination">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -55,6 +55,7 @@
                       class="purpleBtn addAgreementBtn">
                       Add Addendum
                     </a>
+                    <a href="javascript:" class="userHelpLink agreementsAddendumsHelpLink">?</a>
                   </div>
                 </div>
                 <div class="pagination">
@@ -285,6 +286,12 @@
         </div>
         <!-- /.modalFooter -->
       </div>
+
+      <div id="new-modal">
+        <c:set var="userHelpModalId" value="user-help-modal"/>
+        <h:handlebars template="includes/userhelp/user_help_modal" context="${pageContext}" />
+      </div>
+
     </div>
   </body>
 </html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/definitions_modal.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/definitions_modal.jsp
@@ -10,7 +10,7 @@
 <div class="inner">
 <!-- title -->
 <div class="modal-title">
-    <a href="javascript:;" class="greyBtn iconX">
+    <a href="javascript:;" class="greyBtn iconX modalCloseButton">
       Close
     </a>
     <h3>Definitions</h3>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -3305,6 +3305,10 @@ a.searchBtn {
   font-size:14px;
 
 }
+#new-modal .userHelpModalBody p {
+  text-align: left;
+  margin: 0.8em 0 0.5em 0;
+}
 #new-modal .inner .buttonArea{
   padding-top:35px;
   padding-bottom:15px;

--- a/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
@@ -47,6 +47,8 @@
     {{/if}}
   </script>
 
+  <script src="{{ctx}}/js/common.js" type="text/javascript"></script>
+
   {{#if adminPage}}
     <script src="{{ctx}}/js/admin/script.js" type="text/javascript"></script>
   {{else if systemPage}}

--- a/psm-app/cms-web/WebContent/templates/includes/userhelp/user_help_modal.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/userhelp/user_help_modal.template.html
@@ -3,7 +3,7 @@
   <div class="inner">
 
     <div class="modal-title">
-      <a href="javascript:;" class="greyBtn iconX">
+      <a href="javascript:;" class="greyBtn iconX modalCloseButton">
         Close
       </a>
       <h2 class="userHelpModalTitle"></h2>

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -565,16 +565,6 @@ $(document).ready(function () {
 
   /*new js*/
 
-  $(".submitEnrollmentModalBtn").click(function () {
-      addresscloseModal();
-      addressLoadModal('#submitEnrollmentModal');
-    });
-
-  $(".saveAsDraftModalBtn").click(function () {
-      addresscloseModal();
-      addressLoadModal('#saveAsDraftModal');
-    });
-
   $('.printModalBtn').click(function () {
       addresscloseModal();
       addressLoadModal('#printModal');

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -580,6 +580,12 @@ $(document).ready(function () {
       addressLoadModal('#printModal');
     });
 
+  addUserHelpClickHandler(
+    'a.agreementsAddendumsHelpLink',
+    '/help/service-admin-help.html',
+    'what-s-the-difference-between-an-agreement-and-an-addendum'
+  );
+
   $('.editInfo').click(function () {
     $(this).parents('.tabContent').find('.editInfo').hide();
     $(this).parents('.tabContent').find('.plainInformation').hide();

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -562,52 +562,8 @@ $(document).ready(function () {
       alert("processing failed,please try later.")
     }
   });
+
   /*new js*/
-  $('.searchPanel input[type="checkbox"]').css("border", "none").css("background", "none").css("position", "relative").css('top', "-1px");
-  addressPositionModal = function () {
-    var wWidth  = window.innerWidth;
-    var wHeight = window.innerHeight;
-
-    if (wWidth == undefined) {
-      wWidth  = document.documentElement.clientWidth;
-      wHeight = document.documentElement.clientHeight;
-    }
-
-    var boxLeft = parseInt((wWidth / 2) - ($("#new-modal").width() / 2));
-    //var boxTop  = parseInt((wHeight / 2) - ( $("#new-modal").height() / 2 ));
-
-    // position modal
-    $("#new-modal").css({
-      'margin': 120 + 'px auto 0 ' + boxLeft + 'px'
-    });
-
-    $("#modalBackground").css("opacity", "0.8");
-
-    if ($("body").height() > $("#modalBackground").height()) {
-      $("#modalBackground").css("height", $("body").height() + "px");
-    }
-
-    if ($('#new-modal').height() > $("#modalBackground").height()) {
-      $("#modalBackground").css("height", $('#new-modal').height() + 120 + "px");
-    }
-
-    window.scrollTo(0);
-  }
-
-  addressLoadModal = function (itemId) {
-        $('#modalBackground').show();
-        $(itemId).show();
-        addressPositionModal();
-      }
-
-  addresscloseModal = function () {
-        $('#modalBackground').hide();
-        $('#new-modal>div').hide();
-      }
-
-  $(".closeModal,#new-modal #printModal .modal-title a.greyBtn").click(function () {
-    addresscloseModal();
-  });
 
   $(".submitEnrollmentModalBtn").click(function () {
       addresscloseModal();

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -566,7 +566,7 @@ $(document).ready(function () {
   /*new js*/
 
   $('.printModalBtn').click(function () {
-      addresscloseModal();
+      addressCloseModal();
       addressLoadModal('#printModal');
     });
 

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -108,7 +108,7 @@ $(document).ready(function () {
     });
   };
 
-  $(".closeModal, #new-modal #printModal .modal-title a.greyBtn, #new-modal .definitionsModal .modal-title a.greyBtn")
+  $(".closeModal, .modalCloseButton, #new-modal #printModal .modal-title a.greyBtn")
     .click(addresscloseModal);
 
 });

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -42,7 +42,7 @@ $(document).ready(function () {
     addressPositionModal();
   }
 
-  addresscloseModal = function () {
+  addressCloseModal = function () {
     $('#modalBackground').hide();
     $('#new-modal>div').hide();
   }
@@ -109,15 +109,15 @@ $(document).ready(function () {
   };
 
   $(".closeModal, .modalCloseButton, #new-modal #printModal .modal-title a.greyBtn")
-    .click(addresscloseModal);
+    .click(addressCloseModal);
 
   $(".submitEnrollmentModalBtn").click(function () {
-    addresscloseModal();
+    addressCloseModal();
     addressLoadModal('#submitEnrollmentModal');
   });
 
   $(".saveAsDraftModalBtn").click(function () {
-    addresscloseModal();
+    addressCloseModal();
     addressLoadModal('#saveAsDraftModal');
   });
 

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -111,4 +111,14 @@ $(document).ready(function () {
   $(".closeModal, .modalCloseButton, #new-modal #printModal .modal-title a.greyBtn")
     .click(addresscloseModal);
 
+  $(".submitEnrollmentModalBtn").click(function () {
+    addresscloseModal();
+    addressLoadModal('#submitEnrollmentModal');
+  });
+
+  $(".saveAsDraftModalBtn").click(function () {
+    addresscloseModal();
+    addressLoadModal('#saveAsDraftModal');
+  });
+
 });

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -1,0 +1,114 @@
+$(document).ready(function () {
+
+  $('.searchPanel input[type="checkbox"]')
+    .css("border", "none")
+    .css("background", "none")
+    .css("position", "relative")
+    .css('top', "-1px");
+
+  addressPositionModal = function () {
+    var wWidth  = window.innerWidth;
+    var wHeight = window.innerHeight;
+
+    if (wWidth == undefined) {
+      wWidth  = document.documentElement.clientWidth;
+      wHeight = document.documentElement.clientHeight;
+    }
+
+    boxLeft = parseInt((wWidth / 2) - ($("#new-modal").width() / 2));
+    //var boxTop  = parseInt((wHeight / 2) - ( $("#new-modal").height() / 2 ));
+
+    // position modal
+    $("#new-modal").css({
+      'margin': 120 + 'px auto 0 ' + boxLeft + 'px'
+    });
+
+    $("#modalBackground").css("opacity", "0.8");
+
+    if ($("body").height() > $("#modalBackground").height()) {
+      $("#modalBackground").css("height", $("body").height() + "px");
+    }
+
+    if ($('#new-modal').height() > $("#modalBackground").height()) {
+      $("#modalBackground").css("height", $('#new-modal').height() + 120 + "px");
+    }
+
+    $(window).scrollTop(0);
+  };
+
+  addressLoadModal = function (itemId) {
+    $('#modalBackground').show();
+    $(itemId).show();
+    addressPositionModal();
+  }
+
+  addresscloseModal = function () {
+    $('#modalBackground').hide();
+    $('#new-modal>div').hide();
+  }
+
+  /**
+  * Clears and resets the contents of the user help modal
+  * (before it gets populated with results of AJAX call).
+  */
+  resetUserHelpModal = function (modalSelector) {
+    var modal = document.querySelector(modalSelector);
+    var modalTitle = modal.querySelector('.userHelpModalTitle');
+    var modalBody = modal.querySelector('.userHelpModalBody');
+    modalTitle.innerHTML = '';
+    modalBody.innerHTML = 'Loading...';
+  }
+
+  /**
+  * Populates a user help modal with content.  With the first two
+  * arguments bound (using '.bind'), this is used as the callback
+  * function for AJAX calls that fetch a user help page.  It extracts
+  * the relevant content from the help page and adds it to the modal.
+  *
+  * @param modalId {string} - ID of the target modal.
+  * @param helpItemId {string} - ID of the source help item.
+  * @param helpPageString {string} - HTML of the help page.
+  */
+  populateUserHelpModal = function (modalId, helpItemId, helpPageString) {
+    var parser = new DOMParser();
+    var helpPage = parser.parseFromString(helpPageString, "text/html");
+
+    var helpItem = helpPage.getElementById(helpItemId);
+    var helpTitle = helpItem.querySelector("h2");
+
+    var modal = document.getElementById(modalId);
+    var modalTitle = modal.querySelector(".userHelpModalTitle");
+    var modalBody = modal.querySelector(".userHelpModalBody");
+
+    modalTitle.innerHTML = helpTitle.firstChild.textContent;
+
+    helpItem.removeChild(helpTitle);
+    modalBody.innerHTML = helpItem.innerHTML;
+  };
+
+  /**
+  * Add a click handler function to a user help modal link.
+  *
+  * @param helpLinkSelector {string} - Selector for the help link.
+  * @param helpDocsPath {string} - Path to the help doc html file.
+  * @param helpItemId {string} - ID of the source help item.
+  */
+  addUserHelpClickHandler = function (helpLinkSelector, helpDocsPath, helpItemId) {
+    $(helpLinkSelector).click(function () {
+      resetUserHelpModal('#user-help-modal');
+      addressLoadModal('#user-help-modal');
+      $.get(
+        ctx + helpDocsPath,
+        populateUserHelpModal.bind(
+          undefined,
+          'user-help-modal',
+          helpItemId
+        )
+      );
+    });
+  };
+
+  $(".closeModal, #new-modal #printModal .modal-title a.greyBtn, #new-modal .definitionsModal .modal-title a.greyBtn")
+    .click(addresscloseModal);
+
+});

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -10,51 +10,6 @@ $(document).ready(function () {
   });
 
   /*new js*/
-  $('.searchPanel input[type="checkbox"]').css("border", "none").css("background", "none").css("position", "relative").css('top', "-1px");
-  addressPositionModal = function () {
-    var wWidth  = window.innerWidth;
-    var wHeight = window.innerHeight;
-
-    if (wWidth == undefined) {
-      wWidth  = document.documentElement.clientWidth;
-      wHeight = document.documentElement.clientHeight;
-    }
-
-    var boxLeft = parseInt((wWidth / 2) - ($("#new-modal").width() / 2));
-    //var boxTop  = parseInt((wHeight / 2) - ( $("#new-modal").height() / 2 ));
-
-    // position modal
-    $("#new-modal").css({
-      'margin': 120 + 'px auto 0 ' + boxLeft + 'px'
-    });
-
-    $("#modalBackground").css("opacity", "0.8");
-
-    if ($("body").height() > $("#modalBackground").height()) {
-      $("#modalBackground").css("height", $("body").height() + "px");
-    }
-
-    if ($('#new-modal').height() > $("#modalBackground").height()) {
-      $("#modalBackground").css("height", $('#new-modal').height() + 120 + "px");
-    }
-
-    $(window).scrollTop(0);
-  }
-
-  addressLoadModal = function (itemId) {
-    $('#modalBackground').show();
-    $(itemId).show();
-    addressPositionModal();
-  }
-
-  addresscloseModal = function () {
-      $('#modalBackground').hide();
-      $('#new-modal>div').hide();
-    }
-
-  $(".closeModal,#new-modal #printModal .modal-title a.greyBtn,#new-modal .definitionsModal .modal-title a.greyBtn").click(function () {
-      addresscloseModal();
-    });
 
   $(".submitEnrollmentModalBtn").click(function () {
       addresscloseModal();
@@ -70,45 +25,6 @@ $(document).ready(function () {
   //		addresscloseModal();
   //        addressLoadModal('#printModal');
   //    });
-
-  /**
-  * Clears and resets the contents of the user help modal
-  * (before it gets populated with results of AJAX call).
-  */
-  resetUserHelpModal = function(modalSelector) {
-    var modal = document.querySelector(modalSelector);
-    var modalTitle = modal.querySelector('.userHelpModalTitle');
-    var modalBody = modal.querySelector('.userHelpModalBody');
-    modalTitle.innerHTML = '';
-    modalBody.innerHTML = 'Loading...';
-  }
-
-  /**
-  * Populates a user help modal with content.  With the first two
-  * arguments bound (using '.bind'), this is used as the callback
-  * function for AJAX calls that fetch a user help page.  It extracts
-  * the relevant content from the help page and adds it to the modal.
-  *
-  * @param modalId {string} - ID of the target modal.
-  * @param helpItemId {string} - ID of the source help item.
-  * @param helpPageString {string} - HTML of the help page.
-  */
-  populateUserHelpModal = function(modalId, helpItemId, helpPageString) {
-    var parser = new DOMParser();
-    var helpPage = parser.parseFromString(helpPageString, "text/html");
-
-    var helpItem = helpPage.getElementById(helpItemId);
-    var helpTitle = helpItem.querySelector("h2");
-
-    var modal = document.getElementById(modalId);
-    var modalTitle = modal.querySelector(".userHelpModalTitle");
-    var modalBody = modal.querySelector(".userHelpModalBody");
-
-    modalTitle.innerHTML = helpTitle.firstChild.textContent;
-
-    helpItem.removeChild(helpTitle);
-    modalBody.innerHTML = helpItem.innerHTML;
-  };
 
   $('.printMe').click(function () {
     printThis($(this).attr("href"));
@@ -1968,29 +1884,6 @@ $(document).ready(function () {
   $('a.ownershipTypeDefinition').click(function () {
     addressLoadModal('#definitionsModal');
   });
-
-
-  /**
-  * Add a click handler function to a user help modal link.
-  *
-  * @param helpLinkSelector {string} - Selector for the help link.
-  * @param helpDocsPath {string} - Path to the help doc html file.
-  * @param helpItemId {string} - ID of the source help item.
-  */
-  addUserHelpClickHandler = function(helpLinkSelector, helpDocsPath, helpItemId) {
-    $(helpLinkSelector).click(function () {
-      resetUserHelpModal('#user-help-modal');
-      addressLoadModal('#user-help-modal');
-      $.get(
-        ctx + helpDocsPath,
-        populateUserHelpModal.bind(
-          undefined,
-          'user-help-modal',
-          helpItemId
-        )
-      );
-    });
-  };
 
   addUserHelpClickHandler(
     'a.NPIdefinition',

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -12,7 +12,7 @@ $(document).ready(function () {
   /*new js*/
 
   //	$('.printModalBtn').click(function(){
-  //		addresscloseModal();
+  //		addressCloseModal();
   //        addressLoadModal('#printModal');
   //    });
 
@@ -28,7 +28,7 @@ $(document).ready(function () {
     });
 
   //	$('.practiceLookupModalBtn').click(function(){
-  //		addresscloseModal();
+  //		addressCloseModal();
   //		addressLoadModal('#practiceLookupModal');
   //	});
   //		$('#practiceLookupModal .searchBtn').click(function(){
@@ -49,21 +49,21 @@ $(document).ready(function () {
       $('#tabLicense .editContent').hide();
       $('#tabLicense .plainInformation').show();
       $('#tabLicense .editInfo').show();
-      addresscloseModal();
+      addressCloseModal();
     });
 
   $('#saveAsDraftModalPersonal .editToPlain').click(function () {
       $('#tabPersonal .editContent').hide();
       $('#tabPersonal .plainInformation').show();
       $('#tabPersonal .editInfo').show();
-      addresscloseModal();
+      addressCloseModal();
     });
 
   $('#saveAsDraftModalPractice .editToPlain').click(function () {
       $('#tabPractice .editContent').hide();
       $('#tabPractice .plainInformation').show();
       $('#tabPractice .editInfo').show();
-      addresscloseModal();
+      addressCloseModal();
     });
 
   $(window).resize(function () {
@@ -1464,16 +1464,16 @@ $(document).ready(function () {
 
         stripTable();
         update();
-        addresscloseModal();
+        addressCloseModal();
       });
 
-      addresscloseModal();
+      addressCloseModal();
       addressLoadModal('#deleteUserAccountModal');
     }
   });
 
   $(".deleteUserAccountModalBtnSingle").click(function () {
-      addresscloseModal();
+      addressCloseModal();
       addressLoadModal('#deleteUserAccountModal');
       $("a#deleteBtn").unbind();
     })
@@ -1484,10 +1484,10 @@ $(document).ready(function () {
         tr.remove();
         stripTable();
         update();
-        addresscloseModal();
+        addressCloseModal();
       });
 
-      addresscloseModal();
+      addressCloseModal();
       addressLoadModal('#deleteUserAccountModal');
     });
 
@@ -1970,7 +1970,7 @@ $(document).ready(function () {
   })
 
   $('#flashPopUp').each(function () {
-    addresscloseModal();
+    addressCloseModal();
     addressLoadModal('#' + $(this).val());
   });
 

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -11,16 +11,6 @@ $(document).ready(function () {
 
   /*new js*/
 
-  $(".submitEnrollmentModalBtn").click(function () {
-      addresscloseModal();
-      addressLoadModal('#submitEnrollmentModal');
-    });
-
-  $(".saveAsDraftModalBtn").click(function () {
-      addresscloseModal();
-      addressLoadModal('#saveAsDraftModal');
-    });
-
   //	$('.printModalBtn').click(function(){
   //		addresscloseModal();
   //        addressLoadModal('#printModal');

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -8,51 +8,6 @@
  */
 $(document).ready(function () {
   /*new js*/
-  $('.searchPanel input[type="checkbox"]').css("border", "none").css("background", "none").css("position", "relative").css('top', "-1px");
-  addressPositionModal = function () {
-    var wWidth  = window.innerWidth;
-    var wHeight = window.innerHeight;
-
-    if (wWidth == undefined) {
-      wWidth  = document.documentElement.clientWidth;
-      wHeight = document.documentElement.clientHeight;
-    }
-
-    var boxLeft = parseInt((wWidth / 2) - ($("#new-modal").width() / 2));
-    //var boxTop  = parseInt((wHeight / 2) - ( $("#new-modal").height() / 2 ));
-
-    // position modal
-    $("#new-modal").css({
-      'margin': 120 + 'px auto 0 ' + boxLeft + 'px'
-    });
-
-    $("#modalBackground").css("opacity", "0.8");
-
-    if ($("body").height() > $("#modalBackground").height()) {
-      $("#modalBackground").css("height", $("body").height() + "px");
-    }
-
-    if ($('#new-modal').height() > $("#modalBackground").height()) {
-      $("#modalBackground").css("height", $('#new-modal').height() + 120 + "px");
-    }
-
-    window.scrollTo(0, 0);
-  };
-
-  addressLoadModal = function (itemId) {
-        $('#modalBackground').show();
-        $(itemId).show();
-        addressPositionModal();
-      }
-
-  addresscloseModal = function () {
-        $('#modalBackground').hide();
-        $('#new-modal>div').hide();
-      }
-
-  $(".closeModal,#new-modal #printModal .modal-title a.greyBtn").click(function () {
-    addresscloseModal();
-  });
 
   $(".submitEnrollmentModalBtn").click(function () {
       addresscloseModal();

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -9,16 +9,6 @@
 $(document).ready(function () {
   /*new js*/
 
-  $(".submitEnrollmentModalBtn").click(function () {
-      addresscloseModal();
-      addressLoadModal('#submitEnrollmentModal');
-    });
-
-  $(".saveAsDraftModalBtn").click(function () {
-      addresscloseModal();
-      addressLoadModal('#saveAsDraftModal');
-    });
-
   $('.printModalBtn').click(function () {
       addresscloseModal();
       addressLoadModal('#printModal');

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
   /*new js*/
 
   $('.printModalBtn').click(function () {
-      addresscloseModal();
+      addressCloseModal();
       addressLoadModal('#printModal');
     });
 
@@ -21,7 +21,7 @@ $(document).ready(function () {
   });
 
   $('.practiceLookupModalBtn').click(function () {
-    addresscloseModal();
+    addressCloseModal();
     addressLoadModal('#practiceLookupModal');
   });
 
@@ -44,21 +44,21 @@ $(document).ready(function () {
     $('#tabLicense .editContent').hide();
     $('#tabLicense .plainInformation').show();
     $('#tabLicense .editInfo').show();
-    addresscloseModal();
+    addressCloseModal();
   });
 
   $('#saveAsDraftModalPersonal .editToPlain').click(function () {
     $('#tabPersonal .editContent').hide();
     $('#tabPersonal .plainInformation').show();
     $('#tabPersonal .editInfo').show();
-    addresscloseModal();
+    addressCloseModal();
   });
 
   $('#saveAsDraftModalPractice .editToPlain').click(function () {
     $('#tabPractice .editContent').hide();
     $('#tabPractice .plainInformation').show();
     $('#tabPractice .editInfo').show();
-    addresscloseModal();
+    addressCloseModal();
   });
 
   $(window).resize(function () {
@@ -1143,10 +1143,10 @@ $(document).ready(function () {
             });
 
             deleteUserAccounts(userIds, false);
-            addresscloseModal();
+            addressCloseModal();
           });
 
-        addresscloseModal();
+        addressCloseModal();
         $('.deleteAccountSpan').html('the selected user account');
         if (table.find("tbody").find("input:checkbox:checked").length > 1) {
           $('.deleteAccountSpan').html('the selected user accounts');
@@ -1159,7 +1159,7 @@ $(document).ready(function () {
 
   $(".deleteUserAccountModalBtnSingle").click(function () {
     var userId = $(this).attr('rel');
-    addresscloseModal();
+    addressCloseModal();
     $('.deleteAccountSpan').html('this user account');
     deleteSeletedFlag = false;
     $("a#deleteBtn").unbind().bind("click", function () {
@@ -1168,7 +1168,7 @@ $(document).ready(function () {
               }
 
               deleteUserAccounts([userId], true);
-              addresscloseModal();
+              addressCloseModal();
             });
 
     addressLoadModal('#deleteUserAccountModal');
@@ -1182,10 +1182,10 @@ $(document).ready(function () {
             }
 
             deleteUserAccounts([$('input[type="checkbox"]', tr).val()], false);
-            addresscloseModal();
+            addressCloseModal();
           });
 
-    addresscloseModal();
+    addressCloseModal();
     $('.deleteAccountSpan').html('this user account');
     deleteSeletedFlag = false;
     addressLoadModal('#deleteUserAccountModal');


### PR DESCRIPTION
Add contextual user help link and modal for the difference between agreements and addendums, on the admin login > functions > agreements and addendums page, next to the "Add Agreement" buttons.

Includes introducing and using a JS file for code that is shared across provider, admin, and system logins / parts of the site, and some related refactoring.

Tested by checking that the help link works as expected.  Also checked other help links and successfully ran integration tests, noting that other modals still work.

Issue #422 Review documentation to add [...] help links