### PR TITLE
Delete subcontractor name

### DIFF
--- a/psm-app/cms-business-model/src/main/resources/Entities.xsd
+++ b/psm-app/cms-business-model/src/main/resources/Entities.xsd
@@ -969,7 +969,6 @@
       <element name="PersonInd" type="string" maxOccurs="1" minOccurs="1"/>
       <element name="BeneficialOwnerType" type="string" maxOccurs="1" minOccurs="0"/>
       <element name="OtherBeneficialOwnerDescription" type="string" maxOccurs="1" minOccurs="0"/>
-      <element name="SubcontractorName" type="string" maxOccurs="1" minOccurs="0"/>
       <element name="PercentOwnership" type="double" maxOccurs="1" minOccurs="0"/>
       <element name="PersonInformation" type="tns:PersonType" maxOccurs="1" minOccurs="0"/>
       <element name="EntityInformation" type="tns:OrganizationType" maxOccurs="1" minOccurs="0"/>

--- a/psm-app/cms-business-process/src/main/resources/cms.validation.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.validation.drl
@@ -13093,57 +13093,6 @@ dialect 'mvel'
 
 end
 
-rule 'Subcontractor Name Is Required If Beneficial Owner Type Is Subcontractor'
-dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
-    when
-        LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
-        IsOrganization($provider : provider)
-        OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(beneficialOwnerType == "Subcontractor", subcontractorName == null || subcontractorName matches "^[\\s]*$") from $ownerList
-        $report: ErrorReporter()
-    then
-        int index = $ownerList.indexOf($owner);
-        $report.addError(
-            "/ProviderInformation/OwnershipInformation/BeneficialOwner[" + index + "]/SubcontractorName",
-            "00001",
-            "Subcontractor name is required."
-        );
-
-end
-
-rule 'Subcontractor Name Maximum Length Check'
-dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
-    when
-        LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
-        IsOrganization($provider : provider)
-        OwnershipInformationType($ownerList: beneficialOwner) from $provider.ownershipInformation
-        $owner: BeneficialOwnerType(subcontractorName != null, subcontractorName not matches "^.{0,100}$") from $ownerList
-        $report: ErrorReporter()
-    then
-        int index = $ownerList.indexOf($owner);
-        $report.addError(
-            "/ProviderInformation/OwnershipInformation/BeneficialOwner[" + index + "]/SubcontractorName",
-            "00001",
-            "Subcontractor name length cannot exceed 100 characters."
-        );
-
-end
-
-
 rule 'TaxPayer Name Is Required For PCPO'
 dialect 'mvel'
 /*

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -104,13 +104,6 @@
                     </c:forEach>
                 </select>
 
-                <div class="subType subcontractor">
-                    <c:set var="formName" value="_17_iboSubcontractorName_${status.index - 1}"></c:set>
-                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">Name Subcontractor</label>
-                    <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
-                    <div class="clear"></div>
-                </div>
                 <div class="subType owner">
                     <c:set var="formName" value="_17_iboPercentOwnership_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -366,13 +359,6 @@
                     </c:forEach>
                 </select>
 
-                <div class="subType subcontractor">
-                    <c:set var="formName" value="_17_cboSubcontractorName_${status.index - 1}"></c:set>
-                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">Name Subcontractor</label>
-                    <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
-                    <div class="clear"></div>
-                </div>
                 <div class="subType owner">
                     <c:set var="formName" value="_17_cboPercentOwnership_${status.index - 1}"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -582,13 +568,6 @@
                     </c:forEach>
                 </select>
 
-                <div class="subType subcontractor">
-                    <c:set var="formName" value="_17_cboSubcontractorName"></c:set>
-                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">Name Subcontractor</label>
-                    <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
-                    <div class="clear"></div>
-                </div>
                 <div class="subType owner">
                     <c:set var="formName" value="_17_cboPercentOwnership"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -786,13 +765,6 @@
                     </c:forEach>
                 </select>
 
-                <div class="subType subcontractor">
-                    <c:set var="formName" value="_17_iboSubcontractorName"></c:set>
-                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="${formIdPrefix}_${formName}">Name Subcontractor</label>
-                    <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
-                    <div class="clear"></div>
-                </div>
                 <div class="subType owner">
                     <c:set var="formName" value="_17_iboPercentOwnership"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -1135,7 +1135,6 @@ CREATE TABLE beneficial_owner (
   ben_type_cd               CHARACTER VARYING(2)
     REFERENCES beneficial_owner_types (code),
   oth_type_desc             TEXT,
-  subcontractor_name        TEXT,
   own_interest_pct          FLOAT,
   address_id                BIGINT
     REFERENCES addresses (address_id),

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1745,8 +1745,6 @@ $(document).ready(function () {
       $(this).siblings('.other').show();
     } else if ($(this).val() == 'Owner - 5% or more of Ownership Interest') {
       $(this).siblings('.owner').show();
-    } else if ($(this).val() == 'Subcontractor') {
-      $(this).siblings('.subcontractor').show();
     }
 
   }).trigger('change');
@@ -1756,34 +1754,33 @@ $(document).ready(function () {
     $('.personOwnersTable .personOwner').each(function (index) {
       var $i = $(this);
       $i.find('select:eq(0)').attr("name", "_17_iboType_" + index);
-      $i.find('input:eq(0)').attr("name", "_17_iboSubcontractorName_" + index);
-      $i.find('input:eq(1)').attr("name", "_17_iboPercentOwnership_" + index);
-      $i.find('input:eq(2)').attr("name", "_17_iboOtherType_" + index);
-      $i.find('input:eq(3)').attr("name", "_17_iboFirstName_" + index);
-      $i.find('input:eq(4)').attr("name", "_17_iboMiddleName_" + index);
-      $i.find('input:eq(5)').attr("name", "_17_iboLastName_" + index);
-      $i.find('input:eq(6)').attr("name", "_17_iboSSN_" + index);
-      $i.find('input:eq(7)').attr("name", "_17_iboDOB_" + index);
-      $i.find('input:eq(8)').attr("name", "_17_iboHireDate_" + index);
+      $i.find('input:eq(0)').attr("name", "_17_iboPercentOwnership_" + index);
+      $i.find('input:eq(1)').attr("name", "_17_iboOtherType_" + index);
+      $i.find('input:eq(2)').attr("name", "_17_iboFirstName_" + index);
+      $i.find('input:eq(3)').attr("name", "_17_iboMiddleName_" + index);
+      $i.find('input:eq(4)').attr("name", "_17_iboLastName_" + index);
+      $i.find('input:eq(5)').attr("name", "_17_iboSSN_" + index);
+      $i.find('input:eq(6)').attr("name", "_17_iboDOB_" + index);
+      $i.find('input:eq(7)').attr("name", "_17_iboHireDate_" + index);
+      $i.find('input:eq(8)').attr("name", "_17_iboRelationship_" + index);
       $i.find('input:eq(9)').attr("name", "_17_iboRelationship_" + index);
       $i.find('input:eq(10)').attr("name", "_17_iboRelationship_" + index);
       $i.find('input:eq(11)').attr("name", "_17_iboRelationship_" + index);
-      $i.find('input:eq(12)').attr("name", "_17_iboRelationship_" + index);
-      $i.find('input:eq(13)').attr("name", "_17_iboAddressLine1_" + index);
-      $i.find('input:eq(14)').attr("name", "_17_iboAddressLine2_" + index);
-      $i.find('input:eq(15)').attr("name", "_17_iboCity_" + index);
+      $i.find('input:eq(12)').attr("name", "_17_iboAddressLine1_" + index);
+      $i.find('input:eq(13)').attr("name", "_17_iboAddressLine2_" + index);
+      $i.find('input:eq(14)').attr("name", "_17_iboCity_" + index);
       $i.find('select:eq(1)').attr("name", "_17_iboState_" + index);
-      $i.find('input:eq(16)').attr("name", "_17_iboZip_" + index);
+      $i.find('input:eq(15)').attr("name", "_17_iboZip_" + index);
       $i.find('select:eq(2)').attr("name", "_17_iboCounty_" + index);
-      $i.find('input:eq(17)').attr("name", "_17_iboOtherInterestInd_" + index);
-      $i.find('input:eq(18)').attr("name", "_17_iboOtherInterestName_" + index);
-      $i.find('input:eq(19)').attr("name", "_17_iboOtherInterestPct_" + index);
-      $i.find('input:eq(20)').attr("name", "_17_iboOtherAddressLine1_" + index);
-      $i.find('input:eq(21)').attr("name", "_17_iboOtherAddressLine2_" + index);
-      $i.find('input:eq(22)').attr("name", "_17_iboOtherCity_" + index);
+      $i.find('input:eq(16)').attr("name", "_17_iboOtherInterestInd_" + index);
+      $i.find('input:eq(17)').attr("name", "_17_iboOtherInterestName_" + index);
+      $i.find('input:eq(18)').attr("name", "_17_iboOtherInterestPct_" + index);
+      $i.find('input:eq(19)').attr("name", "_17_iboOtherAddressLine1_" + index);
+      $i.find('input:eq(20)').attr("name", "_17_iboOtherAddressLine2_" + index);
+      $i.find('input:eq(21)').attr("name", "_17_iboOtherCity_" + index);
       $i.find('select:eq(3)').attr("name", "_17_iboOtherCounty" + index);
       $i.find('select:eq(4)').attr("name", "_17_iboOtherState_" + index);
-      $i.find('input:eq(23)').attr("name", "_17_iboOtherZip_" + index);
+      $i.find('input:eq(22)').attr("name", "_17_iboOtherZip_" + index);
     });
   }
 
@@ -1792,24 +1789,23 @@ $(document).ready(function () {
     $('.corpOwnersTable .corpOwner').each(function (index) {
       var $i = $(this);
       $i.find('select:eq(0)').attr("name", "_17_cboType_" + index);
-      $i.find('input:eq(0)').attr("name", "_17_cboSubcontractorName_" + index);
-      $i.find('input:eq(1)').attr("name", "_17_cboPercentOwnership_" + index);
-      $i.find('input:eq(2)').attr("name", "_17_cboOtherType_" + index);
-      $i.find('input:eq(3)').attr("name", "_17_cboLegalName_" + index);
-      $i.find('input:eq(4)').attr("name", "_17_cboFEIN_" + index);
-      $i.find('input:eq(5)').attr("name", "_17_cboAddressLine1_" + index);
-      $i.find('input:eq(6)').attr("name", "_17_cboAddressLine2_" + index);
-      $i.find('input:eq(7)').attr("name", "_17_cboCity_" + index);
+      $i.find('input:eq(0)').attr("name", "_17_cboPercentOwnership_" + index);
+      $i.find('input:eq(1)').attr("name", "_17_cboOtherType_" + index);
+      $i.find('input:eq(2)').attr("name", "_17_cboLegalName_" + index);
+      $i.find('input:eq(3)').attr("name", "_17_cboFEIN_" + index);
+      $i.find('input:eq(4)').attr("name", "_17_cboAddressLine1_" + index);
+      $i.find('input:eq(5)').attr("name", "_17_cboAddressLine2_" + index);
+      $i.find('input:eq(6)').attr("name", "_17_cboCity_" + index);
       $i.find('select:eq(1)').attr("name", "_17_cboState_" + index);
-      $i.find('input:eq(8)').attr("name", "_17_cboZip_" + index);
-      $i.find('input:eq(9)').attr("name", "_17_cboCounty_" + index);
-      $i.find('input:eq(10)').attr("name", "_17_cboOtherInterestInd_" + index);
-      $i.find('input:eq(11)').attr("name", "_17_cboOtherInterestName_" + index);
-      $i.find('input:eq(12)').attr("name", "_17_cboOtherAddressLine1_" + index);
-      $i.find('input:eq(13)').attr("name", "_17_cboOtherAddressLine2_" + index);
-      $i.find('input:eq(14)').attr("name", "_17_cboOtherCity_" + index);
+      $i.find('input:eq(7)').attr("name", "_17_cboZip_" + index);
+      $i.find('input:eq(8)').attr("name", "_17_cboCounty_" + index);
+      $i.find('input:eq(9)').attr("name", "_17_cboOtherInterestInd_" + index);
+      $i.find('input:eq(10)').attr("name", "_17_cboOtherInterestName_" + index);
+      $i.find('input:eq(11)').attr("name", "_17_cboOtherAddressLine1_" + index);
+      $i.find('input:eq(12)').attr("name", "_17_cboOtherAddressLine2_" + index);
+      $i.find('input:eq(13)').attr("name", "_17_cboOtherCity_" + index);
       $i.find('select:eq(2)').attr("name", "_17_cboOtherState_" + index);
-      $i.find('input:eq(15)').attr("name", "_17_cboOtherZip_" + index);
+      $i.find('input:eq(14)').attr("name", "_17_cboOtherZip_" + index);
     });
   }
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
@@ -91,7 +91,6 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
             bo.setPersonInd("Y");
             bo.setBeneficialOwnerType(param(request, "iboType", i));
             bo.setOtherBeneficialOwnerDescription(param(request, "iboOtherType", i));
-            bo.setSubcontractorName(param(request, "iboSubcontractorName", i));
             bo.setPercentOwnership(BinderUtils.getAsDouble(param(request, "iboPercentOwnership", i)));
 
             PersonType person = new PersonType();
@@ -139,7 +138,6 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
             bo.setPersonInd("N");
             bo.setBeneficialOwnerType(param(request, "cboType", i));
             bo.setOtherBeneficialOwnerDescription(param(request, "cboOtherType", i));
-            bo.setSubcontractorName(param(request, "cboSubcontractorName", i));
             bo.setPercentOwnership(BinderUtils.getAsDouble(param(request, "cboPercentOwnership", i)));
 
             OrganizationType org = new OrganizationType();
@@ -207,7 +205,6 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
             if ("Y".equals(personInd)) {
                 attr(mv, "iboType", personIndex, bo.getBeneficialOwnerType());
                 attr(mv, "iboOtherType", personIndex, bo.getOtherBeneficialOwnerDescription());
-                attr(mv, "iboSubcontractorName", personIndex, bo.getSubcontractorName());
                 if (bo.getPercentOwnership() != null) {
                     attr(mv, "iboPercentOwnership", personIndex, bo.getPercentOwnership().toString());
                 }
@@ -244,7 +241,6 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
             } else {
                 attr(mv, "cboType", corpIndex, bo.getBeneficialOwnerType());
                 attr(mv, "cboOtherType", personIndex, bo.getOtherBeneficialOwnerDescription());
-                attr(mv, "cboSubcontractorName", personIndex, bo.getSubcontractorName());
                 if (bo.getPercentOwnership() != null) {
                     attr(mv, "cboPercentOwnership", personIndex, bo.getPercentOwnership().toString());
                 }
@@ -508,7 +504,6 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
             hbOwner.setType(getLookupService().findLookupByDescription(gov.medicaid.entities.BeneficialOwnerType.class,
                 owner.getBeneficialOwnerType()));
             hbOwner.setTypeDescription(owner.getOtherBeneficialOwnerDescription());
-            hbOwner.setSubcontractorName(owner.getSubcontractorName());
             if (owner.getPercentOwnership() != null) {
                 hbOwner.setOwnershipInterest(BigDecimal.valueOf(owner.getPercentOwnership()));
             }
@@ -554,7 +549,6 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
                 if (owner.getType() != null) {
                     bo.setBeneficialOwnerType(owner.getType().getDescription());
                 }
-                bo.setSubcontractorName(owner.getSubcontractorName());
                 if (owner.getOwnershipInterest() != null) {
                     bo.setPercentOwnership(owner.getOwnershipInterest().doubleValue());
                 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
@@ -61,12 +61,6 @@ public abstract class BeneficialOwner implements Serializable {
     private String typeDescription;
 
     /**
-     * If type is sub contractor, specify name.
-     */
-    @Column(name = "subcontractor_name")
-    private String subcontractorName;
-
-    /**
      * If type is owner, specify ownership percent.
      */
     @Column(name = "own_interest_pct")
