### PR TITLE
Improve integration test invocation

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -362,6 +362,10 @@ project(':integration-tests') {
         // Allow command-line options to be passed into Cucumber by calling
         // gradle with an argument like -Dcucumber.options=...
         systemProperty 'cucumber.options', System.properties.get('cucumber.options')
+
+        // Allow Serenity test aggregation (`:aggregate` target) to run even if
+        // the integration tests fail
+        gradle.startParameter.continueOnFailure = true
     }
 }
 

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -356,6 +356,9 @@ project(':integration-tests') {
     }
 
     test {
+        // Always run the integration tests when asked to
+        outputs.upToDateWhen { false }
+
         // Allow command-line options to be passed into Cucumber by calling
         // gradle with an argument like -Dcucumber.options=...
         systemProperty 'cucumber.options', System.properties.get('cucumber.options')

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -356,6 +356,8 @@ project(':integration-tests') {
     }
 
     test {
+        // Allow command-line options to be passed into Cucumber by calling
+        // gradle with an argument like -Dcucumber.options=...
         systemProperty 'cucumber.options', System.properties.get('cucumber.options')
     }
 }

--- a/psm-app/integration-tests/README.md
+++ b/psm-app/integration-tests/README.md
@@ -20,9 +20,9 @@ edit to fit your needs. Make a copy of `serenity.properties.template` as
 `serenity.properties` and edit the latter file.
 
 The most straightforward browser configuration is Chrome with the chromedriver.
-It can be run in GUI mode so you can follow along with the tests, or headless
-for more efficient test runs. Instructions for other configurations are provided
-further down in this README.
+It will run in GUI mode by default so you can follow along with the tests, and
+can be configured to run headless for more efficient test runs. Instructions
+for other configurations are provided further down in this README.
 
 To use Chrome you can just switch the commented `webdriver.driver` properties in
 `serenity.properties`. You need to download a copy of
@@ -64,6 +64,17 @@ There are many different options for running the serenity tests. Finding the
 correct configuration for each browser and operating system can be a challenge.
 The following sections document what works.
 
+## Chromium
+
+The webdriver for Chromium is packaged on Debian as
+[chromium-driver](https://packages.debian.org/stretch/chromium-driver) and on
+Ubuntu as
+[chromium-chromedriver](https://packages.ubuntu.com/xenial/chromium-chromedriver).
+`apt install` the appropriate package, and update `serenity.properties` to
+specify the Chrome driver and the location of the driver
+(`/usr/bin/chromedriver` on Debian, or `/usr/lib/chromium-browser/chromedriver`
+on Ubuntu).
+
 ## Headless Chrome & Firefox
 
 For testing the system in a continuous integration environment it is
@@ -89,17 +100,6 @@ environment variable to be set called `XVFB_DISPLAY`. Set it to `:10` before
 starting the gradle task like so:
 
     $ env XVFB_DISPLAY=":10" ./gradlew test aggregate
-
-## Interactive Chrome on Linux
-On Linux, the only way we've found to force an interactive Chrome session is
-to delete [the line in `build.gradle` in the test settings
-for
-`integration-tests`](https://github.com/SolutionGuidance/psm/blob/master/psm-app/build.gradle#L264):
-
-`environment "DISPLAY", System.getenv('XVFB_DISPLAY')`
-
-Delete this line and re-run the tests. You should see Chrome pop up on your
-screen and run through the tests.
 
 ## Firefox
 Selenium can only interact with specific versions of Firefox. The current version

--- a/psm-app/integration-tests/serenity.properties.template
+++ b/psm-app/integration-tests/serenity.properties.template
@@ -10,3 +10,10 @@ phantomjs.binary.path= ../../../phantomjs-2.1.1-linux-x86_64/bin/phantomjs
 # of the chrome driver
 webdriver.chrome.driver=../../../chromedriver
 
+# Set the base URL for the integration tests.
+#
+# Note that the root path of the application, `cms`, will be appended to this
+# URL; that means that if you set http://example.com/foo, the integration tests
+# will go to http://example.com/foo/cms.
+#
+#webdriver.base.url=http://localhost:8080/


### PR DESCRIPTION
While working with @slifty on the integration tests today, I noticed a number of problems with the way we run our integration tests and our documentation around it.

1. Always run the integration tests, even if "nothing" has changed, since gradle doesn't (and can't) know when something relevant *has* changed
2. Run `integration-tests:aggregate`, even if `integration-tests:test` failed
3. Document the `webdriver.base.url` property
4. Remove some outdated documentation