### PR TITLE
Add Checkstyle rules for space separators

### DIFF
--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -16,6 +16,7 @@
     <module name="NoLineWrap"/>
     <module name="NoWhitespaceBefore"/>
     <module name="ParenPad"/>
+    <module name="SingleSpaceSeparator"/>
     <module name="TypecastParenPad"/>
     <module name="WhitespaceAfter"/>
     <module name="EmptyLineSeparator">

--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -17,6 +17,7 @@
     <module name="NoWhitespaceBefore"/>
     <module name="ParenPad"/>
     <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter"/>
     <module name="EmptyLineSeparator">
       <property name="allowMultipleEmptyLines" value="false"/>
       <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>

--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -19,6 +19,11 @@
     <module name="SingleSpaceSeparator"/>
     <module name="TypecastParenPad"/>
     <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+    </module>
     <module name="EmptyLineSeparator">
       <property name="allowMultipleEmptyLines" value="false"/>
       <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/Exclusion.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/Exclusion.java
@@ -232,7 +232,7 @@ public class Exclusion extends Resource {
                 Pair.of("State", state),
                 Pair.of("Zip Code", zip),
                 Pair.of("Date of Birth", dateOfBirth),
-                Pair.of("Exclusion Date",exclusionDate),
+                Pair.of("Exclusion Date", exclusionDate),
                 Pair.of("Exclusion Type", exclusionType),
                 Pair.of("General", general),
                 Pair.of("Speciality", specialty),

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
@@ -162,6 +162,6 @@ public class OnboardingServiceBean extends BaseService implements OnboardingServ
      */
     public boolean verifyCredentials(ExternalAccountLink link, String password) throws PortalServiceException {
         PartnerSystemService partner = partnerSystemServices.get(link.getSystemId());
-        return  partner.authenticate(link.getExternalUserId(), password, null, null);
+        return partner.authenticate(link.getExternalUserId(), password, null, null);
     }
 }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -621,7 +621,7 @@ public class RegistrationServiceBean extends BaseService implements Registration
      * @throws PortalServiceException for any errors encountered
      */
     @SuppressWarnings("unchecked")
