### PR TITLE
Fix "No file selected" on upload file prompt

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/tags/attachment.tag
+++ b/psm-app/cms-web/WebContent/WEB-INF/tags/attachment.tag
@@ -12,14 +12,31 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="cms" uri="CMSTags"  %>
 
-<input type="file"
-       title="${title}"
-       class="fileUpload"
-       size="10" name="${name}" />
-<c:if test="${not empty attachmentId}">
-    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-         <c:param name="id" value="${attachmentId}"></c:param>
-    </c:url>
-    <div><a href="${downloadLink}"><cms:truncate text="${filename}" /></a></div>
-    <input type="hidden" name="${attachmentIdName}" value="${attachmentId}"/>
-</c:if>
+<span class="fileUploadWrapper">
+    <c:choose>
+        <c:when test="${empty attachmentId}">
+            <div class="previousFile"></div>
+            <label class="fileUploadLabel">
+                <span class="fileUploadButton greyBtn">Upload...</span>
+                <input type="file"
+                       title="${title}"
+                       class="hidden"
+                       name="${name}" />
+            </label>
+        </c:when>
+        <c:otherwise>
+            <c:url var="downloadLink" value="/provider/enrollment/attachment">
+                 <c:param name="id" value="${attachmentId}"></c:param>
+            </c:url>
+            <div class="previousFile"><a href="${downloadLink}"><cms:truncate text="${filename}" /></a></div>
+            <input type="hidden" name="${attachmentIdName}" value="${attachmentId}"/>
+            <label class="fileUploadLabel">
+                <span class="fileUploadButton greyBtn">Replace...</span>
+                <input type="file"
+                       title="${title}"
+                       class="hidden"
+                       name="${name}" />
+            </label>
+        </c:otherwise>
+    </c:choose>
+</span>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -848,6 +848,7 @@ input.date{
   border: solid 1px #cdcdcd;
   display: inline-block;
   text-decoration: none;
+  white-space: nowrap;
 }
 .greyBtn:hover {
   background: linear-gradient(#d8d8d8, #fafafa);
@@ -4716,10 +4717,6 @@ input[type=checkbox]{
 }
 #printModal span.providerPic{
   padding: 0 10px;
-  display: block;
-}
-.addPracticeLocations .generalTable td span{
-  line-height: 17px;
   display: block;
 }
 

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -98,6 +98,22 @@ function populateUserHelpModal(modalId, helpItemIds, title, helpPageString) {
   }
 };
 
+function setFileUploadClickHandler() {
+  $(".fileUploadLabel input")
+    .off()
+    .on('change', function (event) {
+      var filename = event.target.files[0].name;
+
+      var wrapper = $(event.target).closest('.fileUploadWrapper');
+      wrapper
+        .find('.fileUploadButton')
+        .text('Replace...');
+      wrapper
+        .find('.previousFile')
+        .text(filename);
+    });
+}
+
 /**
 * Add a click handler function to a user help modal link, and remove any
 * existing click handler. Title is optional; is absent (undefined) to show a
@@ -152,4 +168,5 @@ $(document).ready(function() {
     addressLoadModal('#saveAsDraftModal');
   });
 
+  setFileUploadClickHandler();
 });

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -342,6 +342,8 @@ $(document).ready(function () {
         $(select).change();
       }
     });
+
+    setFileUploadClickHandler();
   });
 
   $('#addInService').live('click', function () {
@@ -396,6 +398,8 @@ $(document).ready(function () {
         $(select).change();
       }
     });
+
+    setFileUploadClickHandler();
   });
 
   $('#addCLIALicense').live('click', function () {


### PR DESCRIPTION
Prevent the browser from showing the "No file selected" message despite the user having previously uploaded a file by hiding the file `<input>` element and wrapping it in a `<label>`, as suggested [on StackOverflow](https://stackoverflow.com/a/17949302/25637).

The four possible states are:
1. no previous file, no current file (first view) -> prompt for new file
2. no previous file, new current file (after selecting file) -> show new filename
3. previous file, no current file (clicking "back") -> show old filename with link to download, and set button name to "Replace..."
4. previous file, new current file (clicking "back" and selecting a new file) -> show new filename, set button name to "Replace..."

Numbers 1 and 3 are rendered on the server side in the attachment tag, and the transition to either 2 or 4 is done in JavaScript. Selecting a new file to upload replaces the link to the existing file in state 3 (or the empty div in state 1) with the name of the new file.

The attachment tag is currently used in the individual and facility license upload forms. Here's how those look like with this PR:

- Individual provider, state 1 (no previous file, no current file): ![Individual provider, state 1](https://user-images.githubusercontent.com/1494855/38115550-7981bd5a-337a-11e8-9915-349f843325f6.png)
- Individual provider, state 2 (no previous file, new current file) - this is visually identical to state 4 (previous file, new current file): ![Individual provider, state 2](https://user-images.githubusercontent.com/1494855/38115552-798e0c9a-337a-11e8-8170-607b7270a70b.png)
- Individual provider, state 3 (previous file, no current file): ![acupuncturist-state3](https://user-images.githubusercontent.com/1494855/38115553-799b472a-337a-11e8-8af0-c52743505074.png)

- Organization provider, state 1: ![pharmacy-state1](https://user-images.githubusercontent.com/1494855/38115554-79a79e9e-337a-11e8-8d92-0421d4d3a9c9.png)
- Organization provider, state 2 / 4: ![pharmacy-state2](https://user-images.githubusercontent.com/1494855/38115555-79b2fa50-337a-11e8-8d55-d9f3b7fa9319.png)
- Organization provider, state 3: ![pharmacy-state3](https://user-images.githubusercontent.com/1494855/38115556-79c0f2cc-337a-11e8-81b8-1543481a1290.png)


Thanks to @PaulMorris for pairing with me on this!

Issue #158 "No file selected" is confusing when a file is uploaded
