### PR TITLE
Hide "Specify Type" field unless "Entity Type" is "Other"

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -36,12 +36,19 @@
             <div class="row">
                 <c:set var="formName" value="_17_entityDescription"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">Specify Type</label>
+                <c:set var="formNameEntityType" value="_17_entityType"></c:set>
+                <c:set var="formValueEntityType" value="${requestScope[formNameEntityType]}"></c:set>
+                <label
+                  for="${formIdPrefix}_${formName}"
+                  class="${formValueEntityType == 'Other' ? '' : 'hidden disabled'}"
+                >
+                  Specify Other Entity Type
+                </label>
                 <input
                   id="${formIdPrefix}_${formName}"
                   type="text"
-                  class="normalInput ${formValue eq 'Other' ? '' : 'disabled'}"
-                  ${formValue eq 'Other' ? '' : disabledMarkup}
+                  class="normalInput ${formValueEntityType == 'Other' ? '' : 'hidden disabled'}"
+                  ${formValueEntityType == 'Other' ? '' : disabledMarkup}
                   name="${formName}"
                   value="${formValue}"
                   maxlength="100"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -37,7 +37,15 @@
                 <c:set var="formName" value="_17_entityDescription"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Specify Type</label>
-                <input id="${formIdPrefix}_${formName}" type="text" class="normalInput ${formValue eq 'Other' ? '' : 'disabled'}" ${formValue eq 'Other' ? '' : disabledMarkup} name="${formName}" value="${formValue}" maxlength="100"/>
+                <input
+                  id="${formIdPrefix}_${formName}"
+                  type="text"
+                  class="normalInput ${formValue eq 'Other' ? '' : 'disabled'}"
+                  ${formValue eq 'Other' ? '' : disabledMarkup}
+                  name="${formName}"
+                  value="${formValue}"
+                  maxlength="100"
+                />
             </div>
             <div class="clearFixed"></div>
         </div>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4141,13 +4141,12 @@ input.passwordNormalInput{
   width: 150px;
 }
 
-/*.homeHealthAgency input:disabled, .homeHealthAgency select:disabled, .addPracticeLocations .generalTable input:disabled{*/
-/*background-color: #d2d2d2 !important;*/
-/*border: 1px solid #999 !important;*/
-/*background-image: none;*/
-/*}*/
-.homeHealthAgency input.disabled, .homeHealthAgency select.disabled, .addPracticeLocations .generalTable input.disabled, .licenseInformationTable input.disabled,
-#enrollmentForm input.disabled, #enrollmentForm select.disabled {
+.homeHealthAgency input.disabled,
+.homeHealthAgency select.disabled,
+.addPracticeLocations .generalTable input.disabled,
+.licenseInformationTable input.disabled,
+#enrollmentForm input.disabled,
+#enrollmentForm select.disabled {
   background-color: #d2d2d2 !important;
   border: 1px solid #999 !important;
   background-image: none !important;

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4152,6 +4152,10 @@ input.passwordNormalInput{
   background-image: none !important;
 }
 
+.hidden {
+  display:none !important;
+}
+
 .alternateTable td{
   line-height: 18px;
 }

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1724,15 +1724,15 @@ $(document).ready(function () {
     if ($(this).val() == 'Other') {
       $('input[name="_17_entityDescription"]')
         .removeAttr('disabled')
-        .removeClass('disabled')
+        .removeClass('hidden disabled')
         .siblings('label')
-        .removeClass('disabled');
+        .removeClass('hidden disabled');
     } else {
       $('input[name="_17_entityDescription"]')
         .attr('disabled', 'disabled')
-        .addClass('disabled')
+        .addClass('hidden disabled')
         .siblings('label')
-        .addClass('disabled');
+        .addClass('hidden disabled');
     }
 
     updateBeneficialOwnerTypes($(this).val());

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1719,13 +1719,20 @@ $(document).ready(function () {
     performSetupLookup($(this));
   });
 
-  /*entity type change function*/
-  //$('input[name="_17_entityDescription"]').attr('disabled','disabled').addClass('disabled').siblings('label').addClass('disabled');
+  /* entity type change function */
   $('#entityType').change(function () {
     if ($(this).val() == 'Other') {
-      $('input[name="_17_entityDescription"]').removeAttr('disabled').removeClass('disabled').siblings('label').removeClass('disabled');
+      $('input[name="_17_entityDescription"]')
+        .removeAttr('disabled')
+        .removeClass('disabled')
+        .siblings('label')
+        .removeClass('disabled');
     } else {
-      $('input[name="_17_entityDescription"]').attr('disabled', 'disabled').addClass('disabled').siblings('label').addClass('disabled');
+      $('input[name="_17_entityDescription"]')
+        .attr('disabled', 'disabled')
+        .addClass('disabled')
+        .siblings('label')
+        .addClass('disabled');
     }
 
     updateBeneficialOwnerTypes($(this).val());

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1743,7 +1743,7 @@ $(document).ready(function () {
     $(this).siblings('.subType').hide();
     if ($(this).val() == 'Other') {
       $(this).siblings('.other').show();
-    } else if ($(this).val() == 'Owner - 5% or more') {
+    } else if ($(this).val() == 'Owner - 5% or more of Ownership Interest') {
       $(this).siblings('.owner').show();
     } else if ($(this).val() == 'Subcontractor') {
       $(this).siblings('.subcontractor').show();


### PR DESCRIPTION
In the enrollment steps, on the organization provider "Ownership Info" page, hide the "Specify Type" field unless "Entity Type" is "Other".

Tested by selecting "Other" and other options on that page to see that the field was dynamically shown and hidden, and by saving the enrollment with "Other" (and other options) selected then navigating away from the page and back to make sure the field is shown (or not shown) when the page loads.

Includes some reformatting, deletion of commented out code, and a fix for a small, easy-fix bug I stumbled into.

Issue #422 Review documentation to add [...] help links