### PR TITLE
Remove extra colons from Personal Care Assistant pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_agency_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_agency_information.jsp
@@ -16,14 +16,12 @@
                 <c:set var="formName" value="_11_name"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Agency Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_11_agencyId"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="agencyId">Agency Id<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input type="text" class="normalInput" id="agencyId" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row">
@@ -34,13 +32,11 @@
                   <span class="required">*</span>
                   <a href="javascript:;" class="userHelpLink NPIdefinition">?</a>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <input type="text" class="npiMasked normalInput" id="agencyNpiUmpi" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>
 
             <div class="row">
                 <label>Fax Number<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_11_fax1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" title="Fax Number Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>
@@ -58,7 +54,6 @@
                 <c:set var="formName" value="_11_contactName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="contactName">Agency Contact Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input type="text" class="normalInput" id="contactName" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
 
@@ -66,7 +61,6 @@
                 <c:set var="formName" value="_11_bgsId"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="bgsId">Background Study ID<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input type="text" class="normalInput" id="bgsId" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
 
@@ -74,7 +68,6 @@
                 <c:set var="formName" value="_11_clearanceDate"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Clearance Date<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
             </div>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
@@ -11,28 +11,24 @@
                 <c:set var="formName" value="_10_firstName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="firstName">First Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="firstName" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row">
                 <c:set var="formName" value="_10_middleName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="middleName">Middle Name</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="middleName" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_10_lastName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Last Name<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_10_ssn"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Social Security Number<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput ssnMasked" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
 
@@ -40,28 +36,25 @@
                 <c:set var="formName" value="_10_addressLine1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Residential Address<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Address, Line 1" class="wholeInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
             <div class="row inlineBox addressline2">
                 <c:set var="formName" value="_10_addressLine2"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">(Residential Address only - do not<br />enter a PO Box)</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Address, Line 2" class="wholeInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_10_city"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span> : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City<span class="required">*</span></label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_10_state"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State<span class="required">*</span> : </label>
+                <label for="${formIdPrefix}_${formName}">State<span class="required">*</span></label>
                 <select id="${formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -71,12 +64,12 @@
 
                 <c:set var="formName" value="_10_zip"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code<span class="required">*</span> : </label>
+                <label for="${formIdPrefix}_${formName}">ZIP Code<span class="required">*</span></label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                 <c:set var="formName" value="_10_county"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">County : </label>
+                <label for="${formIdPrefix}_${formName}">County</label>
                 <select id="${formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                        <option value="">Please select</option>
                        <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -89,7 +82,6 @@
                 <c:set var="formName" value="_10_umpi"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">UMPI</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>
 
@@ -97,7 +89,6 @@
                 <c:set var="formName" value="_10_dob"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Date of Birth<span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -105,7 +96,6 @@
 
             <div class="row">
                 <label>Phone Number</label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_10_phone1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <input type="text" title="Area Code" class="autotab smallInput" name="${formName}" value="${formValue}" maxlength="3"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
@@ -45,9 +45,6 @@
                   <div class="wholeCol">
                     <div class="row">
                       <label for="oldPassword">Old Password</label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
 
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="oldPassword">
@@ -57,9 +54,6 @@
                     </div>
                     <div class="row">
                       <label for="password">New Password</label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
 
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="password">
@@ -69,9 +63,6 @@
                     </div>
                     <div class="row">
                       <label for="confirmPassword">Confirm New Password</label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
 
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="confirmPassword">


### PR DESCRIPTION
These are the two enrollment steps/pages:

- Personal Care Assistant > Individual PCA Info

- Personal Care Assistant > Agency Info

And one general page:

- Login as a provider > My Profile > Change Password

Tested by inspecting these pages to confirm the colons were gone, and the page layout was not messed up.

Issue #376 Remove colons between form labels and fields