### PR TITLE
Add user help links for "Title V" etc. form labels

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
@@ -12,11 +12,14 @@
     <div class="clearFixed"></div>
     <div class="disclosure">
         <div class="row">
-            <label>Have you ever been convicted of a criminal offense related to
-                involvement in any program under Medicare, Medicaid, Title XX,
-                or Title XXI in Minnesota or any other state or jurisdiction
-                since the inception of these programs?<span
-                    class="required">*</span></label>
+            <label>
+              Have you ever been convicted of a criminal offense related to
+              involvement in any program under Medicare, Medicaid, Title XX,
+              or Title XXI in Minnesota or any other state or jurisdiction
+              since the inception of these programs?
+              <span class="required">*</span>
+              <a href="javascript:;" class="userHelpLink titleVHelpLink">?</a>
+            </label>
             <div>
                 <c:set var="formName"
                     value="_08_criminalConvictionInd"></c:set>
@@ -72,12 +75,15 @@
             </div>
         </div>
         <div class="row">
-            <label>Have you ever been excluded or terminated from participation
-                in Medicare, Medicaid, Children's Health Insurance Program
-                (CHIP),<br />
-                or the Title XXI services program in Minnesota or any other
-                state since the inception of these
-                programs?<span class="required">*</span></label>
+            <label>
+              Have you ever been excluded or terminated from participation
+              in Medicare, Medicaid, Children's Health Insurance Program
+              (CHIP),<br />
+              or the Title XXI services program in Minnesota or any other
+              state since the inception of these programs?
+              <span class="required">*</span>
+              <a href="javascript:;" class="userHelpLink titleVHelpLink">?</a>
+            </label>
             <div>
                 <c:set var="formName"
                     value="_08_previousExclusionInd"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_disclosure.jsp
@@ -21,7 +21,14 @@
             <div class="row">
                 <c:set var="formName" value="_18_empCriminalConvictionInd"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label class="longLbl">Been convicted of a criminal offense related to that person's involvement in any program under Medicare, Medicaid, Title XX, or Title XXI in Minnesota or any other state or jurisdiction since the inception of these programs? <span class="required">*</span></label>
+                <label class="longLbl">
+                  Been convicted of a criminal offense related to that person's
+                  involvement in any program under Medicare, Medicaid, Title XX,
+                  or Title XXI in Minnesota or any other state or jurisdiction
+                  since the inception of these programs?
+                  <span class="required">*</span>
+                  <a href="javascript:;" class="userHelpLink titleVHelpLink">?</a>
+                </label>
                 <label class="inline leftPadding"><input type="radio" value="Y" name="${formName}" ${formValue eq 'Y' ? 'checked' : ''} />Yes</label>
                 <label class="inline leftPadding"><input type="radio" value="N" name="${formName}" ${formValue eq 'N' ? 'checked' : ''} />No</label>
 
@@ -64,7 +71,14 @@
             <div class="row">
                 <c:set var="formName" value="_18_criminalConvictionInd"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label class="longLbl">Been convicted of a criminal offense related to that person's involvement in any program under Medicare, Medicaid, Title XX, or Title XXI in Minnesota or any other state or jurisdiction since the inception of these programs?  <span class="required">*</span></label>
+                <label class="longLbl">
+                  Been convicted of a criminal offense related to that person's
+                  involvement in any program under Medicare, Medicaid, Title XX,
+                  or Title XXI in Minnesota or any other state or jurisdiction
+                  since the inception of these programs?
+                  <span class="required">*</span>
+                  <a href="javascript:;" class="userHelpLink titleVHelpLink">?</a>
+                </label>
                 <label class="inline leftPadding"><input type="radio" value="Y" name="${formName}" ${formValue eq 'Y' ? 'checked' : ''} />Yes</label>
                 <label class="inline leftPadding"><input type="radio" value="N" name="${formName}" ${formValue eq 'N' ? 'checked' : ''} />No</label>
                 <div class="clear"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -240,6 +240,7 @@
               This person/business has an ownership or control interest in another Medicaid disclosing entity, or an
               entity that does not participate in Medicaid but is required to disclose ownership and control interest
               because of participation in any Title V, XVIII, or XX programs.
