### PR TITLE
 Add user help link to "Action" column header of enrollment tables 

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_table.jsp
@@ -73,7 +73,10 @@
         </div>
       </th>
       <th class="alignCenter" >
-        <div class="tablesorter-header-inner">Action</div>
+        <div class="tablesorter-header-inner">
+          Action
+          <a href="javascript:" class="userHelpLink actionColumnHelpLink">?</a>
+        </div>
       </th>
     </tr>
   </thead>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -116,6 +116,9 @@
 
       <%@include file="/WEB-INF/pages/provider/enrollment/steps/modal/print_modal.jsp" %>
 
+      <c:set var="userHelpModalId" value="user-help-modal"/>
+      <h:handlebars template="includes/userhelp/user_help_modal" context="${pageContext}" />
+
     </div>
   </body>
 </html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -191,6 +191,10 @@
         </div>
       </div>
       <!-- /#printModal-->
+
+      <c:set var="userHelpModalId" value="user-help-modal"/>
+      <h:handlebars template="includes/userhelp/user_help_modal" context="${pageContext}" />
+
     </div>
   </body>
 </html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
@@ -86,6 +86,7 @@
       <th class="alignCenter" >
         <div class="tablesorter-header-inner">
           Action
+          <a href="javascript:" class="userHelpLink actionColumnHelpLink">?</a>
         </div>
       </th>
     </tr>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4347,6 +4347,10 @@ input.passwordNormalInput{
   cursor: help;
 }
 
