### PR TITLE
Extract tag for attachment upload

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
@@ -1,7 +1,7 @@
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<%@taglib prefix="cms" uri="CMSTags"  %>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 
 <c:set var="showCategories" value="${viewModel.tabModels[viewModel.currentTab].formSettings['Facility License Form'].settings['showCategories']}"></c:set>
 <input type="hidden" name="formNames" value="<%= ViewStatics.FACILITY_LICENSE_FORM %>">
@@ -125,20 +125,15 @@
                         </select>
                     </td>
                     <td>
-                        <c:set var="formName" value="_21_attachment_${status.index - 1}"></c:set>
-                        <input type="file" title="Copy of License (License ${status.index})" class="fileUpload" size="10" name="${formName}" />
-
-                        <c:set var="formName" value="_21_filename_${status.index - 1}"></c:set>
-                        <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <c:if test="${not empty formValue}">
-                            <c:set var="formName" value="_21_attachmentId_${status.index - 1}"></c:set>
-                            <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                                 <c:param name="id" value="${requestScope[formName]}"></c:param>
-                            </c:url>
-                            <div><a href="${downloadLink}"><cms:truncate text="${formValue}" /></a></div>
-                            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <input type="hidden" name="${formName}" value="${formValue}"/>
-                        </c:if>
+                        <c:set var="formName" value="_21_attachment_${status.index - 1}" />
+                        <c:set var="filenameKey" value="_21_filename_${status.index - 1}" />
+                        <c:set var="attachmentIdName" value="_21_attachmentId_${status.index - 1}" />
+                        <h:attachment
+                            name="${formName}"
+                            title="Copy of License (License ${status.index})"
+                            attachmentId="${requestScope[attachmentIdName]}"
+                            attachmentIdName="${attachmentIdName}"
+                            filename="${requestScope[filenameKey]}" />
                     </td>
                     <td class="alignCenter"><a href="javascript:;" class="remove">REMOVE</a></td>
                 </tr>
@@ -204,7 +199,11 @@
                 </td>
                 <c:set var="formName" value="_21_attachment"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <td><input type="file" title="Copy of License" class="fileUpload" size="10" name="${formName}" /></td>
+                <td>
+                    <h:attachment
+                        name="_21_attachment"
+                        title="Copy of License" />
+                </td>
                 <td class="alignCenter"><a href="javascript:;" class="remove">REMOVE</a></td>
             </tr>
         </tbody>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
@@ -1,7 +1,8 @@
-<%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
-<%@page import="gov.medicaid.entities.dto.ViewStatics"%>
-<%@taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<%@taglib prefix="cms" uri="CMSTags"  %>
+<%@ page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
+<%@ page import="gov.medicaid.entities.dto.ViewStatics"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <c:set var="formIdPrefix" value="license_information"></c:set>
 
 <c:set var="hideRenewalDate" value="${viewModel.tabModels['Personal Information'].formSettings['Personal Information Form'].settings['hideRenewalDate']}"></c:set>
@@ -58,20 +59,15 @@
                         </c:if>
                     </td>
                     <td>
-                        <c:set var="formName" value="_03_attachment_${status.index - 1}"></c:set>
-                        <input type="file" title="Upload License/Certification (License ${status.index})" class="fileUpload" size="10" name="${formName}" />
-
-                        <c:set var="formName" value="_03_filename_${status.index - 1}"></c:set>
-                        <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <c:if test="${not empty formValue}">
-                            <c:set var="formName" value="_03_attachmentId_${status.index - 1}"></c:set>
-                            <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                                 <c:param name="id" value="${requestScope[formName]}"></c:param>
-                            </c:url>
-                            <div><a href="${downloadLink}"><cms:truncate text="${formValue}" /></a></div>
-                            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                            <input type="hidden" name="${formName}" value="${formValue}"/>
-                        </c:if>
+                        <c:set var="formName" value="_03_attachment_${status.index - 1}" />
+                        <c:set var="filenameKey" value="_03_filename_${status.index - 1}" />
+                        <c:set var="attachmentIdName" value="_03_attachmentId_${status.index - 1}" />
+                        <h:attachment
+                            name="${formName}"
+                            title="Upload License/Certification (License ${status.index})"
+                            attachmentId="${requestScope[attachmentIdName]}"
+                            attachmentIdName="${attachmentIdName}"
+                            filename="${requestScope[filenameKey]}" />
                     </td>
                     <c:choose>
                         <c:when test="${hideLicenseNumber}">
@@ -147,7 +143,11 @@
                 </td>
                 <c:set var="formName" value="_03_attachment"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <td><input type="file" title="Upload License/Certification" class="fileUpload" size="10" name="${formName}" /></td>
+                <td>
+                  <h:attachment
+                      name="_03_attachment"
+                      title="Upload License/Certification" />
+                </td>
                 <c:choose>
                         <c:when test="${hideLicenseNumber}">
                             <td width="0"></td>

--- a/psm-app/cms-web/WebContent/WEB-INF/tags/attachment.tag
+++ b/psm-app/cms-web/WebContent/WEB-INF/tags/attachment.tag
@@ -1,0 +1,25 @@
+<%@ attribute name="name" required="true"
+    description="Set the `name` attribute of the <input> element." %>
+<%@ attribute name="title" required="true"
+    description="Set the `title` attribute of the <input> element." %>
+<%@ attribute name="attachmentId" required="false"
+    description="Id of existing attachment; used to generate download link." %>
+<%@ attribute name="attachmentIdName" required="false"
+    description="Set the `name` attribute for the hidden attachment element." %>
+<%@ attribute name="filename" required="false"
+    description="Name of previously uploaded file." %>
+
+<%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="cms" uri="CMSTags"  %>
+
+<input type="file"
+       title="${title}"
+       class="fileUpload"
+       size="10" name="${name}" />
+<c:if test="${not empty attachmentId}">
+    <c:url var="downloadLink" value="/provider/enrollment/attachment">
+         <c:param name="id" value="${attachmentId}"></c:param>
+    </c:url>
+    <div><a href="${downloadLink}"><cms:truncate text="${filename}" /></a></div>
+    <input type="hidden" name="${attachmentIdName}" value="${attachmentId}"/>
+</c:if>


### PR DESCRIPTION
We handle file uploads in several places, and we seem to have some common patterns around them:

- an input element
- optionally a link to download the existing, previously uploaded attachment
- a hidden element containing the previously uploaded attachment ID

In order to better handle the misleading "No file selected" message, first extract the common functionality from each of the different forms that have an attachment upload form. This will allow us to make sure our forms are consistent in how they handle files, and allow us to later change the behavior of all the forms at once.

Use the new tag in an individual provider's license information step, and in an organizational provider's facility license step.

I tested this by adding a debugging `<div>` to the tag, deploying, and verifying that it showed up in the two places listed above.

This should be a refactoring only, with no change in behavior.

There are many many instances of this file upload pattern, and some of them are slightly different, so I want to get the most common places done first, and then we can work on changing the behavior of the places that use the tag, and in parallel use the tag in more places. I think that it's worthwhile to have many smaller PRs for the sake of testing and reviewing, as some of the forms with file uploads are relatively obscure and hard to get to.

Issue #158 "No file selected" is confusing when a file is uploaded