### PR TITLE
Remove two unused properties in JAXB types

### DIFF
--- a/psm-app/cms-business-model/src/main/resources/EnrollmentProcess.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentProcess.xsd
@@ -23,7 +23,6 @@
 				<element name="EnrollmentStatusHistory" type="cms:EnrollmentStatusHistoryType"></element>
 				<element name="PostSubmissionInformation" type="cms:PostSubmissionInformationType"></element>
 				<element name="PreApprovalQuestions" type="string"></element>
-				<element name="AssessedFees" type="tns:AssessedFeesType"></element>
 				<element name="ProcessResults" type="tns:ProcessResultsType"></element>
 				<element name="ProcessAudit" type="tns:ProcessAuditType"></element>
 			</sequence>
@@ -43,15 +42,6 @@
 				</sequence>
 			</extension>
 		</complexContent>
-	</complexType>
-
-	<complexType name="AssessedFeesType">
-		<annotation>
-			<documentation xml:lang="en">All fees assessed by the business rules.</documentation>
-		</annotation>
-		<sequence>
-			<element name="PaymentInformation" type="cms:PaymentInformationType"></element>
-		</sequence>
 	</complexType>
 
 	<complexType name="EditHistoryType">

--- a/psm-app/cms-business-model/src/main/resources/EnrollmentProcess.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentProcess.xsd
@@ -22,7 +22,6 @@
 				<element name="EnrollmentStatus" type="cms:EnrollmentStatusType"></element>
 				<element name="EnrollmentStatusHistory" type="cms:EnrollmentStatusHistoryType"></element>
 				<element name="PostSubmissionInformation" type="cms:PostSubmissionInformationType"></element>
-				<element name="PreApprovalQuestions" type="string"></element>
 				<element name="ProcessResults" type="tns:ProcessResultsType"></element>
 				<element name="ProcessAudit" type="tns:ProcessAuditType"></element>
 			</sequence>

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
@@ -43,7 +43,6 @@ public class XMLSerializingEnrollmentProcess extends EnrollmentProcess implement
             setEnrollmentStatus(result.getEnrollmentStatus());
             setEnrollmentStatusHistory(result.getEnrollmentStatusHistory());
             setPostSubmissionInformation(result.getPostSubmissionInformation());
-            setPreApprovalQuestions(result.getPreApprovalQuestions());
             setProcessAudit(result.getProcessAudit());
             setProcessResults(result.getProcessResults());
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
@@ -39,7 +39,6 @@ public class XMLSerializingEnrollmentProcess extends EnrollmentProcess implement
             EnrollmentProcess result = (EnrollmentProcess) um.unmarshal(new StringReader((String) input.readObject()));
 
             setSessionId(result.getSessionId());
-            setAssessedFees(result.getAssessedFees());
             setEnrollment(result.getEnrollment());
             setEnrollmentStatus(result.getEnrollmentStatus());
             setEnrollmentStatusHistory(result.getEnrollmentStatusHistory());


### PR DESCRIPTION
Remove the `PreApprovalQuestions` and `AssessedFees` properties from the `EnrollmentProcess` JAXB data type, as well as the associated `AssessedFeesType`. These properties were only ever referenced from deserialization code, and as far as I can tell were never used anywhere else.

Note that because this changes serialization/deserialization, pending enrollments submitted before this change cannot be reviewed after it, and vice versa. Draft enrollments can still be edited, and all enrollments can still be viewed.

I tested this by building, deploying, and running the integration tests.

Issue 596 Reduce use of JAXB class generation