### PR TITLE
Remove incorrect JSP headers

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/errors.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/errors.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${not empty requestScope['flash_error']}">
     <div class="errorInfo formErrorMarker" style="display: block;">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_agency.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_practice.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/adult_day_treatment_application.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/adult_day_treatment_application.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <input type="hidden" name="formNames" value="<%= ViewStatics.ADULT_DAY_TREATMENT_APPLICATION_FORM %>">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/clia_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/clia_license.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/cmhrt_contract.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/cmhrt_contract.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <input type="hidden" name="formNames" value="<%= ViewStatics.CMHRT_FORM %>">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <input type="hidden" name="formNames" value="<%= ViewStatics.CTCC_FORM %>">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_capacity.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_capacity.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="facility_capacity"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_contracts.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_contracts.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_eligibility.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_eligibility.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_agency_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_agency_information.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="ind_agency_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="ind_pca_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="member_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/nonprofit_corporation.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/nonprofit_corporation.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <input type="hidden" name="formNames" value="<%= ViewStatics.NONPROFIT_CORPORATION_FORM %>">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_disclosure.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="organization_disclosure"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="organization_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="organization_statement"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pca_billing.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pca_billing.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="pca_billing"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="pcpo_insurance"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="personal_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/phn_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/phn_agency.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="phn_agency"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/practice_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/practice_type.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="provider_setup"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@taglib prefix="cms" uri="CMSTags"  %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/remittance_sequence.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/remittance_sequence.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="remittance_sequence"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/sliding_fee.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/sliding_fee.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="sliding_fee"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/specialty_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/specialty_information.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tcm_contract.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tcm_contract.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="tcm_contract"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/screening_errors.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/screening_errors.jsp
@@ -1,10 +1,3 @@
-<%--
-    JSP Fragment for provider type selection form.
-
-    @author j3_guile
-    @version 1.0
- --%>
-
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${not empty errors}">
     <div class="errorInfo formErrorMarker" style="display: block;">


### PR DESCRIPTION
It seems that the header in `provider_type.jsp` was copy and pasted in to several new JSPs as they were being written - about three dozen of them! Delete the misleading and noisy headers.