### PR TITLE
Add user help links for "NPI/UMPI" form labels

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_agency_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_agency_information.jsp
@@ -29,7 +29,11 @@
             <div class="row">
                 <c:set var="formName" value="_11_npi"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="agencyNpiUmpi">Agency NPI/UMPI<span class="required">*</span></label>
+                <label for="agencyNpiUmpi">
+                  Agency NPI/UMPI
+                  <span class="required">*</span>
+                  <a href="javascript:;" class="userHelpLink NPIdefinition">?</a>
+                </label>
                 <span class="floatL"><b>:</b></span>
                 <input type="text" class="npiMasked normalInput" id="agencyNpiUmpi" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
@@ -21,7 +21,11 @@
             <div class="row requireField">
                 <c:set var="formName" value="_16_npi_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">NPI/UMPI<span class="required">*</span></label>
+                <label for="${formIdPrefix}_${formName}">
+                  NPI/UMPI
+                  <span class="required">*</span>
+                  <a href="javascript:;" class="userHelpLink NPIdefinition">?</a>
+                </label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="umpiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
                 <a href="javascript:;" class="purpleBtn NPILook"><span class="icon">
                 <c:choose>
@@ -133,7 +137,11 @@
             <div class="row requireField">
                 <c:set var="formName" value="_16_npi"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">NPI/UMPI<span class="required">*</span></label>
+                <label for="${formIdPrefix}_${formName}">
+                  NPI/UMPI
+                  <span class="required">*</span>
+                  <a href="javascript:;" class="userHelpLink NPIdefinition">?</a>
+                </label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="umpiMasked smallInput" name="${formName}" value="${formValue}" maxlength="10"/>
                 <a href="javascript:;" class="purpleBtn NPILook"><span class="icon"></span>
                 <c:choose>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
@@ -50,7 +50,11 @@
                 <div class="row">
                     <c:set var="formName" value="_06_npi"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">Group NPI / UMPI<span class="required">*</span></label>
+                    <label for="${formIdPrefix}_${formName}">
+                      Group NPI/UMPI
+                      <span class="required">*</span>
+                      <a href="javascript:;" class="userHelpLink NPIdefinition">?</a>
+                    </label>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                     <input id="unlinkPracticeButton" type="button" value="Remove Reference" onclick="unlinkPractice('_06_')" style="display: ${isLinked ? 'inline' : 'none'}"/>
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
@@ -49,7 +49,10 @@
                 <div class="row">
                     <c:set var="formName" value="_05_npi"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">Group NPI / UMPI</label>
+                    <label for="${formIdPrefix}_${formName}">
+                      Group NPI / UMPI
+                      <a href="javascript:;" class="userHelpLink NPIdefinition">?</a>
+                    </label>
                     <input id="${formIdPrefix}_${formName}" ${disableLinkedFields} type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
                     <input id="unlinkPracticeButton" type="button" value="Remove Reference" onclick="unlinkPractice('_05_')" style="display: ${isLinked ? 'inline' : 'none'}"/>
                 </div>

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -570,7 +570,7 @@ $(document).ready(function () {
       addressLoadModal('#printModal');
     });
 
