### PR TITLE
Use HTML5 instead of XHTML

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Register"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
@@ -63,7 +63,7 @@
                       </spring:bind>
                       <form:input id="registerMiddleName" path="middleName" cssClass="normalInput ${errorCls}"/>
                     </div>
-                    
+
                     <div class="row">
                       <label for="registerLastName">Last Name<span class="required">*</span></label>
                       <c:set var="errorCls" value=""/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Registration Complete"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
@@ -10,8 +10,8 @@
 <c:set value="false" var="isUpdateUser"></c:set>
 <c:set value="false" var="hasArrow"></c:set>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set value="Advanced Search (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Dashboard"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
@@ -42,7 +42,7 @@
                 <div class="noData">No matched data found.</div>
               </c:when>
               <c:otherwise>
-                <table cellpadding="0" cellspacing="0" class="generalTable fixedWidthTable">
+                <table class="generalTable fixedWidthTable">
                   <thead>
                     <tr>
                       <th class="alignCenter">NPI / UMPI<span class="sep"></span></th>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/error.jsp
@@ -8,8 +8,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Error" />
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/help.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/help.jsp
@@ -6,8 +6,8 @@
   - Description: This is the help page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Help"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/help_detail.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/help_detail.jsp
@@ -6,8 +6,8 @@
   - Description: This is the help item details page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Help"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/accountsTab.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/accountsTab.jsp
@@ -16,7 +16,7 @@
 </c:when>
 <c:otherwise>
 <div class="tableContainer">
-    <table cellpadding="0" cellspacing="0" class="generalTable">
+    <table class="generalTable">
         <colgroup>
             <col width="30"/>
             <col width="145"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -8,8 +8,6 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <table
   id="${searchTableId}"
-  cellpadding="0"
-  cellspacing="0"
   class="generalTable fixedWidthTable ${active_enrollment_tab eq 'notes' ? 'table-enrollment-notes-sort' : ''}"
   >
   <colgroup>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search-result-section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search-result-section.jsp
@@ -26,7 +26,7 @@
         <c:otherwise>
         <div class="tableContainer">
           <div class="tableMain">
-            <table cellpadding="0" cellspacing="0" class="generalTable" id="userAccountResultsTable">
+            <table class="generalTable" id="userAccountResultsTable">
                 <colgroup>
                     <col width="35"/>
                     <col width="125"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screening_log.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screening_log.jsp
@@ -6,8 +6,8 @@
   - Description: This is the approval page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Screening Log"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
@@ -10,8 +10,8 @@
 <c:set value="false" var="isUpdateUser"></c:set>
 <c:set value="false" var="hasArrow"></c:set>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set value="Advanced Search (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Agreements & Addendums - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
@@ -117,7 +117,7 @@
                 <c:otherwise>
                   <div class="tableWrapper">
                     <div class="tableContainer">
-                      <table cellpadding="0" cellspacing="0" class="generalTable" id="agreementTable">
+                      <table class="generalTable" id="agreementTable">
                         <thead>
                           <tr>
                             <th class="alignCenter">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Create Provider Type - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Edit Agreement Document - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
@@ -81,7 +81,7 @@
       <h:handlebars template="includes/footer" context="${pageContext}"/>
     </div>
     <!-- /#wrapper -->
