### PR TITLE
Add abbreviation tooltip for 'FEIN' form labels

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
@@ -60,7 +60,9 @@
     </c:if>
 </div>
 <div class="row">
-    <label>FEIN</label>
+    <label>
+      <abbr title="Federal Employer Identification Number">FEIN</abbr>
+    </label>
     <span class="floatL"><b>:</b></span>
     <span id="fein">${requestScope['_05_fein']}</span>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -246,7 +246,11 @@
                 <label for="${formIdPrefix}_${formName}" class="multiLine">Full Legal Name of Other Provider<span class="required">*</span></label>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
-                    <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
+                    <span class="label">
+                      (Taxpayer name of
+                      <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                      or on W-9 from IRS)
+                    </span>
                 </span>
 
                 <c:set var="formName" value="_17_iboOtherInterestPct_${status.index - 1}"></c:set>
@@ -381,12 +385,19 @@
                 <label for="${formIdPrefix}_${formName}">Full Legal Name<span class="required">*</span></label>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
-                    <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
+                    <span class="label">
+                      (Taxpayer name of
+                      <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                      or on W-9 from IRS)
+                    </span>
                 </span>
 
                 <c:set var="formName" value="_17_cboFEIN_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="inlineLabel">FEIN<span class="required">*</span></label>
+                <label for="${formIdPrefix}_${formName}" class="inlineLabel">
+                  <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                  <span class="required">*</span>
+                </label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput smallInput feinMasked" name="${formName}" value="${formValue}" maxlength="10"/>
                 <div class="clearFixed"></div>
             </div>
@@ -459,7 +470,11 @@
                 <label for="${formIdPrefix}_${formName}" class="multiLine">Full Legal Name of Other Provider<span class="required">*</span></label>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
-                    <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
+                    <span class="label">
+                      (Taxpayer name of
+                      <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                      or on W-9 from IRS)
+                    </span>
                 </span>
 
                 <c:set var="formName" value="_17_cboOtherInterestPct_${status.index - 1}"></c:set>
@@ -586,12 +601,19 @@
                 <label for="${formIdPrefix}_${formName}">Full Legal Name<span class="required">*</span></label>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
-                    <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
+                    <span class="label">
+                      (Taxpayer name of
+                      <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                      or on W-9 from IRS)
+                    </span>
                 </span>
 
                 <c:set var="formName" value="_17_cboFEIN"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="inlineLabel">FEIN<span class="required">*</span></label>
+                <label for="${formIdPrefix}_${formName}" class="inlineLabel">
+                  <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                  <span class="required">*</span>
+                </label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput smallInput feinMasked" name="${formName}" value="${formValue}" maxlength="7"/>
                 <div class="clearFixed"></div>
             </div>
@@ -664,7 +686,11 @@
                 <label for="${formIdPrefix}_${formName}" class="multiLine">Full Legal Name of Other Provider<span class="required">*</span></label>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
-                    <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
+                    <span class="label">
+                      (Taxpayer name of
+                      <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                      or on W-9 from IRS)
+                    </span>
                 </span>
 
                 <c:set var="formName" value="_17_cboOtherInterestPct"></c:set>
@@ -902,7 +928,11 @@
                 <label for="${formIdPrefix}_${formName}" class="multiLine">Full Legal Name of Other Provider<span class="required">*</span></label>
                 <span class="floatL inputCnt">
                     <input id="${formIdPrefix}_${formName}" type="text" class="wholeInput fullLengthName" name="${formName}" value="${formValue}" maxlength="100"/><br/>
-                    <span class="label">(Taxpayer name of FEIN or on W-9 from IRS)</span>
+                    <span class="label">
+                      (Taxpayer name of
+                      <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                      or on W-9 from IRS)
+                    </span>
                 </span>
 
                 <!-- TODO: Issue #564: Why doesn't this field have a name? -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
@@ -204,7 +204,9 @@
                 <div class="row">
                     <c:set var="formName" value="_05_fein"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">FEIN</label>
+                    <label for="${formIdPrefix}_${formName}">
+                      <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                    </label>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="normalInput feinMasked" name="${formName}" value="${formValue}" maxlength="10"/>
                 </div>
                 <div class="row">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
@@ -36,7 +36,10 @@
                 </span>
             </div>
             <div class="row">
-                <label>Federal Employer ID (FEIN)</label>
+                <label>
+                  Federal Employer ID
+                  (<abbr title="Federal Employer Identification Number">FEIN</abbr>)
+                </label>
                 <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_fein']}</span>
             </div>
@@ -105,7 +108,10 @@
                 <span>${requestScope['_15_orgCountyName']}</span>
             </div>
             <div class="row">
-                <label>Federal Employer ID (FEIN)</label>
+                <label>
+                  Federal Employer ID
+                  (<abbr title="Federal Employer Identification Number">FEIN</abbr>)
+                </label>
                 <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_fein']}</span>
             </div>
@@ -162,9 +168,12 @@
                     <span>${requestScope['_15_name']}</span>
                 </div>
                 <div class="row">
-                    <label>Federal Employer ID (FEIN)</label>
-                    <span class="floatL"><b>:</b></span>
-                    <span>${requestScope['_15_fein']}</span>
+                  <label>
+                    Federal Employer ID
+                    (<abbr title="Federal Employer Identification Number">FEIN</abbr>)
+                  </label>
+                  <span class="floatL"><b>:</b></span>
+                  <span>${requestScope['_15_fein']}</span>
                 </div>
                 <div class="row">
                     <label>MN Tax Id</label>
@@ -271,9 +280,12 @@
                     </span>
                 </div>
                 <div class="row">
-                    <label>Federal Employer ID (FEIN)</label>
-                    <span class="floatL"><b>:</b></span>
-                    <span>${requestScope['_15_fein']}</span>
+                  <label>
+                    Federal Employer ID
+                    (<abbr title="Federal Employer Identification Number">FEIN</abbr>)
+                  </label>
+                  <span class="floatL"><b>:</b></span>
+                  <span>${requestScope['_15_fein']}</span>
                 </div>
                 <c:if test="${askFiscalYear}">
                     <div class="row">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ownership_information.jsp
@@ -125,7 +125,9 @@
                 </div>
                 <div class="rightCol">
                     <div class="row">
-                        <label>FEIN</label>
+                        <label>
+                          <abbr title="Federal Employer Identification Number">FEIN</abbr>
+                        </label>
                         <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_17_cboFEIN_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>


### PR DESCRIPTION
In the enrollment steps, these FEIN labels appear on the individual provider 'Practice Info' page and summary page, and on the organization provider 'Ownership Info' page (for 'Business Ownership or Control Interest') and the summary page.

Tested by checking these pages to see that when you hover the mouse over "FEIN" (which has a dashed underline) you see a tooltip with the expansion of the abbreviation (Federal Employer Identification Number).

Issue #422 Review documentation to add [...] help links