### PR TITLE
Show Facility Credentials in review screen

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -174,54 +174,56 @@
                     </tbody>
                   </table>
 
-                  <div class="tableHeader"><span>License Information</span></div>
-                  <div class="clearFixed"></div>
-                  <table class="generalTable">
-                    <thead>
-                      <tr>
-                        <th>Type<span class="sep"></span></th>
-                        <th>Number<span class="sep"></span></th>
-                        <th>Auto Screening<span class="sep"></span></th>
-                        <th>Verified</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <c:forEach var="license" items="${model.enrollment.providerInformation.licenseInformation.license}">
+                  <c:if test="${not empty model.enrollment.providerInformation.licenseInformation.license}">
+                    <div class="tableHeader"><span>License Information</span></div>
+                    <div class="clearFixed"></div>
+                    <table class="generalTable">
+                      <thead>
                         <tr>
-                          <td>${license.licenseType}${license.specialtyType}</td>
-                          <td>${license.licenseNumber}
-
-                            <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                            <c:param name="id" value="${license.attachmentObjectId}"></c:param>
-                            </c:url>
-                            <a href="${downloadLink}">View</a>
-
-                          </td>
-                          <td><a class="autoScreeningResultLink"
-                                href="${ctx}/agent/enrollment/autoScreeningResult?type=LICENSE VERIFICATION&id=${id}&licenseId=${license.objectId}"
-                                target="_blank">
-                            <c:choose>
-                            <c:when test="${empty license.verified}">
-                              Not performed
-                            </c:when>
-                            <c:otherwise>
-                              View results
-                            </c:otherwise>
-                            </c:choose>
-                          </a></td>
-                          <td>
-                            <input
-                              type="checkbox"
-                              title="License Number ${license.licenseNumber} Verified"
-                              name="verifiedLicenses"
-                              value="${license.attachmentObjectId}"
-                              ${license.verified eq 'Y' ? 'checked' : ''}
-                              />
-                          </td>
+                          <th>Type<span class="sep"></span></th>
+                          <th>Number<span class="sep"></span></th>
+                          <th>Auto Screening<span class="sep"></span></th>
+                          <th>Verified</th>
                         </tr>
-                      </c:forEach>
-                    </tbody>
-                  </table>
+                      </thead>
+                      <tbody>
+                        <c:forEach var="license" items="${model.enrollment.providerInformation.licenseInformation.license}">
+                          <tr>
+                            <td>${license.licenseType}${license.specialtyType}</td>
+                            <td>${license.licenseNumber}
+
+                              <c:url var="downloadLink" value="/provider/enrollment/attachment">
+                              <c:param name="id" value="${license.attachmentObjectId}"></c:param>
+                              </c:url>
+                              <a href="${downloadLink}">View</a>
+
+                            </td>
+                            <td><a class="autoScreeningResultLink"
+                                  href="${ctx}/agent/enrollment/autoScreeningResult?type=LICENSE VERIFICATION&id=${id}&licenseId=${license.objectId}"
+                                  target="_blank">
+                              <c:choose>
+                              <c:when test="${empty license.verified}">
+                                Not performed
+                              </c:when>
+                              <c:otherwise>
+                                View results
+                              </c:otherwise>
+                              </c:choose>
+                            </a></td>
+                            <td>
+                              <input
+                                type="checkbox"
+                                title="License Number ${license.licenseNumber} Verified"
+                                name="verifiedLicenses"
+                                value="${license.attachmentObjectId}"
+                                ${license.verified eq 'Y' ? 'checked' : ''}
+                                />
+                            </td>
+                          </tr>
+                        </c:forEach>
+                      </tbody>
+                    </table>
+                  </c:if>
                   <div class="row"></div>
                 </div>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -224,6 +224,42 @@
                       </tbody>
                     </table>
                   </c:if>
+
+                  <c:if test="${not empty model.enrollment.providerInformation.facilityCredentials.signedContract}">
+                    <div class="tableHeader"><span>Facility Credentials</span></div>
+                    <div class="clearFixed"></div>
+                    <table class="generalTable">
+                      <thead>
+                        <tr>
+                          <th>Type<span class="sep"></span></th>
+                          <th>Begin<span class="sep"></span></th>
+                          <th>End<span class="sep"></span></th>
+                          <th>Attachment<span class="sep"></span></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <c:forEach var="contract" items="${model.enrollment.providerInformation.facilityCredentials.signedContract}">
+                          <tr>
+                            <td>${contract.name}</td>
+                            <td>
+                              <fmt:formatDate pattern="MM/dd/yyyy"
+                                              value="${contract.beginDate.time}"/>
+                            </td>
+                            <td>
+                              <fmt:formatDate pattern="MM/dd/yyyy"
+                                              value="${contract.endDate.time}"/>
+                            </td>
+                            <td>
+                              <c:url var="downloadLink" value="/provider/enrollment/attachment">
+                                <c:param name="id" value="${contract.copyAttachmentId}"></c:param>
+                              </c:url>
+                              <a href="${downloadLink}">View</a>
+                            </td>
+                          </tr>
+                        </c:forEach>
+                      </tbody>
+                    </table>
+                  </c:if>
                   <div class="row"></div>
                 </div>
 


### PR DESCRIPTION
Provider types that allow uploading of facility credentials - such as the County Contracted Mental Health Rehab provider type - did not previously allow those credentials to be shown anywhere. Add a section
to the admin review screen that includes the name, begin date, end date, and a link to the uploaded attachment.

For providers that have no licenses to review, hide the "License Information" section of the admin review enrollment page.

Note that this only includes "signed contracts" (as the code refers to them); it is possible that there are other kind of facility credentials that are not shown by this change.

Before:
![contracts-before](https://user-images.githubusercontent.com/1494855/37489126-09d07b6c-286d-11e8-9f46-3eedb0c0df03.png)


After:
![contracts-with-dates](https://user-images.githubusercontent.com/1494855/37489088-e7b5eeae-286c-11e8-8229-02719f8eb267.png)

Resolves #261 Facility credentials not shown at review time