### PR TITLE
Show additional addresses in h-adr format

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_pca_rows.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_pca_rows.jsp
@@ -21,14 +21,13 @@
 <div class="row address">
     <label>Residential Address</label>
     <span class="floatL"><b>:</b></span>
-    <span>
-        <c:if test="${not empty requestScope['_10_addressLine1']}"><c:out value="${requestScope['_10_addressLine1']}" /><br /></c:if>
-        <c:out value="${requestScope['_10_addressLine2']}" /><br />
-        <c:set var="city" value="${requestScope['_10_city']}" /><c:out value="${city}" />
-        <c:set var="state" value="${requestScope['_10_state']}" /><c:if test="${not empty state}">,</c:if>${state}
-        <c:set var="zip" value="${requestScope['_10_zip']}" /><c:if test="${not empty zip}">,</c:if>${zip}
-        <c:set var="county" value="${requestScope['_10_county']}" /><c:if test="${not empty county}">,</c:if>${county}
-    </span>
+    <h:address name="residential"
+        streetAddress="${requestScope['_10_addressLine1']}"
+        extendedAddress="${requestScope['_10_addressLine2']}"
+        city="${requestScope['_10_city']}"
+        state="${requestScope['_10_state']}"
+        postalCode="${requestScope['_10_zip']}"
+        county="${requestScope['_10_county']}" />
 </div>
 
 <div class="row">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_pca_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_pca_information.jsp
@@ -1,4 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <c:if test="${requestScope['_10_bound'] eq 'Y'}">
     <div class="practiceSection">
         <div class="wholeCol">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
@@ -1,4 +1,6 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <c:if test="${requestScope['_15_bound'] eq 'Y'}">
 <c:set var="askEffectiveDate" value="${viewModel.tabModels['Organization Information'].formSettings['Organization Information Form'].settings['askEffectiveDate']}"></c:set>
 <c:set var="askFiscalYear" value="${viewModel.tabModels['Organization Information'].formSettings['Organization Information Form'].settings['askFiscalYear']}"></c:set>
@@ -253,14 +255,13 @@
                 <div class="row">
                     <label>Practice Address</label>
                     <span class="floatL"><b>:</b></span>
-                    <span>
-                        <c:if test="${not empty requestScope['_15_addressLine1']}"><c:out value="${requestScope['_15_addressLine1']}" /><br /></c:if>
-                        <c:out value="${requestScope['_15_addressLine2']}" /><br />
-                        <c:set var="city" value="${requestScope['_15_city']}" /><c:out value="${city}" />
-                        <c:set var="state" value="${requestScope['_15_state']}" /><c:if test="${not empty state}">,</c:if>${state}
-                        <c:set var="zip" value="${requestScope['_15_zip']}" /><c:if test="${not empty zip}">,</c:if>${zip}
-                        <c:set var="county" value="${requestScope['_15_county']}" /><c:if test="${not empty county}">,</c:if>${county}
-                    </span>
+                    <h:address name="practice"
+                        streetAddress="${requestScope['_15_addressLine1']}"
+                        extendedAddress="${requestScope['_15_addressLine2']}"
+                        city="${requestScope['_15_city']}"
+                        state="${requestScope['_15_state']}"
+                        postalCode="${requestScope['_15_zip']}"
+                        county="${requestScope['_15_county']}" />
                 </div>
                 <div class="row">
                     <label>Office Phone Number</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ownership_information.jsp
@@ -1,4 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 
 <c:if test="${requestScope['_17_bound'] eq 'Y'}">
 <table class="memberInfo">
@@ -40,18 +41,20 @@
                     <div class="row">
                         <label>Home Residence Address</label>
                         <span class="floatL"><b>:</b></span>