+              <a href="javascript:;" class="userHelpLink titleVHelpLink">?</a>
             </label>
         </span>
     </div>
@@ -458,6 +459,7 @@
               This person/business has an ownership or control interest in another Medicaid disclosing entity, or an
               entity that does not participate in Medicaid but is required to disclose ownership and control interest
               because of participation in any Title V, XVIII, or XX programs.
+              <a href="javascript:;" class="userHelpLink titleVHelpLink">?</a>
             </label>
         </span>
     </div>
@@ -667,6 +669,7 @@
               This person/business has an ownership or control interest in another Medicaid disclosing entity, or an
               entity that does not participate in Medicaid but is required to disclose ownership and control interest
               because of participation in any Title V, XVIII, or XX programs.
+              <a href="javascript:;" class="userHelpLink titleVHelpLink">?</a>
             </label>
         </span>
     </div>
@@ -901,6 +904,7 @@
               This person/business has an ownership or control interest in another Medicaid disclosing entity, or an
               entity that does not participate in Medicaid but is required to disclose ownership and control interest
               because of participation in any Title V, XVIII, or XX programs.
+              <a href="javascript:;" class="userHelpLink titleVHelpLink">?</a>
             </label>
         </span>
     </div>

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -5,11 +5,11 @@ var setNpiUserHelpClickHandler = setUserHelpClickHandler.bind(
   ['what-is-an-npi']
 );
 
