### PR TITLE
Refactor npm-installed JS deps in gradle

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -320,12 +320,15 @@ project(':frontend') {
     artifacts {
         javascript file('src/main/js')
         javascript file('src/vendor/js')
-        javascript(file('node_modules/axe-core/axe.min.js')) {
-            builtBy npmInstall
-        }
-        javascript(file('node_modules/jquery-mask-plugin/dist/jquery.mask.min.js')) {
-            builtBy npmInstall
-        }
+
+        // Files to include from npm-managed JavaScript dependencies
+        [
+            'axe-core/axe.min.js',
+            'jquery-mask-plugin/dist/jquery.mask.min.js',
+        ]
+            .collect { "node_modules/${it}" }
+            .collect { project.file(it) }
+            .each { javascript file: it, builtBy: npmInstall }
     }
 }
 


### PR DESCRIPTION
While I was working with @PaulMorris on #732, we were exploring a jQuery plugin that was packaged as several split JavaScript files. Adding each to `build.gradle` was painful, as we had to duplicate the block for each.

Make it easier to add additional JavaScript dependencies managed by npm by iterating over a (currently single-element) list rather than requiring three lines of mostly copy-paste for each additional dependency.

I tested this by cleaning and rebuilding `cms-web`, and verifying that `axe.min.js` was still present in the war file:

```
./gradlew cms-web:{clean,build} && unzip -l cms-web/build/libs/cms-web.war | grep axe
```

See also:
- http://docs.groovy-lang.org/latest/html/groovy-jdk/java/util/Collection.html#collect(groovy.lang.Closure)
- https://docs.gradle.org/current/userguide/artifact_management.html

Issue #626 Manage JavaScript dependencies and modernize build