-  addUserHelpClickHandler(
+  setUserHelpClickHandler(
     'a.agreementsAddendumsHelpLink',
     '/help/service-admin-help.html',
     ['what-s-the-difference-between-an-agreement-and-an-addendum']

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -1,3 +1,30 @@
+/**
+* Add a click handler function to a user help modal link.
+* Title is optional; is absent (undefined) to show a single help item.
+*
+* @param helpLinkSelector {string} - Selector for the help link.
+* @param helpDocsPath {string} - Path to the help doc html file.
+* @param helpItemIds {array of strings} - IDs of the source help items.
+* @param title {string or undefined} - Title to use with multiple help items.
+*/
+function addUserHelpClickHandler(helpLinkSelector, helpDocsPath, helpItemIds, title) {
+  $(helpLinkSelector)
+    .off("click")
+    .click(function userHelpClickHandler() {
+      resetUserHelpModal('#user-help-modal');
+      addressLoadModal('#user-help-modal');
+      $.get(
+        ctx + helpDocsPath,
+        populateUserHelpModal.bind(
+          undefined,
+          'user-help-modal',
+          helpItemIds,
+          title
+        )
+      );
+    });
+};
+
 $(document).ready(function () {
 
   $('.searchPanel input[type="checkbox"]')
@@ -104,31 +131,6 @@ $(document).ready(function () {
       helpItem.removeChild(helpTitle);
       modalBody.innerHTML = helpItem.innerHTML;
     }
-  };
-
-  /**
-  * Add a click handler function to a user help modal link.
-  * Title is optional; is absent (undefined) to show a single help item.
-  *
-  * @param helpLinkSelector {string} - Selector for the help link.
-  * @param helpDocsPath {string} - Path to the help doc html file.
-  * @param helpItemIds {array of strings} - IDs of the source help items.
-  * @param title {string or undefined} - Title to use with multiple help items.
-  */
-  addUserHelpClickHandler = function (helpLinkSelector, helpDocsPath, helpItemIds, title) {
-    $(helpLinkSelector).click(function () {
-      resetUserHelpModal('#user-help-modal');
-      addressLoadModal('#user-help-modal');
-      $.get(
-        ctx + helpDocsPath,
-        populateUserHelpModal.bind(
-          undefined,
-          'user-help-modal',
-          helpItemIds,
-          title
-        )
-      );
-    });
   };
 
   $(".closeModal, .modalCloseButton, #new-modal #printModal .modal-title a.greyBtn")

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -1,3 +1,103 @@
+function addressPositionModal() {
+  var wWidth  = window.innerWidth;
+  var wHeight = window.innerHeight;
+
+  if (wWidth == undefined) {
+    wWidth  = document.documentElement.clientWidth;
+    wHeight = document.documentElement.clientHeight;
+  }
+
+  boxLeft = parseInt((wWidth / 2) - ($("#new-modal").width() / 2));
+  //var boxTop  = parseInt((wHeight / 2) - ( $("#new-modal").height() / 2 ));
+
+  // position modal
+  $("#new-modal").css({
+    'margin': 120 + 'px auto 0 ' + boxLeft + 'px'
+  });
+
+  $("#modalBackground").css("opacity", "0.8");
+
+  if ($("body").height() > $("#modalBackground").height()) {
+    $("#modalBackground").css("height", $("body").height() + "px");
+  }
+
+  if ($('#new-modal').height() > $("#modalBackground").height()) {
+    $("#modalBackground").css("height", $('#new-modal').height() + 120 + "px");
+  }
+
+  $(window).scrollTop(0);
+};
+
+function addressLoadModal(itemId) {
+  $('#modalBackground').show();
+  $(itemId).show();
+  addressPositionModal();
+}
+
+function addressCloseModal() {
+  $('#modalBackground').hide();
+  $('#new-modal>div').hide();
+}
+
+/**
+* Clears and resets the contents of the user help modal
+* (before it gets populated with results of AJAX call).
+*/
+function resetUserHelpModal(modalSelector) {
+  var modal = document.querySelector(modalSelector);
+  var modalTitle = modal.querySelector('.userHelpModalTitle');
+  var modalBody = modal.querySelector('.userHelpModalBody');
+  modalTitle.innerHTML = '';
+  modalBody.innerHTML = 'Loading...';
+}
+
+/**
+* Populates a user help modal with content.  With the first three
+* arguments bound (using '.bind'), this is used as the callback
+* function for AJAX calls that fetch a user help page.  It extracts
+* the relevant content from the help page and adds it to the modal.
+*
+* @param modalId {string} - ID of the target modal.
+* @param helpItemIds {array of strings} - IDs of the source help items.
+* @param title {string or undefined} - modal title to use with multiple help items.
+* @param helpPageString {string} - HTML of the help page.
+*/
+function populateUserHelpModal(modalId, helpItemIds, title, helpPageString) {
+  var parser = new DOMParser();
+  var helpPage = parser.parseFromString(helpPageString, "text/html");
+
+  var modal = document.getElementById(modalId);
+  var modalTitle = modal.querySelector(".userHelpModalTitle");
+  var modalBody = modal.querySelector(".userHelpModalBody");
+
+  if (title) {
+    modalTitle.innerHTML = title;
+    // Remove "Loading..." or other text from modal body.
+    modalBody.innerHTML = "";
+
+    helpItemIds.forEach(function (helpItemId) {
+      var helpItem = helpPage.getElementById(helpItemId);
+
+      // Remove the permalink anchor tag from the help title.
+      var helpTitle = helpItem.querySelector("h2");
+      helpTitle.innerHTML = helpTitle.firstChild.textContent;
+
+      while (helpItem.firstChild) {
+        modalBody.appendChild(helpItem.firstChild);
+      }
+    });
+
+  } else {
+    var helpItem = helpPage.getElementById(helpItemIds[0]);
+    var helpTitle = helpItem.querySelector("h2");
+
+    modalTitle.innerHTML = helpTitle.firstChild.textContent;
+
+    helpItem.removeChild(helpTitle);
+    modalBody.innerHTML = helpItem.innerHTML;
+  }
+};
+
 /**
 * Add a click handler function to a user help modal link.
 * Title is optional; is absent (undefined) to show a single help item.
@@ -7,131 +107,36 @@
 * @param helpItemIds {array of strings} - IDs of the source help items.
 * @param title {string or undefined} - Title to use with multiple help items.
 */
-function addUserHelpClickHandler(helpLinkSelector, helpDocsPath, helpItemIds, title) {
-  $(helpLinkSelector)
-    .off("click")
-    .click(function userHelpClickHandler() {
-      resetUserHelpModal('#user-help-modal');
-      addressLoadModal('#user-help-modal');
-      $.get(
-        ctx + helpDocsPath,
-        populateUserHelpModal.bind(
-          undefined,
-          'user-help-modal',
-          helpItemIds,
-          title
-        )
-      );
-    });
+function addUserHelpClickHandler(
+    helpLinkSelector,
+    helpDocsPath,
+    helpItemIds,
+    title
+  ) {
+    $(helpLinkSelector)
+      .off("click")
+      .click(function userHelpClickHandler() {
+        resetUserHelpModal('#user-help-modal');
+        addressLoadModal('#user-help-modal');
+        $.get(
+          ctx + helpDocsPath,
+          populateUserHelpModal.bind(
+            undefined,
+            'user-help-modal',
+            helpItemIds,
+            title
+          )
+        );
+      });
 };
 
-$(document).ready(function () {
+$(document).ready(function() {
 
   $('.searchPanel input[type="checkbox"]')
     .css("border", "none")
     .css("background", "none")
     .css("position", "relative")
     .css('top', "-1px");
-
-  addressPositionModal = function () {
-    var wWidth  = window.innerWidth;
-    var wHeight = window.innerHeight;
-
-    if (wWidth == undefined) {
-      wWidth  = document.documentElement.clientWidth;
-      wHeight = document.documentElement.clientHeight;
-    }
-
-    boxLeft = parseInt((wWidth / 2) - ($("#new-modal").width() / 2));
-    //var boxTop  = parseInt((wHeight / 2) - ( $("#new-modal").height() / 2 ));
-
-    // position modal
-    $("#new-modal").css({
-      'margin': 120 + 'px auto 0 ' + boxLeft + 'px'
-    });
-
-    $("#modalBackground").css("opacity", "0.8");
-
-    if ($("body").height() > $("#modalBackground").height()) {
-      $("#modalBackground").css("height", $("body").height() + "px");
-    }
-
-    if ($('#new-modal').height() > $("#modalBackground").height()) {
-      $("#modalBackground").css("height", $('#new-modal').height() + 120 + "px");
-    }
-
-    $(window).scrollTop(0);
-  };
-
-  addressLoadModal = function (itemId) {
-    $('#modalBackground').show();
-    $(itemId).show();
-    addressPositionModal();
-  }
-
-  addressCloseModal = function () {
-    $('#modalBackground').hide();
-    $('#new-modal>div').hide();
-  }
-
-  /**
-  * Clears and resets the contents of the user help modal
-  * (before it gets populated with results of AJAX call).
-  */
-  resetUserHelpModal = function (modalSelector) {
-    var modal = document.querySelector(modalSelector);
-    var modalTitle = modal.querySelector('.userHelpModalTitle');
-    var modalBody = modal.querySelector('.userHelpModalBody');
-    modalTitle.innerHTML = '';
-    modalBody.innerHTML = 'Loading...';
-  }
-
-  /**
-  * Populates a user help modal with content.  With the first three
-  * arguments bound (using '.bind'), this is used as the callback
-  * function for AJAX calls that fetch a user help page.  It extracts
-  * the relevant content from the help page and adds it to the modal.
-  *
-  * @param modalId {string} - ID of the target modal.
-  * @param helpItemIds {array of strings} - IDs of the source help items.
-  * @param title {string or undefined} - modal title to use with multiple help items.
-  * @param helpPageString {string} - HTML of the help page.
-  */
-  populateUserHelpModal = function (modalId, helpItemIds, title, helpPageString) {
-    var parser = new DOMParser();
-    var helpPage = parser.parseFromString(helpPageString, "text/html");
-
-    var modal = document.getElementById(modalId);
-    var modalTitle = modal.querySelector(".userHelpModalTitle");
-    var modalBody = modal.querySelector(".userHelpModalBody");
-
-    if (title) {
-      modalTitle.innerHTML = title;
-      // Remove "Loading..." or other text from modal body.
-      modalBody.innerHTML = "";
-
-      helpItemIds.forEach(function (helpItemId) {
-        var helpItem = helpPage.getElementById(helpItemId);
-
-        // Remove the permalink anchor tag from the help title.
-        var helpTitle = helpItem.querySelector("h2");
-        helpTitle.innerHTML = helpTitle.firstChild.textContent;
-
-        while (helpItem.firstChild) {
-          modalBody.appendChild(helpItem.firstChild);
-        }
-      });
-
-    } else {
-      var helpItem = helpPage.getElementById(helpItemIds[0]);
-      var helpTitle = helpItem.querySelector("h2");
-
-      modalTitle.innerHTML = helpTitle.firstChild.textContent;
-
-      helpItem.removeChild(helpTitle);
-      modalBody.innerHTML = helpItem.innerHTML;
-    }
-  };
 
   $(".closeModal, .modalCloseButton, #new-modal #printModal .modal-title a.greyBtn")
     .click(addressCloseModal);

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -99,15 +99,16 @@ function populateUserHelpModal(modalId, helpItemIds, title, helpPageString) {
 };
 
 /**
-* Add a click handler function to a user help modal link.
-* Title is optional; is absent (undefined) to show a single help item.
+* Add a click handler function to a user help modal link, and remove any
+* existing click handler. Title is optional; is absent (undefined) to show a
+* single help item.
 *
 * @param helpLinkSelector {string} - Selector for the help link.
 * @param helpDocsPath {string} - Path to the help doc html file.
 * @param helpItemIds {array of strings} - IDs of the source help items.
 * @param title {string or undefined} - Title to use with multiple help items.
 */
-function addUserHelpClickHandler(
+function setUserHelpClickHandler(
     helpLinkSelector,
     helpDocsPath,
     helpItemIds,

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1,3 +1,10 @@
+var addNpiUserHelpClickHandler = addUserHelpClickHandler.bind(
+  undefined,
+  'a.NPIdefinition',
+  '/help/enrollment.html',
+  ['what-is-an-npi']
+);
+
 $(document).ready(function () {
   $("#enrollmentQuickSearch").click(function () {
     var quickSearchInput = $.trim($("#quickSearchInput").val());
@@ -1611,7 +1618,7 @@ $(document).ready(function () {
     reindexSetup();
   });
 
-  $('#addMember').live('click', function () {
+  $('#addMember').click(function () {
     var html = $('#memberPanelTemplate').clone();
     html.attr('id', '');
     html.find('[type=text]').val('');
@@ -1623,6 +1630,7 @@ $(document).ready(function () {
     $(html).find('input.npiMasked').mask("9999999999");
     $(html).find("input.umpiMasked").mask("**********");
     $(html).find('input.ssnMasked').mask("999-99-9999");
+    addNpiUserHelpClickHandler();
     reindexMembers();
   });
 
@@ -1879,11 +1887,7 @@ $(document).ready(function () {
     ['what-are-the-types-for-individual-person-s-ownership-or-control-interest']
   );
 
-  addUserHelpClickHandler(
-    'a.NPIdefinition',
-    '/help/enrollment.html',
-    ['what-is-an-npi']
-  );
+  addNpiUserHelpClickHandler();
 
   addUserHelpClickHandler(
     'a.maintainOwnPrivatePractice',

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1,4 +1,4 @@
-var addNpiUserHelpClickHandler = addUserHelpClickHandler.bind(
+var setNpiUserHelpClickHandler = setUserHelpClickHandler.bind(
   undefined,
   'a.NPIdefinition',
   '/help/enrollment.html',
@@ -1630,7 +1630,7 @@ $(document).ready(function () {
     $(html).find('input.npiMasked').mask("9999999999");
     $(html).find("input.umpiMasked").mask("**********");
     $(html).find('input.ssnMasked').mask("999-99-9999");
-    addNpiUserHelpClickHandler();
+    setNpiUserHelpClickHandler();
     reindexMembers();
   });
 
@@ -1881,27 +1881,27 @@ $(document).ready(function () {
     $(html).attr('alt', '').attr('title', '');
   });
 
-  addUserHelpClickHandler(
+  setUserHelpClickHandler(
     'a.ownershipTypeDefinition',
     '/help/enrollment.html',
     ['what-are-the-types-for-individual-person-s-ownership-or-control-interest']
   );
 
-  addNpiUserHelpClickHandler();
+  setNpiUserHelpClickHandler();
 
-  addUserHelpClickHandler(
+  setUserHelpClickHandler(
     'a.maintainOwnPrivatePractice',
     '/help/enrollment.html',
     ['do-i-maintain-my-own-private-practice']
   );
 
-  addUserHelpClickHandler(
+  setUserHelpClickHandler(
     'a.employedByGroupPractice',
     '/help/enrollment.html',
     ['am-i-employed-and-or-independently-contracted-by-a-group-practice']
   );
 
-  addUserHelpClickHandler(
+  setUserHelpClickHandler(
     'a.actionColumnHelpLink',
     '/help/enrollment.html',
     [
@@ -1913,7 +1913,7 @@ $(document).ready(function () {
     "Questions About Editing an Enrollment"
   );
 
-  addUserHelpClickHandler(
+  setUserHelpClickHandler(
     'a.providerTypeHelpLink',
     '/help/enrollment.html',
     [


### PR DESCRIPTION
These labels appear in the enrollment steps in two places: on the individual provider 'Practice Info' page, and the organization provider 'Individual Member Info' page.

Tested by checking that the "?" links appear correctly on these pages and, when clicked, open the "What is an NPI?" modal.

Issue #422 Review documentation to add [...] help links