-var setIndividualOwnershipUserHelpClickHandler = setUserHelpClickHandler.bind(
+var setOwnershipTypeUserHelpClickHandler = setUserHelpClickHandler.bind(
   undefined,
   '.ownershipTypeDefinition',
   '/help/enrollment.html',
-  ['what-are-the-types-for-individual-person-s-ownership-or-control-interest']
+  ['what-are-the-types-for-ownership-or-control-interest']
 );
 
 var setTitleVUserHelpClickHandler = setUserHelpClickHandler.bind(
@@ -1845,7 +1845,7 @@ $(document).ready(function () {
     $(html).find('input.npiMasked').mask("9999999999");
     $(html).find('input.ssnMasked').mask("999-99-9999");
     reindexPersonOwners();
-    setIndividualOwnershipUserHelpClickHandler();
+    setOwnershipTypeUserHelpClickHandler();
     setTitleVUserHelpClickHandler();
   });
 
@@ -1865,7 +1865,7 @@ $(document).ready(function () {
     $(html).find('input.ssnMasked').mask("999-99-9999");
     $(html).find("input.feinMasked").mask("99-9999999");
     reindexCorpOwners();
-    setIndividualOwnershipUserHelpClickHandler();
+    setOwnershipTypeUserHelpClickHandler();
     setTitleVUserHelpClickHandler();
   });
 
@@ -1898,7 +1898,7 @@ $(document).ready(function () {
     $(html).attr('alt', '').attr('title', '');
   });
 
-  setIndividualOwnershipUserHelpClickHandler();
+  setOwnershipTypeUserHelpClickHandler();
 
   setNpiUserHelpClickHandler();
 

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -5,6 +5,13 @@ var setNpiUserHelpClickHandler = setUserHelpClickHandler.bind(
   ['what-is-an-npi']
 );
 
+var setIndividualOwnershipUserHelpClickHandler = setUserHelpClickHandler.bind(
+  undefined,
+  '.ownershipTypeDefinition',
+  '/help/enrollment.html',
+  ['what-are-the-types-for-individual-person-s-ownership-or-control-interest']
+);
+
 var setTitleVUserHelpClickHandler = setUserHelpClickHandler.bind(
   undefined,
   '.titleVHelpLink',
@@ -1838,6 +1845,7 @@ $(document).ready(function () {
     $(html).find('input.npiMasked').mask("9999999999");
     $(html).find('input.ssnMasked').mask("999-99-9999");
     reindexPersonOwners();
+    setIndividualOwnershipUserHelpClickHandler();
     setTitleVUserHelpClickHandler();
   });
 
@@ -1857,6 +1865,7 @@ $(document).ready(function () {
     $(html).find('input.ssnMasked').mask("999-99-9999");
     $(html).find("input.feinMasked").mask("99-9999999");
     reindexCorpOwners();
+    setIndividualOwnershipUserHelpClickHandler();
     setTitleVUserHelpClickHandler();
   });
 
@@ -1889,11 +1898,7 @@ $(document).ready(function () {
     $(html).attr('alt', '').attr('title', '');
   });
 
-  setUserHelpClickHandler(
-    'a.ownershipTypeDefinition',
-    '/help/enrollment.html',
-    ['what-are-the-types-for-individual-person-s-ownership-or-control-interest']
-  );
+  setIndividualOwnershipUserHelpClickHandler();
 
   setNpiUserHelpClickHandler();
 

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -5,6 +5,13 @@ var setNpiUserHelpClickHandler = setUserHelpClickHandler.bind(
   ['what-is-an-npi']
 );
 
+var setTitleVUserHelpClickHandler = setUserHelpClickHandler.bind(
+  undefined,
+  '.titleVHelpLink',
+  '/help/enrollment.html',
+  ['what-do-title-v-title-xx-etc-refer-to']
+);
+
 $(document).ready(function () {
   $("#enrollmentQuickSearch").click(function () {
     var quickSearchInput = $.trim($("#quickSearchInput").val());
@@ -1817,8 +1824,7 @@ $(document).ready(function () {
     });
   }
 
-  /*add ownership*/
-  $('#addIndividualOwnership').live('click', function () {
+  $('#addIndividualOwnership').click(function addIndividualOwnership() {
     var html = $('#ownerTemplate').clone();
     html.attr('id', '');
     html.find('[type=text]').val('');
@@ -1832,9 +1838,10 @@ $(document).ready(function () {
     $(html).find('input.npiMasked').mask("9999999999");
     $(html).find('input.ssnMasked').mask("999-99-9999");
     reindexPersonOwners();
+    setTitleVUserHelpClickHandler();
   });
 
-  $('#addBusinessOwnership').live('click', function () {
+  $('#addBusinessOwnership').click(function addBusinessOwnership() {
     var html = $('#corpOwnerTemplate').clone();
     html.attr('id', '');
     html.find('[type=text]').val('');
@@ -1850,6 +1857,7 @@ $(document).ready(function () {
     $(html).find('input.ssnMasked').mask("999-99-9999");
     $(html).find("input.feinMasked").mask("99-9999999");
     reindexCorpOwners();
+    setTitleVUserHelpClickHandler();
   });
 
   /*add ownership*/
@@ -1922,6 +1930,8 @@ $(document).ready(function () {
     ],
     'Questions About Selecting a Provider Type'
   );
+
+  setTitleVUserHelpClickHandler();
 
   //$('.inline input[type=radio]').removeAttr('checked');
   //    $('.inline input[name=civilMoney]').click(function(){

--- a/psm-app/userhelp/source/enrollment.rst
+++ b/psm-app/userhelp/source/enrollment.rst
@@ -189,8 +189,8 @@ information on Type 2 NPI numbers and what kinds of business structures
 should have them <https://questions.cms.gov/faq.php?id=5005&faqId=1965>`__.
 
 
-What are the types for "Individual Person(s) Ownership or Control Interest"?
-----------------------------------------------------------------------------
+What are the types for "Ownership or Control Interest"?
+-------------------------------------------------------
 
 **Agent** - anyone who has been delegated the authority to obligate or
 act on behalf of the provider.


### PR DESCRIPTION
These links appear in the enrollment steps for organization providers on the "Ownership Info" page in three places:
  1. when you add individual ownerships, 
  2. when you add business ownerships, 
  3. at the bottom under 'provider disclosure'.  

They also appear in the individual provider steps on the final 'Provider Statement' page.

Tested by checking to see if the links worked as expected, showing the `What do “Title V”, “Title XX”, etc. refer to?` modal, even when they are added to the page dynamically by adding an individual or business ownership.

In the process I discovered that the `Type` user help modals (appearing on the organization provider 'ownership info' page) were not working when they were dynamically added to the page, by adding an individual or business ownership.  So a second commit fixes this problem for those user help links as well.  Tested in the same way as the "title v" user help links.

Resolves #422 Review documentation to add [...] help links