### PR TITLE
Refactor html head template to remove repeated mask plugin

### DIFF
--- a/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
@@ -20,11 +20,11 @@
   <script src="{{ctx}}/js/jquery.ui.core.js"></script>
   <script src="{{ctx}}/js/jquery.ui.widget.js"></script>
   <script src="{{ctx}}/js/jquery.ui.datepicker.js"></script>
+  <script src="{{ctx}}/js/jquery.mask.min.js"></script>
   {{#if adminPage}}
     <script src="{{ctx}}/js/jquery.tinyscrollbar.min.js"></script>
     <script src="{{ctx}}/js/jquery.validate.min.js"></script>
     <script src="{{ctx}}/js/chosen/chosen.jquery.min.js"></script>
-    <script src="{{ctx}}/js/jquery.mask.min.js"></script>
     <script src="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.js"></script>
     <script src="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.js"></script>
     <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.image.js"></script>
@@ -32,9 +32,7 @@
     <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.table.js" ></script>
   {{else if systemPage}}
     <script src="{{ctx}}/js/chosen/chosen.jquery.min.js"></script>
-    <script src="{{ctx}}/js/jquery.mask.min.js"></script>
   {{else}}
-    <script src="{{ctx}}/js/jquery.mask.min.js"></script>
     <script src="{{ctx}}/js/jquery.compare.js"></script>
   {{/if}}
 


### PR DESCRIPTION
The order in which the 'mask' plugin is loaded on the page shouldn't matter since it only depends on jQuery and nothing depends on it, so remove the duplication where it was being loaded from all three branches of the 'if' statement.

Tested by running the integration tests.

Issue #336 Can't paste into NPI field