-    <script type="text/javascript">
+    <script>
       (function($) {
         $(document).ready(function() {
           $('#text').wysiwyg();

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_help_item.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_help_item.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Edit Help Topic - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Edit Provider Type - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Edit Screening Schedule - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_help_items.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_help_items.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Help Topics - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Provider Types - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
@@ -91,7 +91,7 @@
               <c:otherwise>
                 <div class="tableWrapper">
                   <div class="tableContainer">
-                    <table cellpadding="0" cellspacing="0" class="generalTable" id="draftEnrollmentTable">
+                    <table class="generalTable" id="draftEnrollmentTable">
                       <thead>
                         <tr>
                           <th class="alignCenter">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="View Agreement Document - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_help_item.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_help_item.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="View Help Topic - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="View Provider Type - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
@@ -7,8 +7,8 @@
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Screening Schedules - Functions (Service Admin)"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
@@ -6,8 +6,8 @@
   - Description: This is the cos service agent page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Category of Service"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
@@ -6,8 +6,8 @@
   - Description: This is the cos service agent page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Category of Service"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
@@ -6,8 +6,8 @@
   - Description: This is the enrollment status service agent page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Status Query"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_advanced.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_advanced.jsp
@@ -6,8 +6,8 @@
   - Description: This is the advanced search page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Advanced Search"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_approved.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_approved.jsp
@@ -6,8 +6,8 @@
   - Description: This is the enrollments approved page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_draft.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_draft.jsp
@@ -6,8 +6,8 @@
   - Description: This is the enrollments draft page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_notes.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_notes.jsp
@@ -6,8 +6,8 @@
   - Description: This is the enrollments notes page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_pending.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_pending.jsp
@@ -6,8 +6,8 @@
   - Description: This is the enrollments pending page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_print.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_print.jsp
@@ -6,8 +6,8 @@
   - Description: This is the enrollments pending page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
@@ -35,7 +35,7 @@
               <c:otherwise>
                 <div class="tableWrapper">
                   <div class="tableContainer">
-                    <table cellpadding="0" cellspacing="0" class="generalTable fixedWidthTable">
+                    <table class="generalTable fixedWidthTable">
                       <thead>
                         <tr>
                           <th class="alignCenter">NPI/UMPI</th>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_quick.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_quick.jsp
@@ -6,8 +6,8 @@
   - Description: This is the quick search result page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Search Results"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_rejected.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_rejected.jsp
@@ -6,8 +6,8 @@
   - Description: This is the enrollments rejected page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Enrollment"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -6,8 +6,8 @@
   - Description: This is the approval page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="Review Enrollment"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
@@ -6,8 +6,8 @@
   - Description: This is the enrollment service agent details page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set var="title" value="View Enrollment - ${profile.status.description}"/>
   <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
@@ -10,8 +10,8 @@
 <c:set value="false" var="isUpdateUser"></c:set>
 <c:set value="true" var="hasArrow"></c:set>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set value="User Account Details (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
@@ -10,8 +10,8 @@
 <c:set value="true" var="isUpdateUser"></c:set>
 <c:set value="true" var="hasArrow"></c:set>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:choose>
     <c:when test="${not empty user.userId}">
       <c:set value="Edit User Account (System Admin)" var="title"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
@@ -10,8 +10,8 @@
 <c:set value="false" var="isUpdateUser"></c:set>
 <c:set value="true" var="hasArrow"></c:set>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set value="User Account (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
@@ -7,7 +7,7 @@
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <c:choose>
   <c:when test="${principalUser ne null}">
-    <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+    <html lang="en-US">
       <c:set var="title" value="Server Error"/>
       <h:handlebars template="includes/html_head" context="${pageContext}"/>
       <body>
@@ -65,7 +65,7 @@
   </c:when>
   <c:otherwise>
     <%@page import="org.springframework.security.web.WebAttributes"%>
-    <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+    <html lang="en-US">
       <c:set var="title" value="Login"/>
       <c:set var="ctx" value="${pageContext.request.contextPath}"/>
       <h:handlebars template="includes/html_head" context="${pageContext}"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Forgot Password"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@page import="org.springframework.security.web.WebAttributes"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Login"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@page import="org.springframework.security.web.WebAttributes"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Login"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_table.jsp
@@ -4,7 +4,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
-<table cellpadding="0" cellspacing="0" class="generalTable dashboardTable fixedWidthTable">
+<table class="generalTable dashboardTable fixedWidthTable">
 
   <colgroup>
     <col width="125"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Welcome"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Welcome"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list.jsp
@@ -1,10 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Dashboard"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -1,10 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Dashboard"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
@@ -6,10 +6,10 @@
 
 <c:choose>
   <c:when test="${statusFilter != 'Draft'}">
-    <table cellpadding="0" cellspacing="0" class="generalTable table-sort">
+    <table class="generalTable table-sort">
   </c:when>
   <c:otherwise>
-    <table cellpadding="0" cellspacing="0" class="generalTable" id="draftTable">
+    <table class="generalTable" id="draftTable">
   </c:otherwise>
 </c:choose>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -1,10 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <c:set var="selectedMarkup" value='selected="selected"'/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <c:set var="selectedMarkup" value='selected="selected"'/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
@@ -57,7 +57,7 @@
           </form>
           <div class="tableContainer hide">
             <p><strong id="practiceLookupMatches">5 matching practices found:</strong></p>
-            <table cellpadding="0" cellspacing="0" class="generalTable tablesorter" id="draftTable">
+            <table class="generalTable tablesorter" id="draftTable">
               <colgroup>
                 <col width="30" />
                 <col width="125" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/additional_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/additional_practice.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<table cellpadding="0" cellspacing="0" class="generalTable noInput">
+<table class="generalTable noInput">
     <colgroup>
         <col width="22" />
         <col width="126" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/license_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/license_information.jsp
@@ -1,7 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <table
-        cellpadding="0"
-        cellspacing="0"
         class="generalTable noInput"
         id="licenseTable"
 >

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/specialty_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/specialty_information.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<table cellpadding="0" cellspacing="0" class="generalTable noInput">
+<table class="generalTable noInput">
     <colgroup>
         <col width="28"/>
         <col width="148"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_agency.jsp
@@ -18,7 +18,7 @@
     </div>
     <!-- /.tableHeader -->
     <div class="addPracticeLocations">
-        <table cellpadding="0" cellspacing="0" class="generalTable" id="tableAgency">
+        <table class="generalTable" id="tableAgency">
             <colgroup>
                 <col width="22" />
                 <col width="276" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_practice.jsp
@@ -18,7 +18,7 @@
     </div>
     <!-- /.tableHeader -->
     <div class="addPracticeLocations">
-        <table cellpadding="0" cellspacing="0" class="generalTable" id="tablePractice">
+        <table class="generalTable" id="tablePractice">
             <colgroup>
                 <col width="22" />
                 <col width="126" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/clia_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/clia_license.jsp
@@ -19,7 +19,7 @@
         </div>
 
         <div class="addPracticeLocations">
-            <table cellpadding="0" cellspacing="0" class="generalTable facility" id="tableCLIA">
+            <table class="generalTable facility" id="tableCLIA">
                 <colgroup>
                     <col width="20"/>
                     <col width="150"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
@@ -59,7 +59,7 @@
         </c:if>
 
         <div class="addPracticeLocations">
-            <table cellpadding="0" cellspacing="0" class="generalTable facility" id="tableFacilityLicense">
+            <table class="generalTable facility" id="tableFacilityLicense">
                 <colgroup>
                     <col width="20"/>
                     <col width="130"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
@@ -17,7 +17,7 @@
 <div class="tableData" id="tableLicense">
     <input type="hidden" name="formNames" value="<%= ViewStatics.LICENSE_INFO_FORM %>">
 
-    <table cellpadding="0" cellspacing="0" class="generalTable licenseInformationTable">
+    <table class="generalTable licenseInformationTable">
         <thead>
             <tr>
                 <th class="alignCenter">#<span class="sep"></span></th>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
@@ -663,7 +663,7 @@
             <span>Do not list additional practice location addresses here. If there are multiple clinic locations, each one must be enrolled separately,</span>
         </div>
         <div class="addPracticeLocations">
-        <table cellpadding="0" cellspacing="0" class="generalTable alternateTable" id="tablePractice">
+        <table class="generalTable alternateTable" id="tablePractice">
             <colgroup>
                 <col width="115"/>
                 <col width="142"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
@@ -197,7 +197,7 @@
     </div>
 
     <div class="tableData">
-    <table cellpadding="0" cellspacing="0" class="generalTable fixedWidthTable">
+    <table class="generalTable fixedWidthTable">
         <colgroup>
             <col width="30">
             <col width="183">
@@ -532,7 +532,7 @@
     </div>
 
     <div class="tableData">
-    <table cellpadding="0" cellspacing="0" class="generalTable">
+    <table class="generalTable">
         <thead>
             <tr>
                 <th class="alignCenter">#<span class="sep"></span></th>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/specialty_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/specialty_information.jsp
@@ -14,7 +14,7 @@
 <div class="tableData" id="tableLicense2">
     <input type="hidden" name="formNames" value="<%= ViewStatics.SPECIALTY_INFO_FORM %>">
 
-    <table cellpadding="0" cellspacing="0" class="generalTable">
+    <table class="generalTable">
         <thead>
             <tr>
                 <th class="alignCenter">#<span class="sep"></span></th>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
@@ -48,7 +48,7 @@
 
 <div class="tableData" id="tableLicense3" style="display: ${formValue eq 'Y' ? 'block' : 'none'};">
 
-    <table cellpadding="0" cellspacing="0" class="generalTable">
+    <table class="generalTable">
         <thead>
             <tr>
                 <th class="reservationTableHeader">Reservation<span class="required">*</span><span class="sep"></span></th>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/additional_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/additional_agency.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<table cellpadding="0" cellspacing="0" class="generalTable noInput">
+<table class="generalTable noInput">
     <colgroup>
         <col width="22" />
         <col width="300" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/clia_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/clia_license.jsp
@@ -1,7 +1,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_22_bound'] eq 'Y'}">
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<table cellpadding="0" cellspacing="0" class="generalTable noInput">
+<table class="generalTable noInput">
     <colgroup>
         <col width="28"/>
         <col width="284"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_contracts.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_contracts.jsp
@@ -1,7 +1,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_34_bound'] eq 'Y'}">
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<table cellpadding="0" cellspacing="0" class="generalTable noInput">
+<table class="generalTable noInput">
     <colgroup>
         <col width="284"/>
         <col width="128"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_license.jsp
@@ -1,7 +1,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_21_bound'] eq 'Y'}">
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<table cellpadding="0" cellspacing="0" class="generalTable noInput">
+<table class="generalTable noInput">
     <colgroup>
         <col width="28"/>
         <col width="284"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/tribal_information.jsp
@@ -16,7 +16,7 @@
 </div>
 
 <c:if test="${requestScope['_13_worksOnReservation'] eq 'Y'}">
-<table cellpadding="0" cellspacing="0" class="generalTable noInput">
+<table class="generalTable noInput">
     <colgroup>
         <col width="28"/>
         <col width="180"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <c:set var="selectedMarkup" value='selected="selected"'/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <c:set var="selectedMarkup" value='selected="selected"'/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="${pageTitle}"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -1,10 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Import Profiles"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
@@ -41,7 +41,7 @@
                   <input type="hidden" name="accountId" value="${accountId}"></input>
                   <input type="hidden" name="hash" value="${hash}"></input>
                 </div>
-                <table cellpadding="0" cellspacing="0" class="generalTable">
+                <table class="generalTable">
                   <thead>
                     <tr>
                       <c:if test="${not empty profiles}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Confirm Action"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Import Profiles"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>
@@ -33,7 +33,7 @@
               <div class="tableTitle">
                 <h2>Profiles</h2>
               </div>
-              <table cellpadding="0" cellspacing="0" class="generalTable">
+              <table class="generalTable">
                 <thead>
                   <tr>
                     <th>NPI / UMPI<span class="sep"></span></th>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
   <c:set var="title" value="Update Password"/>
   <h:handlebars template="includes/html_head" context="${pageContext}"/>
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
@@ -11,8 +11,8 @@
 <c:set value="false" var="hasArrow"></c:set>
 <c:set var="formIdPrefix" value="advanced_search_system_admin"></c:set>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
   <c:set value="Advanced Search (System Admin)" var="title"></c:set>
   <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />

--- a/psm-app/cms-web/WebContent/css/reset.css
+++ b/psm-app/cms-web/WebContent/css/reset.css
@@ -49,7 +49,6 @@ del {
 	text-decoration: line-through;
 }
 
-/* tables still need 'cellspacing="0"' in the markup */
 table {
 	border-collapse: collapse;
 	border-spacing: 0;

--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
 {{> includes/html_head title="Update Profile (Service Admin)" adminPage=true }}
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<!DOCTYPE html>
+<html lang="en-US">
 {{> includes/html_head title="My Profile (Service Admin)" adminPage=true }}
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
@@ -1,44 +1,44 @@
 {{!-- Common HTML head element declarations. --}}
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta charset="utf-8">
   <meta name="_csrf" content="{{csrf.token}}"/>
   <meta name="_csrf_header" content="{{csrf.headerName}}"/>
 
   <title>{{title}}</title>
-  <link rel="stylesheet" href="{{ctx}}/css/reset.css" type="text/css" media="all" />
-  <link rel="stylesheet" href="{{ctx}}/css/style.css" type="text/css" media="all" />
-  <link rel="stylesheet" href="{{ctx}}/css/jquery.ui.css" type="text/css" media="all" />
+  <link rel="stylesheet" href="{{ctx}}/css/reset.css" media="all" />
+  <link rel="stylesheet" href="{{ctx}}/css/style.css" media="all" />
+  <link rel="stylesheet" href="{{ctx}}/css/jquery.ui.css" media="all" />
   {{#if adminPage}}
-    <link rel="stylesheet" href="{{ctx}}/js/chosen/chosen.css" type="text/css" media="all"/>
-    <link rel="stylesheet" href="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.css" type="text/css"/>
+    <link rel="stylesheet" href="{{ctx}}/js/chosen/chosen.css" media="all"/>
+    <link rel="stylesheet" href="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.css"/>
   {{else if systemPage}}
-    <link rel="stylesheet" href="{{ctx}}/js/chosen/chosen.css" type="text/css" media="all"/>
+    <link rel="stylesheet" href="{{ctx}}/js/chosen/chosen.css" media="all"/>
   {{/if}}
-  <script src="{{ctx}}/js/jquery-1.7.1.min.js" type="text/javascript"></script>
-  <script src="{{ctx}}/js/jquery.tablesorter.min.js" type="text/javascript"></script>
-  <script src="{{ctx}}/js/jquery.tablesorter.widgets.js" type="text/javascript"></script>
-  <script src="{{ctx}}/js/jquery.ui.core.js" type="text/javascript"></script>
-  <script src="{{ctx}}/js/jquery.ui.widget.js" type="text/javascript"></script>
-  <script src="{{ctx}}/js/jquery.ui.datepicker.js" type="text/javascript"></script>
+  <script src="{{ctx}}/js/jquery-1.7.1.min.js"></script>
+  <script src="{{ctx}}/js/jquery.tablesorter.min.js"></script>
+  <script src="{{ctx}}/js/jquery.tablesorter.widgets.js"></script>
+  <script src="{{ctx}}/js/jquery.ui.core.js"></script>
+  <script src="{{ctx}}/js/jquery.ui.widget.js"></script>
+  <script src="{{ctx}}/js/jquery.ui.datepicker.js"></script>
   {{#if adminPage}}
-    <script src="{{ctx}}/js/jquery.tinyscrollbar.min.js" type="text/javascript"></script>
-    <script src="{{ctx}}/js/jquery.validate.min.js" type="text/javascript"></script>
-    <script src="{{ctx}}/js/chosen/chosen.jquery.min.js" type="text/javascript"></script>
-    <script src="{{ctx}}/js/jquery.maskedinput.min.js" type="text/javascript"></script>
-    <script src="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.js" type="text/javascript"></script>
-    <script src="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.js" type="text/javascript"></script>
-    <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.image.js" type="text/javascript"></script>
-    <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.link.js" type="text/javascript" ></script>
-    <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.table.js" type="text/javascript" ></script>
+    <script src="{{ctx}}/js/jquery.tinyscrollbar.min.js"></script>
+    <script src="{{ctx}}/js/jquery.validate.min.js"></script>
+    <script src="{{ctx}}/js/chosen/chosen.jquery.min.js"></script>
+    <script src="{{ctx}}/js/jquery.maskedinput.min.js"></script>
+    <script src="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.js"></script>
+    <script src="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.js"></script>
+    <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.image.js"></script>
+    <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.link.js" ></script>
+    <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.table.js" ></script>
   {{else if systemPage}}
-    <script src="{{ctx}}/js/chosen/chosen.jquery.min.js" type="text/javascript"></script>
-    <script src="{{ctx}}/js/jquery.maskedinput.min.js" type="text/javascript"></script>
+    <script src="{{ctx}}/js/chosen/chosen.jquery.min.js"></script>
+    <script src="{{ctx}}/js/jquery.maskedinput.min.js"></script>
   {{else}}
-    <script src="{{ctx}}/js/jquery.maskedinput.min.js" type="text/javascript"></script>
-    <script src="{{ctx}}/js/jquery.compare.js" type="text/javascript"></script>
+    <script src="{{ctx}}/js/jquery.maskedinput.min.js"></script>
+    <script src="{{ctx}}/js/jquery.compare.js"></script>
   {{/if}}
 
-  <script type="text/javascript">
+  <script>
     var ctx = "{{ctx}}";
     {{#if systemPage}}
       var roles = "{{role}}";
@@ -47,13 +47,13 @@
     {{/if}}
   </script>
 
-  <script src="{{ctx}}/js/common.js" type="text/javascript"></script>
+  <script src="{{ctx}}/js/common.js"></script>
 
   {{#if adminPage}}
-    <script src="{{ctx}}/js/admin/script.js" type="text/javascript"></script>
+    <script src="{{ctx}}/js/admin/script.js"></script>
   {{else if systemPage}}
-    <script src="{{ctx}}/js/system/script.js" type="text/javascript"></script>
+    <script src="{{ctx}}/js/system/script.js"></script>
   {{else}}
-    <script src="{{ctx}}/js/script.js" type="text/javascript"></script>
+    <script src="{{ctx}}/js/script.js"></script>
   {{/if}}
 </head>


### PR DESCRIPTION
Switch the DOCTYPE and <html> tags from XHTML to HTML5, so that we can start using HTML5 features.

I tested this by poking around in the app with the dev tools console open and watching for warnings or errors.

Resolves #613 Use HTML5 instead of XHTML