### PR TITLE
Add search to the Task / enrollment API

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/TaskResourceProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/TaskResourceProvider.java
@@ -2,9 +2,14 @@ package gov.medicaid.api;
 
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Read;
+import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import gov.medicaid.api.transformers.EnrollmentToFhir;
+import gov.medicaid.entities.CMSUser;
 import gov.medicaid.entities.Enrollment;
+import gov.medicaid.entities.ProviderSearchCriteria;
+import gov.medicaid.entities.SearchResult;
+import gov.medicaid.entities.UserRequest;
 import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
@@ -12,11 +17,16 @@ import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Task;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class TaskResourceProvider implements IResourceProvider {
     private final ProviderEnrollmentService providerEnrollmentService;
+    private final CMSUser systemUser;
 
     TaskResourceProvider(ProviderEnrollmentService providerEnrollmentService) {
         this.providerEnrollmentService = providerEnrollmentService;
+        systemUser = new CMSConfigurator().getSystemUser();
     }
 
     @Override
@@ -25,11 +35,34 @@ public class TaskResourceProvider implements IResourceProvider {
     }
 
     @Read
-    public Task getResourceById(@IdParam IdType id) throws PortalServiceException {
-        Enrollment enrollment = providerEnrollmentService.getTicketDetails(
-                new CMSConfigurator().getSystemUser(),
-                id.getIdPartAsLong()
+    public Task getResourceById(@IdParam IdType id) {
+        return enrollmentIdToTask(id.getIdPartAsLong());
+    }
+
+    @Search
+    public List<Task> findAll() throws PortalServiceException {
+        ProviderSearchCriteria criteria = new ProviderSearchCriteria();
+        SearchResult<UserRequest> results = providerEnrollmentService.searchTickets(
+                systemUser,
+                criteria
         );
+
+        return results.getItems()
+                .stream()
+                .map(result -> enrollmentIdToTask(result.getTicketId()))
+                .collect(Collectors.toList());
+    }
+
+    private Task enrollmentIdToTask(long enrollmentId) {
+        Enrollment enrollment;
+        try {
+            enrollment = providerEnrollmentService.getTicketDetails(
+                    systemUser,
+                    enrollmentId
+            );
+        } catch (PortalServiceException e) {
+            return null;
+        }
         if (enrollment == null) {
             return null;
         }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentStatusToPsmName.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentStatusToPsmName.java
@@ -1,0 +1,27 @@
+package gov.medicaid.api.transformers;
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import org.hl7.fhir.dstu3.model.Task;
+
+import java.util.function.Function;
+
+public class EnrollmentStatusToPsmName implements Function<String, String> {
+    private static final String INVALID_STATUS_CODE_MESSAGE =
+            "Invalid task status code. Must be one of 'draft'," +
+            " 'requested', 'rejected', or 'accepted'.";
+
+    @Override
+    public String apply(String s) {
+        if (Task.TaskStatus.DRAFT.toCode().equalsIgnoreCase(s)) {
+            return "Draft";
+        } else if (Task.TaskStatus.REQUESTED.toCode().equalsIgnoreCase(s)) {
+            return "Pending";
+        } else if (Task.TaskStatus.REJECTED.toCode().equalsIgnoreCase(s)) {
+            return "Rejected";
+        } else if (Task.TaskStatus.ACCEPTED.toCode().equalsIgnoreCase(s)) {
+            return "Approved";
+        } else {
+            throw new InvalidRequestException(INVALID_STATUS_CODE_MESSAGE);
+        }
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
@@ -2,7 +2,6 @@ package gov.medicaid.api.transformers;
 
 import gov.medicaid.entities.Enrollment;
 import org.hl7.fhir.dstu3.model.DomainResource;
-import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.Task;
 
@@ -16,7 +15,7 @@ public class EnrollmentToFhir implements Function<Enrollment, Task> {
         );
 
         Task task = new Task();
-        task.addIdentifier(getIdentifier(enrollment));
+        task.setId(Long.toString(enrollment.getTicketId()));
         task.setStatus(
                 new EnrollmentStatusToFhir().apply(enrollment.getStatus())
         );
@@ -30,10 +29,5 @@ public class EnrollmentToFhir implements Function<Enrollment, Task> {
         task.addContained(requester);
 
         return task;
-    }
-
-    private Identifier getIdentifier(Enrollment enrollment) {
-        return new Identifier()
-                .setValue(Long.toString(enrollment.getTicketId()));
     }
 }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
@@ -64,7 +64,7 @@ class TaskResourceProviderTest extends Specification {
 
         then:
         result instanceof Task
-        result.identifier.size() == 1
-        result.identifier.first().value == Long.toString(ticketId)
+        result.hasId()
+        result.getId() == Long.toString(ticketId)
     }
 }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
@@ -1,5 +1,6 @@
 package gov.medicaid.api
 
+import gov.medicaid.entities.CMSUser
 import gov.medicaid.entities.Enrollment
 import gov.medicaid.entities.Organization
 import gov.medicaid.entities.ProviderProfile
@@ -27,8 +28,8 @@ class TaskResourceProviderTest extends Specification {
 
         then:
         1 * mockEnrollmentService.getTicketDetails(
-                {it.role.description == "System Administrator"},
-                _
+                { it.role.description == "System Administrator" } as CMSUser,
+                _ as Long
         )
     }
 

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
@@ -1,9 +1,13 @@
 package gov.medicaid.api
 
+import ca.uhn.fhir.rest.param.StringOrListParam
+import ca.uhn.fhir.rest.param.StringParam
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException
 import gov.medicaid.entities.CMSUser
 import gov.medicaid.entities.Enrollment
 import gov.medicaid.entities.Organization
 import gov.medicaid.entities.ProviderProfile
+import gov.medicaid.entities.ProviderSearchCriteria
 import gov.medicaid.entities.ProviderType
 import gov.medicaid.entities.SearchResult
 import gov.medicaid.entities.UserRequest
@@ -11,6 +15,7 @@ import gov.medicaid.services.ProviderEnrollmentService
 import org.hl7.fhir.dstu3.model.IdType
 import org.hl7.fhir.dstu3.model.Task
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class TaskResourceProviderTest extends Specification {
     TaskResourceProvider provider
@@ -64,20 +69,20 @@ class TaskResourceProviderTest extends Specification {
         result.getId() == Long.toString(ticketId)
     }
 
-    def "Find all with no applications returns empty list"() {
+    def "Search all with no applications returns empty list"() {
         given:
         def searchResults = new SearchResult<UserRequest>()
         searchResults.items = []
         mockEnrollmentService.searchTickets(_, _) >> searchResults
 
         when:
-        def result = provider.findAll()
+        def result = provider.search(null, null, null, null)
 
         then:
         result.size() == 0
     }
 
-    def "Find all with one application returns a list with that application"() {
+    def "Search all with one application returns a list with that application"() {
         given:
         def searchResults = new SearchResult<UserRequest>()
         def userRequest = new UserRequest(
@@ -100,11 +105,112 @@ class TaskResourceProviderTest extends Specification {
         mockEnrollmentService.getTicketDetails(_, ticketId) >> createEnrollment()
 
         when:
-        def result = provider.findAll()
+        def result = provider.search(null, null, null, null)
 
         then:
         result.size() == 1
         result.first().getId() == Long.toString(ticketId)
+    }
+
+    def "Search by NPI includes NPI in query"() {
+        given:
+        def searchResults = new SearchResult<UserRequest>()
+        searchResults.items = []
+
+        when:
+        provider.search("1234567893", null, null, null)
+
+        then:
+        1 * mockEnrollmentService.searchTickets(
+                _ as CMSUser,
+                { it.npi == "1234567893" } as ProviderSearchCriteria
+        ) >> searchResults
+    }
+
+    def "Search by provider type includes provider type in query"() {
+        given:
+        def searchResults = new SearchResult<UserRequest>()
+        searchResults.items = []
+
+        when:
+        provider.search(null, null, "Acupuncturist", null)
+
+        then:
+        1 * mockEnrollmentService.searchTickets(
+                _ as CMSUser,
+                { it.providerType == "Acupuncturist" } as ProviderSearchCriteria
+        ) >> searchResults
+    }
+
+    def "Search by name includes name in query"() {
+        given:
+        def searchResults = new SearchResult<UserRequest>()
+        searchResults.items = []
+
+        when:
+        provider.search(null, null, null, "name")
+
+        then:
+        1 * mockEnrollmentService.searchTickets(
+                _ as CMSUser,
+                { it.providerName == "name" } as ProviderSearchCriteria
+        ) >> searchResults
+    }
+
+    def "Search by single status includes status in query"() {
+        given:
+        def searchResults = new SearchResult<UserRequest>()
+        searchResults.items = []
+
+        when:
+        def statuses = new StringOrListParam()
+        statuses.addOr(new StringParam("Accepted"))
+        provider.search(null, statuses, null, null)
+
+        then:
+        1 * mockEnrollmentService.searchTickets(
+                _ as CMSUser,
+                { it.statuses == ["Approved"] } as ProviderSearchCriteria
+        ) >> searchResults
+    }
+
+    def "Search by multiple statuses includes statuses in query"() {
+        given:
+        def searchResults = new SearchResult<UserRequest>()
+        searchResults.items = []
+
+        when:
+        def statuses = new StringOrListParam()
+        statuses.addOr(new StringParam("Rejected"))
+        statuses.addOr(new StringParam("Accepted"))
+
+        provider.search(null, statuses, null, null)
+
+        then:
+        1 * mockEnrollmentService.searchTickets(
+                _ as CMSUser,
+                {
+                    it.statuses == ["Rejected", "Approved"]
+                } as ProviderSearchCriteria
+        ) >> searchResults
+    }
+
+    @Unroll
+    def "Search with an invalid (#reason) NPI returns an error"(
+            String reason,
+            String invalidNpi
+    ) {
+        when:
+        provider.search(invalidNpi, null, null, null)
+
+        then:
+        thrown(InvalidRequestException)
+
+        where:
+        reason        | invalidNpi
+        "too short"   | "123456789"
+        "too long"    | "12345678901"
+        "non-numeric" | "12345abcde"
     }
 
     private static Enrollment createEnrollment() {

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentStatusToPsmNameTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentStatusToPsmNameTest.groovy
@@ -1,0 +1,47 @@
+package gov.medicaid.api.transformers
+
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class EnrollmentStatusToPsmNameTest extends Specification {
+    private EnrollmentStatusToPsmName function
+
+    def setup() {
+        function = new EnrollmentStatusToPsmName()
+    }
+
+    @Unroll
+    def "#fhirName maps to #psmName"(fhirName, psmName) {
+        expect:
+        function.apply(fhirName) == psmName
+
+        where:
+        fhirName    | psmName
+        "draft"     | "Draft"
+        "requested" | "Pending"
+        "rejected"  | "Rejected"
+        "accepted"  | "Approved"
+    }
+
+    @Unroll
+    def "Conversion is not case sensitive"(fhirName, psmName) {
+        expect:
+        function.apply(fhirName) == psmName
+
+        where:
+        fhirName    | psmName
+        "DRAFT"     | "Draft"
+        "Requested" | "Pending"
+        "ReJeCtEd"  | "Rejected"
+        "accepted"  | "Approved"
+    }
+
+    def "Invalid status is rejected"() {
+        when:
+        function.apply("not a valid status")
+
+        then:
+        thrown(InvalidRequestException)
+    }
+}

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentToFhirTest.groovy
@@ -69,8 +69,7 @@ class EnrollmentToFhirTest extends Specification {
         def result = transformer.apply(enrollment)
 
         then:
-        result.hasIdentifier()
-        result.identifier.size() == 1
-        result.identifier.first().value == "123"
+        result.hasId()
+        result.getId() == "123"
     }
 }


### PR DESCRIPTION
Allow retrieving all enrollment applications by navigating to `/cms/fhir/Task/`, and searching for particular enrollments by adding query parameters.

The currently allowed query parameters are:
- `name`: searches for providers that contain the value in their name (full name for individual providers, and entity name for organizational providers).
- `providerType`: searches for enrollment applications with the specified provider type.
- `npi`: searches for providers that have a matching NPI.
- `status`: searches for enrollment applications that have one of the listed types ("Draft", "Requested", "Rejected", or "Accepted" (Note that those statuses are from FHIR, and are not the same as the statuses shown in the PSM UI)). This query parameter allows for multiple values, separated by a comma.

These parameters can be combined or omitted; combining them results in `AND`-behavior, where only enrollment applications matching each parameter are returned.

For example, the following query finds enrollment applications that have a provider with "p1" in their name (first, last, or organization), that have an NPI of 1234567893, that have a provider type of Acupuncturist, and that have been either approved or rejected:

```
/cms/fhir/Task/?name=p1&npi=1234567893&providerType=Acupuncturist&status=Accepted,Rejected
```

On my machine, that results in the following response:

```json
{
  "resourceType": "Bundle",
  "id": "28117f52-85aa-432e-9f15-7b34f163315d",
  "meta": {
    "lastUpdated": "2018-03-13T18:36:56.825-04:00"
  },
  "type": "searchset",
  "total": 1,
  "link": [
    {
      "relation": "self",
      "url": "https://localhost:8443/cms/fhir/Task/?name=p1&npi=1234567893&providerType=Acupuncturist&status=Accepted%2CRejected"
    }
  ],
  "entry": [
    {
      "fullUrl": "https://localhost:8443/cms/fhir/Task/2",
      "resource": {
        "resourceType": "Task",
        "id": "2",
        "contained": [
          {
            "resourceType": "Practitioner",
            "id": "789",
            "identifier": [
              {
                "system": "http://hl7.org/fhir/sid/us-ssn",
                "value": "000000001"
              },
              {
                "system": "http://hl7.org/fhir/sid/us-npi",
                "value": "1234567893"
              }
            ],
            "name": [
              {
                "family": "p1",
                "given": [
                  "p1"
                ]
              }
            ]
          }
        ],
        "status": "rejected",
        "intent": "proposal",
        "requester": {
          "agent": {
            "reference": "#789"
          }
        },
        "input": [
          {
            "type": {
              "text": "Provider Type"
            },
            "valueString": "Acupuncturist"
          }
        ]
      }
    }
  ]
}
```

This API does not yet do any paging; it just returns all relevant results. If paging is important to you, please comment here or on #641 to say so!

The performance of this API will scale poorly due to an N+1 query that is not easily fixable with our current data model (see #57).

---

I was able to test this with the added (and existing) unit tests, as well as by deploying and using either curl or my browser to query the API.

Issue #641 Create API that returns a list of approved and/or rejected providers