### PR TITLE
341 notification storage

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -91,6 +91,7 @@
     <class>gov.medicaid.entities.RiskLevel</class>
     <class>gov.medicaid.entities.Role</class>
     <class>gov.medicaid.entities.ScreeningSchedule</class>
+    <class>gov.medicaid.entities.SentNotification</class>
     <class>gov.medicaid.entities.ServiceCategory</class>
     <class>gov.medicaid.entities.SpecialtyType</class>
     <class>gov.medicaid.entities.StateType</class>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -54,6 +54,7 @@ DROP TABLE IF EXISTS
   risk_levels,
   roles,
   screening_schedules,
+  sent_notifications,
   service_categories,
   specialty_types,
   states
@@ -496,6 +497,14 @@ INSERT INTO relationship_types (CODE, DESCRIPTION) VALUES
   ('02', 'Child'),
   ('03', 'Parent'),
   ('04', 'Sibling');
+
+CREATE TABLE sent_notifications(
+  notification_id BIGINT PRIMARY KEY,
+  notification_type TEXT NOT NULL,
+  sent_to TEXT NOT NULL,
+  notification_content TEXT NOT NULL,
+  sent_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
 
 CREATE TABLE enrollment_statuses(
   code CHARACTER VARYING(2) PRIMARY KEY,

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SentNotification.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SentNotification.java
@@ -1,0 +1,92 @@
+package gov.medicaid.entities;
+
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
+import java.util.Date;
+
+import gov.medicaid.entities.EmailTemplate;
+
+/**
+ * Represents an email notification
+ */
+@javax.persistence.Entity
+@Table(name = "sent_notifications")
+public class SentNotification implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "notification_id")
+    private long notificationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type",
+            nullable = false)
+    private EmailTemplate notificationType;
+
+    /**
+     * The email address that the notification was sent to
+     */
+    @Column(name = "sent_to",
+            nullable = false)
+    private String sentTo;
+
+    /**
+     * The content of the notification (the processed template)
+     */
+    @Column(name = "notification_content",
+            nullable = false)
+    private String notificationContent;
+
+    @Column(name = "sent_at",
+            nullable = false)
+    private Date sentAt;
+
+    public SentNotification() {
+    }
+
+    public long getNotificationId() {
+        return notificationId;
+    }
+
+    public void setNotificationId(long notificationId) {
+        this.notificationId = notificationId;
+    }
+
+    public EmailTemplate getNotificationType() {
+        return notificationType;
+    }
+
+    public void setNotificationType(EmailTemplate notificationType) {
+        this.notificationType = notificationType;
+    }
+
+    public String getSentTo() {
+        return sentTo;
+    }
+
+    public void setSentTo(String emailAddress) {
+        this.sentTo = emailAddress;
+    }
+
+    public String getNotificationContent() {
+        return notificationContent;
+    }
+
+    public void setNotificationContent(String notificationContent) {
+        this.notificationContent = notificationContent;
+    }
+
+    public Date getSentAt() {
+        return sentAt;
+    }
+
+    public void setSentAt(Date sentAt) {
+        this.sentAt = sentAt;
+    }
+}


### PR DESCRIPTION
This PR has a change to the database structure, creating a new table for storing copies of notifications sent out -- this includes enrollment notifications as well as account creation notifications.

There's no UX for these things yet, but after this commit the data will be kept.

This PR involves a new database table, to create it you can run the following SQL command:

```SQL
CREATE TABLE sent_notifications(
  notification_id BIGINT PRIMARY KEY,
  notification_type TEXT NOT NULL,
  sent_to TEXT NOT NULL,
  notification_content TEXT NOT NULL,
  sent_at TIMESTAMP WITH TIME ZONE NOT NULL
);
```