### PR TITLE
Use UTF-8 encoding on all pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/web.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/web.xml
@@ -42,6 +42,13 @@
     <param-value>/WEB-INF/mvc-dispatcher-servlet.xml /WEB-INF/spring-security.xml</param-value>
   </context-param>
 
+  <jsp-config>
+    <jsp-property-group>
+      <url-pattern>*.jsp</url-pattern>
+      <page-encoding>UTF-8</page-encoding>
+    </jsp-property-group>
+  </jsp-config>
+
   <listener>
     <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
   </listener>


### PR DESCRIPTION
We were getting this warning in the browser console on forms:

> A form was submitted in the windows-1252 encoding which cannot encode all Unicode characters, so user input may get corrupted. To avoid this problem, the page should be changed so that the form is submitted in the UTF-8 encoding either by changing the encoding of the page itself to UTF-8 or by specifying `accept-charset=utf-8` on the form element.

This was caused by our pages being returned with the header:

```
Content-Type: text/html;charset=ISO-8859-1
```

The ISO-8859-1 charset was chosen because it is the default JSP encoding and many of our JSPs do not specify an encoding in a `<%@ page %>` directive -- although, it turns out that many of the admin pages `<%@ include %>` `taglibs.jsp`, which has such a page directive, and so use UTF-8.

Tell the JSP compiler to use UTF-8 for all pages, instead of the default of ISO-8859-1.  Note that this precludes us from setting per-page encodings using a different encoding, as...

> It is a translation-time error to name different encodings in the pageEncoding attribute of the page directive of a JSP page and in a JSP configuration element matching the page.

I tested this by looking at the network tab of the dev tools to compare the before-and-after response headers for the login page.

See also:
- https://docs.oracle.com/cd/E14571_01/web.1111/e13712/web_xml.htm#sthref243
- https://sorenpoulsen.com/utf-8-encoding-a-jsp-with-spring-mvc