-                        <span>
-                            <c:set var="formName" value="_17_iboAddressLine1_${status.index - 1}"></c:set><c:if test="${not empty requestScope[formName]}"><c:out value="${requestScope[formName]}"><br /></c:out></c:if>
-                            <c:set var="formName" value="_17_iboAddressLine2_${status.index - 1}"></c:set>${requestScope[formName]}<br />
-                            <c:set var="formName" value="_17_iboCity_${status.index - 1}"></c:set>
-                            <c:set var="city" value="${requestScope[formName]}"></c:set>${city}
-                            <c:set var="formName" value="_17_iboState_${status.index - 1}"></c:set>
-                            <c:set var="state" value="${requestScope[formName]}"></c:set><c:if test="${not empty state}">,</c:if>${state}
-                            <c:set var="formName" value="_17_iboZip_${status.index - 1}"></c:set>
-                            <c:set var="zip" value="${requestScope[formName]}"></c:set><c:if test="${not empty zip}">,</c:if>${zip}
-                            <c:set var="formName" value="_17_iboCounty_${status.index - 1}"></c:set>
-                            <c:set var="county" value="${requestScope[formName]}"></c:set><c:if test="${not empty county}">,</c:if>${county}
-                        </span>
+
+                        <c:set var="streetAddress" value="_17_iboAddressLine1_${status.index - 1}" />
+                        <c:set var="extendedAddress" value="_17_iboAddressLine2_${status.index - 1}" />
+                        <c:set var="city" value="_17_iboCity_${status.index - 1}" />
+                        <c:set var="state" value="_17_iboState_${status.index - 1}" />
+                        <c:set var="postalCode" value="_17_iboZip_${status.index - 1}" />
+                        <c:set var="county" value="_17_iboCounty_${status.index - 1}" />
+                        <h:address name="home"
+                            streetAddress="${requestScope[streetAddress]}"
+                            extendedAddress="${requestScope[extendedAddress]}"
+                            city="${requestScope[city]}"
+                            state="${requestScope[state]}"
+                            postalCode="${requestScope[postalCode]}"
+                            county="${requestScope[county]}" />
                     </div>
                 </div>
                 <div class="rightCol">
@@ -109,18 +112,20 @@
                     <div class="row">
                         <label>Business Address</label>
                         <span class="floatL"><b>:</b></span>
-                        <span>
-                            <c:set var="formName" value="_17_cboAddressLine1_${status.index - 1}"></c:set><c:if test="${not empty requestScope[formName]}"><c:out value="${requestScope[formName]}"><br /></c:out></c:if>
-                            <c:set var="formName" value="_17_cboAddressLine2_${status.index - 1}"></c:set>${requestScope[formName]}<br />
-                            <c:set var="formName" value="_17_cboCity_${status.index - 1}"></c:set>
-                            <c:set var="city" value="${requestScope[formName]}"></c:set>${city}
-                            <c:set var="formName" value="_17_cboState_${status.index - 1}"></c:set>
-                            <c:set var="state" value="${requestScope[formName]}"></c:set><c:if test="${not empty state}">,</c:if>${state}
-                            <c:set var="formName" value="_17_cboZip_${status.index - 1}"></c:set>
-                            <c:set var="zip" value="${requestScope[formName]}"></c:set><c:if test="${not empty zip}">,</c:if>${zip}
-                            <c:set var="formName" value="_17_cboCounty_${status.index - 1}"></c:set>
-                            <c:set var="county" value="${requestScope[formName]}"></c:set><c:if test="${not empty county}">,</c:if>${county}
-                        </span>
+
+                        <c:set var="streetAddress" value="_17_cboAddressLine1_${status.index - 1}" />
+                        <c:set var="extendedAddress" value="_17_cboAddressLine2_${status.index - 1}" />
+                        <c:set var="city" value="_17_cboCity_${status.index - 1}" />
+                        <c:set var="state" value="_17_cboState_${status.index - 1}" />
+                        <c:set var="postalCode" value="_17_cboZip_${status.index - 1}" />
+                        <c:set var="county" value="_17_cboCounty_${status.index - 1}" />
+                        <h:address name="business"
+                            streetAddress="${requestScope[streetAddress]}"
+                            extendedAddress="${requestScope[extendedAddress]}"
+                            city="${requestScope[city]}"
+                            state="${requestScope[state]}"
+                            postalCode="${requestScope[postalCode]}"
+                            county="${requestScope[county]}" />
                     </div>
                 </div>
                 <div class="rightCol">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/qualified_professional.jsp