+.generalTable th .actionColumnHelpLink {
+  color: #1AABFF;
+}
+
 /*definition modal style*/
 #new-modal .definitionsModal.definitions .modal-title h3{
   background: none;

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -3303,7 +3303,11 @@ a.searchBtn {
 #new-modal p{
   text-align:center;
   font-size:14px;
-
+}
+#new-modal .userHelpModalBody h2 {
+  /* 13px x 115.4% = 15px */
+  font-size: 115.4%;
+  margin: 1.5rem 0 0.5rem;
 }
 #new-modal .userHelpModalBody p {
   text-align: left;

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -573,7 +573,7 @@ $(document).ready(function () {
   addUserHelpClickHandler(
     'a.agreementsAddendumsHelpLink',
     '/help/service-admin-help.html',
-    'what-s-the-difference-between-an-agreement-and-an-addendum'
+    ['what-s-the-difference-between-an-agreement-and-an-addendum']
   );
 
   $('.editInfo').click(function () {

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -60,40 +60,62 @@ $(document).ready(function () {
   }
 
   /**
-  * Populates a user help modal with content.  With the first two
+  * Populates a user help modal with content.  With the first three
   * arguments bound (using '.bind'), this is used as the callback
   * function for AJAX calls that fetch a user help page.  It extracts
   * the relevant content from the help page and adds it to the modal.
   *
   * @param modalId {string} - ID of the target modal.
-  * @param helpItemId {string} - ID of the source help item.
+  * @param helpItemIds {array of strings} - IDs of the source help items.
+  * @param title {string or undefined} - modal title to use with multiple help items.
   * @param helpPageString {string} - HTML of the help page.
   */
-  populateUserHelpModal = function (modalId, helpItemId, helpPageString) {
+  populateUserHelpModal = function (modalId, helpItemIds, title, helpPageString) {
     var parser = new DOMParser();
     var helpPage = parser.parseFromString(helpPageString, "text/html");
-
-    var helpItem = helpPage.getElementById(helpItemId);
-    var helpTitle = helpItem.querySelector("h2");
 
     var modal = document.getElementById(modalId);
     var modalTitle = modal.querySelector(".userHelpModalTitle");
     var modalBody = modal.querySelector(".userHelpModalBody");
 
-    modalTitle.innerHTML = helpTitle.firstChild.textContent;
+    if (title) {
+      modalTitle.innerHTML = title;
+      // Remove "Loading..." or other text from modal body.
+      modalBody.innerHTML = "";
 
-    helpItem.removeChild(helpTitle);
-    modalBody.innerHTML = helpItem.innerHTML;
+      helpItemIds.forEach(function (helpItemId) {
+        var helpItem = helpPage.getElementById(helpItemId);
+
+        // Remove the permalink anchor tag from the help title.
+        var helpTitle = helpItem.querySelector("h2");
+        helpTitle.innerHTML = helpTitle.firstChild.textContent;
+
+        while (helpItem.firstChild) {
+          modalBody.appendChild(helpItem.firstChild);
+        }
+      });
+
+    } else {
+      var helpItem = helpPage.getElementById(helpItemIds[0]);
+      var helpTitle = helpItem.querySelector("h2");
+
+      modalTitle.innerHTML = helpTitle.firstChild.textContent;
+
+      helpItem.removeChild(helpTitle);
+      modalBody.innerHTML = helpItem.innerHTML;
+    }
   };
 
   /**
   * Add a click handler function to a user help modal link.
+  * Title is optional; is absent (undefined) to show a single help item.
   *
   * @param helpLinkSelector {string} - Selector for the help link.
   * @param helpDocsPath {string} - Path to the help doc html file.
-  * @param helpItemId {string} - ID of the source help item.
+  * @param helpItemIds {array of strings} - IDs of the source help items.
+  * @param title {string or undefined} - Title to use with multiple help items.
   */
-  addUserHelpClickHandler = function (helpLinkSelector, helpDocsPath, helpItemId) {
+  addUserHelpClickHandler = function (helpLinkSelector, helpDocsPath, helpItemIds, title) {
     $(helpLinkSelector).click(function () {
       resetUserHelpModal('#user-help-modal');
       addressLoadModal('#user-help-modal');
@@ -102,7 +124,8 @@ $(document).ready(function () {
         populateUserHelpModal.bind(
           undefined,
           'user-help-modal',
-          helpItemId
+          helpItemIds,
+          title
         )
       );
     });

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1893,6 +1893,18 @@ $(document).ready(function () {
     ['am-i-employed-and-or-independently-contracted-by-a-group-practice']
   );
 
+  addUserHelpClickHandler(
+    'a.actionColumnHelpLink',
+    '/help/enrollment.html',
+    [
+      'why-can-i-edit-some-enrollments-but-not-others',
+      'can-i-change-something-in-a-pending-enrollment-after-i-submit-it',
+      'how-can-i-update-an-existing-organizational-enrollment-to-add-a-new-provider-e-g-if-a-clinic-hires-a-new-physician',
+      'how-can-i-update-an-existing-organizational-enrollment-to-remove-a-provider-e-g-if-a-physician-retires-from-a-clinic'
+    ],
+    "Questions About Editing an Enrollment"
+  );
+
   //$('.inline input[type=radio]').removeAttr('checked');
   //    $('.inline input[name=civilMoney]').click(function(){
   //        if($(this).val()=="yes"){

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1878,19 +1878,19 @@ $(document).ready(function () {
   addUserHelpClickHandler(
     'a.NPIdefinition',
     '/help/enrollment.html',
-    'what-is-an-npi'
+    ['what-is-an-npi']
   );
 
   addUserHelpClickHandler(
     'a.maintainOwnPrivatePractice',
     '/help/enrollment.html',
-    'do-i-maintain-my-own-private-practice'
+    ['do-i-maintain-my-own-private-practice']
   );
 
   addUserHelpClickHandler(
     'a.employedByGroupPractice',
     '/help/enrollment.html',
-    'am-i-employed-and-or-independently-contracted-by-a-group-practice'
+    ['am-i-employed-and-or-independently-contracted-by-a-group-practice']
   );
 
   //$('.inline input[type=radio]').removeAttr('checked');

--- a/psm-app/userhelp/source/enrollment.rst
+++ b/psm-app/userhelp/source/enrollment.rst
@@ -124,6 +124,13 @@ Right now that's not something the PSM can do, but `it'll be possible in
 a future
 version. <https://github.com/SolutionGuidance/psm/issues/401>`__
 
+Why can I edit some enrollments but not others?
+-----------------------------------------------
+
+You can only edit an enrollment if its status is still "Draft"
+(it hasn't been submitted yet).  If its status is "Pending",
+"Approved", or "Denied" then you can view but not edit it.
+
 Can I change something in a pending enrollment after I submit it?
 -----------------------------------------------------------------
 


### PR DESCRIPTION
This user help link covers why some enrollments can be edited and others can't, and similar questions related to the links in the Actions column.  The pages where this link appears are:
 - p1 login dashboard
 - p1 login enrollments pages (draft, pending, etc.)
 - p1 login quick and advanced search results pages
 - admin login enrollments pages (draft, pending, notes, etc.)
 - admin login quick and advanced search results pages

This PR includes making it possible to show multiple help items in a user help modal, and uses that to show multiple help items for the actions column modal.  (This will also be useful for the "Provider Type" selection help modal #710 , and probably other cases.)  Single help item modals appear the same (except the body text is now left-aligned to match those with multiple help items).

Changes in this PR are based on those in PR #713 , and do not need review until this is rebased after 713 lands.

Tested by checking the action column links on the pages above, and a NPI help modal link (when starting a new enrollment) to check a single help item modal.

Screenshots:

![screenshot-2018-3-14 dashboard](https://user-images.githubusercontent.com/1091693/37477621-7ee97026-284e-11e8-8cda-9203af005f6d.png)

Left-aligned text in single help item modal:

![screenshot-2018-3-14 personal information](https://user-images.githubusercontent.com/1091693/37477627-82b7ba00-284e-11e8-8bc8-7fef0187235e.png)


Issue #422 Review documentation to add [...] help links