@@ -126,14 +120,6 @@ public abstract class BeneficialOwner implements Serializable {
 
     public void setTypeDescription(String typeDescription) {
         this.typeDescription = typeDescription;
-    }
-
-    public String getSubcontractorName() {
-        return subcontractorName;
-    }
-
-    public void setSubcontractorName(String subcontractorName) {
-        this.subcontractorName = subcontractorName;
     }
 
     public BigDecimal getOwnershipInterest() {


### PR DESCRIPTION
It's not clear what benefit there is to having a separate subcontractor name. The subcontractor name wasn't being presisted correctly for Business Ownership or Control Interest subcontactors, and rather than fix the bug, we decided that it would be better to remove it entirely.

Delete the subcontractor name from the subcontractor type of both Individual Person(s) Ownership or Control Interest and Business Ownership or Control Interest. Delete associated rules, model attributes, and persistance.

To test this, I loaded a saved draft of an organizational provider, added a subcontractor under both the IPOCI and BOCI sections, and verified that there were no errors on the next page and that all the remaining fields were correctly persisted.

This change deletes a column in the database. Since Hibernate ignores excess columns in mapping tables to entities, I don't think there is any harm in leaving this column in existing databases, since that makes it easier to switch between branches with and without this change; newly (re)created databases will not have the column in question. If, however, you would like to update your database without losing all your existing data, you can run the following SQL command:

```SQL
ALTER TABLE beneficial_owner DROP COLUMN subcontractor_name;
```

---

~~~Adding a "Business Ownership or Control Interest" on the ownership info page of an organizational enrollment would lose the name of the subcontractor, along with, perhaps, the value of the "other" line, the percentage ownership, and the address of the other interest. This was due to using the wrong variable to track additional entries in the list.~~~

~~~Show the collected subcontractor name with the rest of the business ownership or control interest details. This page fragment is used both in the summary step of an enrollment application, as well as on ownership info tab of the view submitted enrollment application page.~~~

~~~I tested this by adding a subcontractor in the "Business Ownership or Control Interest" section of the ownership tab of an organizational provider, verifying that the value turned up in the database, and then seeing it in the enrollment view after.~~~

~~~I have not yet confirmed that the bugs I think I fixed (in the value of the "other" line, the percentage ownership, or the address of the other interest) did in fact exist! I also am not sure that this is the right fix at a high level: should this field even exist? Maybe this pull request should be removing it entirely! Please discuss.~~~

---

Resolves #360 Save subcontractor name