@@ -64,25 +64,20 @@
             <div class="row">
                 <label>Home Residence Address</label>
                 <span class="floatL"><b>:</b></span>
-                <span class="address">
-                    <c:set var="formName" value="_29_addressLine2_${status.index - 1}"></c:set>
-                     ${requestScope[formName]}<br />
-                    <c:set var="formName" value="_29_city_${status.index - 1}"></c:set>
-                    <c:set var="city" value="${requestScope[formName]}"></c:set>
-                    ${city}
-                    <c:set var="formName" value="_29_state_${status.index - 1}"></c:set>
-                    <c:set var="state" value="${requestScope[formName]}"></c:set>
-                    <c:if test="${not empty state}">,</c:if>
-                    ${state}
-                    <c:set var="formName" value="_29_zip_${status.index - 1}"></c:set>
-                    <c:set var="zip" value="${requestScope[formName]}"></c:set>
-                    <c:if test="${not empty zip}">,</c:if>
-                    ${zip}
-                    <c:set var="formName" value="_29_county_${status.index - 1}"></c:set>
-                    <c:set var="county" value="${requestScope[formName]}"></c:set>
-                    <c:if test="${not empty county}">,</c:if>
-                    ${county}
-                </span>
+
+                <c:set var="streetAddress" value="_29_addressLine1_${status.index - 1}" />
+                <c:set var="extendedAddress" value="_29_addressLine2_${status.index - 1}" />
+                <c:set var="city" value="_29_city_${status.index - 1}" />
+                <c:set var="state" value="_29_state_${status.index - 1}" />
+                <c:set var="postalCode" value="_29_zip_${status.index - 1}" />
+                <c:set var="county" value="_29_county_${status.index - 1}" />
+                <h:address name="home"
+                    streetAddress="${requestScope[streetAddress]}"
+                    extendedAddress="${requestScope[extendedAddress]}"
+                    city="${requestScope[city]}"
+                    state="${requestScope[state]}"
+                    postalCode="${requestScope[postalCode]}"
+                    county="${requestScope[county]}" />
             </div>
         </div>
 


### PR DESCRIPTION
Use the address tag introduced in PR #390 to format several addtional addresses:

- individual personal care assistant

Before:
![pca-before](https://user-images.githubusercontent.com/1494855/37686800-4abe0792-2c6f-11e8-9abc-5b4716a087de.png)

After:
![pca-after](https://user-images.githubusercontent.com/1494855/37686535-4524ed7e-2c6e-11e8-80b0-8b9f8b2bdbc8.png)

- organizations - organization info tab

Before:
![org-info-before](https://user-images.githubusercontent.com/1494855/37686802-4af1156a-2c6f-11e8-90e1-0d9bc68f562b.png)

After:
![org-info-after](https://user-images.githubusercontent.com/1494855/37686803-4b04e612-2c6f-11e8-906c-e59b2e87943a.png)

- organizations - ownership info tab

Before:
![ownership-info-before](https://user-images.githubusercontent.com/1494855/37686801-4ad24bb2-2c6f-11e8-812b-a5c9411fc865.png)

After:
![ownership-info-after](https://user-images.githubusercontent.com/1494855/37686534-44fc86d6-2c6e-11e8-83e6-91cd55a9e149.png)

This also changes how addresses are shown for qualified professionals, but as far as I can tell this code is never used, and so I could not test it.

Issue #159 Practice address displays punctuated improperly