### PR TITLE
Remove extra colons from four enrollment step pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/cmhrt_contract.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/cmhrt_contract.jsp
@@ -18,7 +18,6 @@
         <div class="">
             <div class="row requireField">
                 <label for="coverSheet_${formName}" class="mediumLbl">Please upload a copy of cover sheet with contract summary <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
 
                 <c:set var="formName" value="_31_countyContract"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
@@ -29,7 +29,6 @@
         <div class="">
             <div class="row requireField">
                 <label for="dhsContract">Please upload a copy of contract with DHS<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
 
                 <c:set var="formName" value="_30_dhsContract"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
@@ -54,7 +54,7 @@
                     <input
                       id="copyOfDegree_${formName}"
                       type="file"
-                      class="fileUpload"
+                      class="fileUpload newEnrollmentPanelButton"
                       size="10"
                       name="${formName}"
                     />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
@@ -31,7 +31,6 @@
                 <c:set var="formName" value="_14_highestDegreeEarned"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="highestDegree_${formName}" >Highest Degree Earned<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <select id="highestDegree_${formName}" class="bigSelect" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_14_degreeTypes']}">
@@ -43,7 +42,6 @@
                 <c:set var="formName" value="_14_degreeAwardDate"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="degreeAwardDate_${formName}">Degree Award Date<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="degreeAwardDate_${formName}" class="date" type="text" name="${formName}" value="${formValue}" maxlength="10"/>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
@@ -51,7 +51,13 @@
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="copyOfDegree_${formName}">Copy of Highest Degree Earned</label>
                 <span class="floatL">
-                    <input id="copyOfDegree_${formName}" type="file" class="fileUpload" size="10" name="${formName}" />
+                    <input
+                      id="copyOfDegree_${formName}"
+                      type="file"
+                      class="fileUpload"
+                      size="10"
+                      name="${formName}"
+                    />
 
                     <c:if test="${not empty formValue}">
                         <c:url var="downloadLink" value="/provider/enrollment/attachment">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
@@ -27,7 +27,6 @@
                 <c:set var="formName" value="_20_npi_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">NPI<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="npiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
                 <a href="javascript:;" class="purpleBtn NPISetupLookup"><span class="icon">NPI Lookup</span></a>
                 <span class="errorMsg">No records found with NPI number <span></span></span>
@@ -38,14 +37,12 @@
                 <c:set var="formName" value="_20_name_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Pay-to Provider Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_20_contactName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Contact Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="contactNameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="clearFixed"></div>
@@ -55,14 +52,12 @@
                 <c:set var="formName" value="_20_effectiveDate_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Effective Date<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
             </div>
             <div class="row requireField">
                 <label>Phone Number<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_20_phone1_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" title="Phone Number Area Code" class="phone1Input tinyInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -81,7 +76,6 @@
             </div>
             <div class="row requireField">
                 <label class="multiLine">Choose One<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_20_type_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label class="inline"><input type="radio" ${formValue eq 'Claim' ? 'checked' : ''} name="${formName}" value="Claim"/>Claim</label>
@@ -114,7 +108,6 @@
                 <c:set var="formName" value="_20_npi_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">NPI<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="npiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
                 <a href="javascript:;" class="purpleBtn NPISetupLookup"><span class="icon">NPI Lookup</span></a>
                 <span class="errorMsg">No records found with NPI number <span></span></span>
@@ -125,14 +118,12 @@
                 <c:set var="formName" value="_20_name_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Pay-to Provider Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_20_contactName_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Contact Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="contactNameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="clearFixed"></div>
@@ -142,14 +133,12 @@
                 <c:set var="formName" value="_20_startDate_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Effective Date<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
             </div>
             <div class="row requireField">
                 <label>Phone Number<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_20_phone1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" title="Phone Number Area Code" class="phone1Input tinyInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -168,7 +157,6 @@
             </div>
             <div class="row requireField">
                 <label class="multiLine">Choose One<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_20_iboRelationship_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label class="inline"><input type="radio" ${formValue eq 'Claim' ? 'checked' : ''} name="${formName}" value="Claim"/>Claim</label>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -1225,6 +1225,10 @@ input.date{
   padding:0;
 }
 
+.newEnrollmentPanelButton {
+  margin-left: 7px;
+}
+
 /* tableData */
 .tableData{
   width:100%;


### PR DESCRIPTION
These are the four provider types and steps/pages:

 - Childrens Mental Health Residential Treatment Facility > Facility Credentials step

 - Child And Teen Checkup Clinic > Facility Credentials step

 - Licensed Independent Clinical Social Worker  > License Info step

 - Billing Intermediary > Provider Setup step

Tested by inspecting these pages to confirm the colons were gone, and the page layout was not messed up.

Issue #376 Remove colons between form labels and fields