-    public SearchResult<CMSUser> findUsersByCriteria(UserSearchCriteria criteria)  throws PortalServiceException {
+    public SearchResult<CMSUser> findUsersByCriteria(UserSearchCriteria criteria) throws PortalServiceException {
         if (criteria == null) {
             throw new IllegalArgumentException("Criteria cannot be null.");
         }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
@@ -63,9 +63,9 @@ public class CustomAuthenticationProcessingFilter extends UsernamePasswordAuthen
         if (domain == null || "MN_ITS".equalsIgnoreCase(domain)) {
             domain = "MN_ITS";
             String token = request.getParameter("token");
-            String userNPI  = request.getParameter("userNPI");
-            String profileNPI  = request.getParameter("profileNPI");
-            String referrer  = request.getParameter("referrer");
+            String userNPI = request.getParameter("userNPI");
+            String profileNPI = request.getParameter("profileNPI");
+            String referrer = request.getParameter("referrer");
             authRequest = new DomainAuthenticationToken(userNPI, profileNPI, token, referrer, domain);
         } else {
             authRequest = new DomainAuthenticationToken(username, password, domain);

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
@@ -83,13 +83,13 @@ public class DefaultExternalAuthenticationProvider implements AuthenticationProv
     @PostConstruct
     public void init() {
         if (registrationService == null) {
-            throw new  PortalServiceConfigurationException("registrationService must be configured.");
+            throw new PortalServiceConfigurationException("registrationService must be configured.");
         }
         if (system == null) {
-            throw new  PortalServiceConfigurationException("system must be configured.");
+            throw new PortalServiceConfigurationException("system must be configured.");
         }
         if (partnerService == null) {
-            throw new  PortalServiceConfigurationException("partnerService must be configured.");
+            throw new PortalServiceConfigurationException("partnerService must be configured.");
         }
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -125,7 +125,7 @@ public class EnrollmentStepDefinitions {
     }
 
     @Given("^I have indicated that the owner has an interest in another Medicaid disclosing entity$")
-    public void i_have_indicated_that_the_owner_has_an_interest_in_another_Medicaid_disclosing_entity()  {
+    public void i_have_indicated_that_the_owner_has_an_interest_in_another_Medicaid_disclosing_entity() {
         ownershipInfoPage.clickDisclosure();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
@@ -16,12 +16,12 @@ public class ChangePasswordStepDefinitions {
     }
 
     @When("^I click on My Profile$")
-    public void i_click_on_my_profile()  {
+    public void i_click_on_my_profile() {
         generalSteps.clickMyProfile();
     }
 
     @Then("^I should see the Change Password link$")
-    public void i_should_see_change_password()  {
+    public void i_should_see_change_password() {
         generalSteps.seeChangePassword();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -86,12 +86,12 @@ public class GeneralSteps {
     }
 
     @Step
-    public void clickMyProfile()  {
+    public void clickMyProfile() {
         dashboardPage.clickMyProfile();
     }
 
     @Step
-    public void seeChangePassword()  {
+    public void seeChangePassword() {
         profilePage.checkChangePassword();
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
@@ -11,22 +11,22 @@ public class LoginStepDefinitions {
     private LoginPage loginPage;
 
     @Given("^I have the application open in my browser$")
-    public void i_have_the_application_open_in_my_browser()  {
+    public void i_have_the_application_open_in_my_browser() {
         loginPage.open();
     }
 
     @Given("^I enter my username and password$")
-    public void i_enter_my_username_and_password()  {
+    public void i_enter_my_username_and_password() {
         loginPage.enterCredentials("p1", "p1");
     }
 
     @When("^I click on Login$")
-    public void i_click_on_Login()  {
+    public void i_click_on_Login() {
         loginPage.login();
     }
 
     @Then("^I should see my dashboard page$")
-    public void i_should_see_my_dashboard_page()  {
+    public void i_should_see_my_dashboard_page() {
         loginPage.checkUserLoggedIn("p1");
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LogoutStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LogoutStepDefinitions.java
@@ -22,7 +22,7 @@ public class LogoutStepDefinitions {
     }
 
     @When("^I click on Logout$")
-    public void clickLogout()  {
+    public void clickLogout() {
         dashboardPage.logout();
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
@@ -59,9 +59,13 @@ public class FacilityContractsFormBinder extends BaseFormBinder {
      */
     private static final String LICENSE_PATH = "/ProviderInformation/FacilityCredentials/SignedContract[";
 
-    private static final String[] ALL_CONTRACTS = new String[] {"Adult Rehabilitative Mental Health Services",
-        "Children's Therapeutic Services and Supports (CTSS)", "Adult Crisis Response Services - Crisis Assessment & Crisis Intervention",
-        "Adult Crisis Response Services - Crisis Stabilization", "Adult Crisis Response Services - Short-Term Residential",};
+    private static final String[] ALL_CONTRACTS = new String[]{
+            "Adult Rehabilitative Mental Health Services",
+            "Children's Therapeutic Services and Supports (CTSS)",
+            "Adult Crisis Response Services - Crisis Assessment & Crisis Intervention",
+            "Adult Crisis Response Services - Crisis Stabilization",
+            "Adult Crisis Response Services - Short-Term Residential",
+    };
 
     /**
      * Creates a new binder.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
@@ -298,11 +298,20 @@ public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBi
                 } else if (path.equals("/ProviderInformation/ApplicantInformation/OrganizationInformation/FEIN")) {
                     errors.add(createError("fein", ruleError.getMessage()));
                 } else if (path.equals("/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/PhoneNumber")) {
-                    errors.add(createError(new String[]{"phone1","phone2","phone3","phone4"}, ruleError.getMessage()));
+                    errors.add(createError(
+                            new String[]{"phone1", "phone2", "phone3", "phone4"},
+                            ruleError.getMessage()
+                    ));
                 } else if (path.equals("/ProviderInformation/ApplicantInformation/OrganizationInformation/ContactInformation/FaxNumber")) {
-                    errors.add(createError(new String[]{"fax1","fax2","fax3"}, ruleError.getMessage()));
+                    errors.add(createError(
+                            new String[]{"fax1", "fax2", "fax3"},
+                            ruleError.getMessage()
+                    ));
                 } else if (path.equals("/ContactInformation/PhoneNumber")) {
-                    errors.add(createError(new String[]{"contactPhone1","contactPhone2","contactPhone3","contactPhone4"}, ruleError.getMessage()));
+                    errors.add(createError(
+                            new String[]{"contactPhone1", "contactPhone2", "contactPhone3", "contactPhone4"},
+                            ruleError.getMessage()
+                    ));
                 } else if (path.startsWith("/ProviderInformation/AlternateAddresses/Address")) {
                     Integer addressIndex = resolveIndex(path);
                     if (addressIndex != null) {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
@@ -175,10 +175,10 @@ public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinde
     private AddressType readAddress(HttpServletRequest request, String prefix, int i) {
         AddressType address = new AddressType();
         address.setAddressLine1(param(request, prefix + "AddressLine1", i));
-        address.setAddressLine2(param(request, prefix +  "AddressLine2", i));
-        address.setCity(param(request, prefix +  "City", i));
+        address.setAddressLine2(param(request, prefix + "AddressLine2", i));
+        address.setCity(param(request, prefix + "City", i));
         address.setState(param(request, prefix + "State", i));
-        address.setZipCode(param(request, prefix +  "Zip", i));
+        address.setZipCode(param(request, prefix + "Zip", i));
         address.setCounty(param(request, prefix + "County", i));
         return address;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
@@ -175,7 +175,7 @@ public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinde
             if (path.endsWith("/Type")) {
                 return createError("type", index, message);
             } else if (path.endsWith("/PhoneNumber")) {
-                return createError(new String[]{"phone1","phone2","phone3", "phone4"}, index, message);
+                return createError(new String[]{"phone1", "phone2", "phone3", "phone4"}, index, message);
             } else if (path.endsWith("/Name")) {
                 return createError("name", index, message);
             } else if (path.endsWith("/EffectiveDate")) {

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
@@ -127,7 +127,7 @@ public class AgreementDocument implements Serializable {
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof AgreementDocument) {
-            return ((AgreementDocument)obj).getId() == this.getId();
+            return ((AgreementDocument) obj).getId() == this.getId();
         }
         return false;
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
@@ -45,7 +45,7 @@ public class OwnershipInformation implements Serializable {
     /**
      * References the ticket for this request.
      */
-    @Column(name= "ticket_id")
+    @Column(name = "ticket_id")
     private long ticketId;
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
@@ -53,7 +53,7 @@ public class PersonBeneficialOwner extends BeneficialOwner {
     /**
      * Last name.
      */
-    @Column(name="last_name")
+    @Column(name = "last_name")
     private String lastName;
 
     /**
@@ -65,7 +65,7 @@ public class PersonBeneficialOwner extends BeneficialOwner {
     /**
      * Date of birth.
      */
-    @Column(name="birth_dt")
+    @Column(name = "birth_dt")
     private Date dob;
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
@@ -161,7 +161,7 @@ public interface RegistrationService {
      * @return the matching users
      * @throws PortalServiceException for any errors encountered
      */
-    SearchResult<CMSUser> findUsersByCriteria(UserSearchCriteria criteria)  throws PortalServiceException;
+    SearchResult<CMSUser> findUsersByCriteria(UserSearchCriteria criteria) throws PortalServiceException;
 
     /**
      * Deletes the given users.


### PR DESCRIPTION
Add three Checkstyle rules:

- [WhitespaceAfter](http://checkstyle.sourceforge.net/config_whitespace.html#WhitespaceAfter), which requires code like `if (condition)` instead of `if(condition)`
- [SingleSpaceSeparator](http://checkstyle.sourceforge.net/config_whitespace.html#SingleSpaceSeparator), which requires code like `a + b` (single space after `+`) instead of `a +  b` (two spaces after `+` - hard to see in HTML, since multiple spaces are collapsed...)
- [WhitespaceAround](http://checkstyle.sourceforge.net/config_whitespace.html#WhitespaceAround), which requires code like `var = value` instead of `var=value`

Clean up existing violations to follow these new rules.

Issue #456 Use consistent code style