### PR TITLE
Make the RTM parseable and map it to issues

### DIFF
--- a/requirements/.gitignore
+++ b/requirements/.gitignore
@@ -1,0 +1,1 @@
+reqs.eld

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,7 +1,45 @@
 # Requirements
 
-Requirements documents related to the PSM that have been shared with the
-project by various states and agencies.
+What's here:
+
+* RTM.xlsx
+  Requirements Traceability Matrix: master spreadsheet of all requirements.
+
+* csv-exports/*.csv
+  CSV files for each reqs category (FR, II, IA, etc).
+
+  These CSV exports were made by manually running LibreOffice Calc on
+  RTML.xlsx multiple times, once for each sheet (tab) in the file,
+  which is a somewhat cumbersome process.  The CSV files should be
+  carefully kept up-to-date with changes to RTM.xlsx so that the CSV
+  remains a reliable data source (other programs rely on this).
+
+* csv-exports/columns.txt
+  Lists the columns (which are the same across all the CSV files).
+
+* psm_reqs.py
+  A Python module for working with PSM requirements.
+
+* reqs2any
+  A script to convert requirements from CSV to some other format.
+  This script depends on the psm_reqs.py module above.
+
+* show-reqs
+  A script that drives `reqs2any` to produce either elisp output or
+  human-readable output (pass "elisp" or "human" as arg to choose).
+
+* psm-reqs.el
+  Elisp for working with requirements in Emacs.  Start by invoking
+  `psm-load-reqs` on a file created by `./show-reqs elisp`, to load
+  all the requirements information into Emacs.  After that, the
+  interactive entry point is `psm-show-req`.  I suggest binding it to
+  a key.  Invoke it while in a req ID to display information about
+  that req.
+
+# Sources of requirements
+
+The requirements here come from documents related to the PSM that have
+been shared with the project by various states and agencies.
 
 ## Vermont
 
@@ -51,3 +89,103 @@ Services.pdf__.
 5. [__Provider Types.xlsx__](VT/Provider%20Types.xlsx): A list of VT's
 provider types.  Does not include subspecialties or rules pertaining to
 each provider type.
+
+# Unofficial history of requirements-to-issues mapping
+
+These are instructions Karl Fogel wrote for Paul Morris, before Paul
+did the second issues sweep (that is, the sweep where we knew about
+the formerly hidden reqs and were now taking them into account).  From
+reading these instructions, you can work out roughly what process was
+used to get us to the mapping we have today.
+
+Note that the *.org files referred to below now live in
+the [PSM Dashboard](https://github.com/solutionguidance/psm-dashboard)
+repository, not here.
+
+-----
+
+Everything is organized around the file 'issues-2018-03-31.org'.  It's
+an export of the current state of the issue tracker, or at any rate
+the state as of March 31st.  Each issue in the file has a top level
+"*" header followed by the issue summary.  Then the issue's labels (if
+any) are listed under a "**" subheader called "LABELS".
+
+The labels we care about start with "Z-REQ-PSM-".  Lop off the
+"Z-REQ-" prefix and you have the requirement ID (e.g., "PSM-FR-7.2").
+Each such label is followed by the description of that requirement and
+the general area of the requirements that it comes from (e.g.,
+something like <<< FR 7. Usability >>>").
+
+(Note that issues 700 and higher don't yet have any req labels.  I
+suggest leaving them till the end of the process, since by then you'll
+know the requirements list much better and it'll be easier to find the
+appropriate labels for those recent issues.)
+
+Now, here's the full story, and instructions for what needs to happen:
+
+Cecilia and I already made one pass over all the issues (at the time
+issue 699 was the highest), assigning requirement IDs as appropriate.
+Unfortunately, as I explained to you on the phone, at the time we
+didn't know that some reqs -- about 60 of them -- were "hidden" and
+not visible to us.  So we went blissfully along using just the req IDs
+in the file now called 'non-hidden-RTM-rows.org'.  (Obviously that
+file had a different name at the time! :-) ) As we were doing that, I
+remember thinking to myself that something was odd, that we seemed to
+be missing req IDs for things I knew we'd identified as requirements
+long ago, such as the PSM having the capability to do full-text
+search... Ah well.
+
+Anyway, as we went along, we created a few new requirements.  Some of
+them later turned out to be redundant or at least partially redundant
+with formerly hidden requirements, while others were genuinely needed
+and will be kept as new requirements.  Both kinds of newly-created
+reqs are listed in 'added-reqs.org', and there's some more explanation
+at the top of that file.
+
+So you need go down the issues in 'issues-2018-03-31.org', starting
+from 699, and see if any of the reqs in 'hidden-RTM-rows.org' or
+'added-reqs.org' are better matches for that issue than the reqs we
+have listed for it currently.  Depending on what you find for a given
+issue, the end result could be that you do nothing for that issue, or
+that you add some new req IDs, or that you add some new req IDs and
+remove some existing req IDs.
+
+The way to express your changes is add a new "**" subheading named
+"LABEL CHANGES" in that issue's section.  Under that header, use a "+"
+line for each req to add and a "-" line for each req to subtract.
+Always do one exactly one req per line.  Here's an example I just did
+in issue 691:
+
+  ** LABEL CHANGES
+     - fr-7.13
+     + iu-2.5
+
+To make things easier, use lower-case and leave off the "Z-REQ-PSM-"
+prefix.  I'll take care of adding those back later when I parse the
+whole file to update the issue tracker.
+
+Now, in 'added-reqs.org' there were two newly-created reqs that turned
+out to be simple duplicates of later-discovered hidden reqs.  I've
+already gone through and added "LABEL CHANGES" sections for all the
+issues that had one of those now-redundant newly-created reqs, so that
+at least the most obvious req replacement is already done.  Of course,
+those issues, like any other issues, still require consideration for
+the other hitherto hidden reqs, and any of the remaining reqs
+currently attached to those issues might still get removed because
+some hidden req turns out to be a better fit.
+
+So for example, my "LABEL CHANGES" section for issue 691 above might
+be incomplete.  I haven't looked through the rest of the formerly
+hidden reqs nor through the rest of the added reqs to determine if any
+other changes are necessary -- I  just took care of that one
+replacement that I knew was an easy call.
+
+I'll be available for questions as you're working, and the README.md
+file in this directory has some more context about what the files
+are.  (I've tried to put all the information you need here, but the
+README.md is probably worth a skim too.)
+
+By the way, it's not actually 700+ issues that need to be done, don't
+worry!  It's only 316.  Remember that issues and pull requests share
+the same namespace on GitHub (an interesting design decision on their
+part), and we're only labeling issues here, not PRs.

--- a/requirements/csv-exports/columns.txt
+++ b/requirements/csv-exports/columns.txt
@@ -1,0 +1,30 @@
+The columns across *.csv are all the same:
+
+  1: Requirement ID Number
+  2: Requirement Category
+  3: Requirement Statement
+  4: Priority
+  5: Rank
+  6: Source
+  7: Source Document
+  8: Release
+  9: Design Reference
+ 10: Acceptance Test Reference
+ 11: Comment
+
+We used CSVkit (https://csvkit.readthedocs.io/en/1.0.3/) to get them:
+
+  $ git clone https://github.com/wireservice/csvkit
+  $ cd csvkit
+  $ python3 -m venv env
+  $ source env/bin/activate
+  (env)$ pip3 install .
+  (env)$ cd wherever_the_csv_files_are
+  (env)$ csvcut -n reqs-fr.csv
+
+To verify that all the CSV files have the same columns, we made sure
+the second command below gives no output:
+
+  (env)$ for name in reqs-??.csv; do csvcut -n "${name}" > "${name}".cols; done
+  (env)$ for name in *.cols; do diff -u reqs-fr.csv.cols "${name}"; done
+  (env)$ rm *.cols

--- a/requirements/csv-exports/reqs-ad.csv
+++ b/requirements/csv-exports/reqs-ad.csv
@@ -1,0 +1,51 @@
+Requirement ID Number,Requirement Category,Requirement Statement,Priority,Rank,Source,Source Document,Release,Design Reference,Acceptance Test Reference,Comment
+,1.  Technical Service Classification:  Business Intelligence,,,,,,,,,
+psm-AD-1.1,,The PSM shall support a range of analysis actions. ,,,TA.BI.2,,Post R1,,,
+psm-AD-1.2,,"The PSM shall collect and summarize data for specific user communities (e.g. data marts or cubes) such as program analysis staff, research group, financial management unit, agency executives (e.g. dashboard).",,,TA.BI.4,,Post R1,,,
+psm-AD-1.3,,The PSM shall provide reports that allow users to drill down from summarized data to detailed data.,,,TA.BI.5,,Release 1,,,
+psm-AD-1.4,,The PSM shall limit access to authorized group of stakeholders.,,,TA.BI.9,,Alpha,,,
+,2.  Technical Service Classification:  Client Support,,,,,,,,,
+psm-AD-2.1,,The PSM shall provide a user interface or associated interfaces text titles for frames to facilitate frame identification and navigation.,,,TA.CS.10,,Release 1,,,
+psm-AD-2.2,,"The PSM shall provide member and provider access to services via browser, kiosk, voice response solution, or mobile device, and manual submissions.",1,Low,TA.CS.14,,MVP - Sept,,,
+psm-AD-2.3,,"The PSM shall conform to usability and design standards set by the state. This includes aesthetics, consistency in the user interface, and visual quality of the interfaces.",,,TA.CS.17,,,,,N/A
+psm-AD-2.4,,The PSM shall fully comply with section 508 accessibility.,,,TA.CS.18,,Release 1,,,
+psm-AD-2.5,,"To the greatest extent possible, the PSM shall be browser agnostic. ",,,TA.CS.6,,MVP - Dec,,,
+,3.  Technical Service Classification:  Forms and Reporting,,,,,,,,,
+psm-AD-3.1,,"The PSM shall support retrieval and presentation of data associated with geographic indicators such as state, county, and zip code.",,,TA.FR.1,,Post R1,,,
+psm-AD-3.2,,The PSM shall support federal reporting requirements when these requirements are met through the decision support services (DSS).,,,TA.FR.2,,Post R1,,,
+psm-AD-3.3,,"The PSM shall support a variety of formats and output options (e.g. Word, Excel, html, Access database, or GUI formats).",,,TA.FR.4,,Post R1,,,
+psm-AD-3.4,,"The PSM shall support simple queries and pre-formatted reports that are easy to access, follow a user-friendly protocol, and produce responses immediately.",,,TA.FR.6,,Release 1,,,
+psm-AD-3.5,,The PSM shall provide ad hoc reporting capability that presents summarized information on key factors to executive staff upon request.,,,TA.FR.7,,Post R1,,,
+psm-AD-3.6,,The PSM shall provide ad hoc query capability for retrieval of data relevant to specific operational units.,,,TA.FR.8,,Post R1,,,
+,4.  Technical Service Classification:  Performance Measurement,,,,,,,,,
+psm-AD-4.1,,The PSM shall provide the ability to record and monitor the performance and utilization of resources within the overall system.,,,TA.PM.7,,Release 1,,,
+psm-AD-4.2,,The PSM shall generate performance measures for specific business processes using predefined and ad hoc reporting methods.,,,TA.PM.8,,Release 1,,,
+,5.  Technical Service Classification:  Security and Privacy,,,,,,,,,
+psm-AD-5.1,,"The PSM shall follow regulations govern the safeguard of information about applicants and beneficiaries.  The following is the minimal set of information that must be safeguarded:
+(1) Name and addresses;
+(2) Social and economic conditions or circumstances:
+(3) Agency evaluation of personal information;
+(4) Any information received for verifying income;
+",,,TA.SP.15,,Alpha,,,
+psm-AD-5.2,,"The PSM shall verify the identity of all users, denies access to invalid users. For example:
+•  Requires unique sign-on (ID and password)
+•  Requires authentication of the receiving entity prior to a system initiated session, such as transmitting responses to eligibility inquiries.",1,High ,TA.SP.22,,MVP - Sept,,,
+psm-AD-5.3,,"The PSM shall enforce password policies for length, character requirements, and updates.",,,TA.SP.24,,Release 1,,,
+psm-AD-5.4,,The PSM shall support a user security profile that controls user access rights to data categories and system functions.,,,TA.SP.25,,MVP - Dec,,,
+psm-AD-5.5,,The PSM shall permit supervisors or other designated officials to set and modify user security access profile.,,,TA.SP.26,,Post R1,,,
+psm-AD-5.6,,"The PSM shall alert appropriate staff authorities of potential violations of privacy safeguards, such as inappropriate access to confidential information.",,,TA.SP.30,,Post R1,,,
+psm-AD-5.7,,The PSM of shall contain verification mechanisms that are capable of authenticating authority (as well as identify) for the use or disclosure requested. ,,,TA.SP.32,,,,,N/A
+psm-AD-5.8,,The PSM shall provide the capability that all system activity can be traced to a specific user or entity.,,,TA.SP.37,,Beta,,,
+psm-AD-5.9,,"The PSM shall log system activity and enable analysts to examine system activity in accordance with audit policies and procedures (error diagnosis, and performance management) adopted by the Medicaid agency.",,,TA.SP.39,,Beta,,,
+psm-AD-5.10,,The PSM shall have the capability to provision access to an authorized user or request.,1,Low,TA.SP.42,,MVP - Sept,,,
+psm-AD-5.11,,"The PSM shall  have standard Access Control specifications to include:
+(i) Assigning a unique name and/or number for identifying and tracking user identity. (Required)
+(iii) Implementing electronic procedures that terminate an electronic session after a predetermined time of inactivity. (Addressable)
+",,,TA.SP.5,,MVP - Dec,,,
+psm-AD-5.12,,The PSM shall support roles and responsibilities of individuals that are separated through assigned information access authorization as necessary to prevent malevolent activity.,,,TA.SP.50,,MVP - Dec,,,
+psm-AD-5.13,,User account access authorization should follow the concept of least privilege; allowing users access to only the information that is necessary to accomplish assigned tasks in accordance with business functions.,,,TA.SP.51,,Alpha,,,
+psm-AD-5.14,,The PSM shall support the state policy to disable account due to invalid login attempts.,,,TA.SP.52,,Release 1,,,
+psm-AD-5.15,,"After 15 minutes of inactivity, the PSM shall initiate a session lock; the session lock should remain in place until the user reestablishes access using established identification and authentication procedures.",,,TA.SP.54,,MVP - Dec,,,
+psm-AD-5.16,,"The PSM shall enforce a sufficient level of authentication / identification against fraudulent transmission and imitative communications deceptions by validating the transmission, message, station or individual.",2,Medium,TA.SP.70,,MVP - Sept,,,
+psm-AD-5.17,,The PSM shall use only FIPS Pub 140-2-approved (or higher) encryption algorithms.,,,TA.SP.74,,MVP - Dec,,,
+psm-AD-5.18,,"The PSM shall be secure from unauthorized access or use, and shall sanitize inputs and outputs where possible so as to avoid compromising itself or other systems.",,,SGC 2018-03-05,,Release 1,,,

--- a/requirements/csv-exports/reqs-fr.csv
+++ b/requirements/csv-exports/reqs-fr.csv
@@ -1,0 +1,131 @@
+Requirement ID Number,Requirement Category,Requirement Statement,Priority,Rank,Source,Source Document,Release,Design Reference,Acceptance Test Reference,Comment
+,1.  Capability to conduct identity verification,,,,,,,,,
+psm-FR-1.1,,The PSM shall accept a form that shows a tax ID number and legal name for each provider (ex forms: CP 575 or 147C letter; 941 Employers' Quarterly Federal Tax Return; 8109 Tax Coupon; or letter from IRS with the Federal Tax Identification Number and legal name).,,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Alpha,,,"Does this include how the provider is legally organized and structured?   Does this include info regarding whether the provider is private vs non-profit, a public entity, state government agency?  Yes. data field entity type under ownership tab, user can specify all these provider business types."
+psm-FR-1.2,,The PSM shall ensure that tax ID number is 9 digits,1,Low,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,
+psm-FR-1.3,,The PSM shall screen providers for managed care plans.,,,LA,PSM State Calls Requirements_functionality needs.xlsx,Alpha,,,Is this based on Final Managed Care Rules and 21st Century Cures Act?  Need to check with LA to verify this is the same requirement
+psm-FR-1.4,,The PSM shall have the capability to identify providers by Employer identification number unless the provider is in solo practice or the provider is not in solo practice but billing is by the individual practitioner in which case the PSM shall have the capability to identify providers by social security number.,1,High ,"Pre-certification
+PM.PR3.1",pre-certification-requirements.md,MVP - Dec,,,
+psm-FR-1.5,,The PSM shall have the capability to escalate the intensity of screening for providers that are flagged as higher risk.,,,MN,Original PSC Master Evaluation Matrix,Alpha,,,
+psm-FR-1.6,,The PSM shall collect and store standardized W-9 information that reflects the owner of the EIN and the Doing Business As (DBA) name.  ,1,Low,MT,PMNT14,MVP - Sept,,,
+,2.  Capability to build provider profile,,,,,,,,,
+psm-FR-2.1,,The PSM shall have the option of zipcode + 4 for all address fields,2,Low,LA,email from Jacques Kado on 7/11,MVP - Sept,,,
+psm-FR-2.2,,The PSM shall allow multiple locations for the provider.,1,High ,LA,email from Jacques Kado on 7/11,MVP - Dec,,,
+psm-FR-2.3,,"The PSM shall associate multiple Medicare IDs with the same provider, if the provider has multiple locations.",,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Beta,,,
+psm-FR-2.4,,The PSM shall allow applicant to upload attachments to support the application.,2,Medium,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,
+psm-FR-2.5,,The PSM shall indicate what kinds of documents/attachments are required by provider type.,3,Medium,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,
+psm-FR-2.6,,"The PSM shall require the following fields: Provider Name, Business Phone, Provider Street Address, City, State, Zip Code, County, SSN, Date of Birth, License Number, IRS Payee Name, DBA Name, Payee Address, Payee City, Payee State, Payee Zip Code, Payee Tax ID, Provider Email address",1,Low,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,Will the PSM identify whether the provider is a rendering (eligible to directly bill) or an ordering/referring/prescribing (eligible to enroll but not directly bill state Medicaid agency)?  Not currently plan for PSM functionality
+psm-FR-2.7,,"The PSM shall accept the following fields: Practice Type, Specialties (1 or more), NPI, HIPAA Taxonomy Codes, CLIA number, DHSS certification, Optical and Audiology y/n, Collaborative Practice Agreement y/n, RHC y/n, Medicare Provider Number, Case Mgmt y/n, Rural Health Rate",,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Beta,,,
+psm-FR-2.8,,"The PSM shall require the following fields: Contact email, Merger y/n, Owner/board names and addresses, Care settings, DEA controlled substances certification y/n, DEA revocation y/n",,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Beta,,,Dos this include SSN for owners and others with >5% ownership? Yes!
+psm-FR-2.9,,"The PSM shall accept the following fields: Applicant Name, Contact Person, Contact phone, Medicaid number",4,Low,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,"To clarify: Applicant is person completing the application, not necessarily provider.  Correct!  Will contact person info differentiate between  contact for billing vs practice locations.  Yes, under Alternative Mailing Addresses."
+psm-FR-2.10,,The PSM shall notify managed care plans when a provider becomes eligible (has been screened) and/or allow a managed care plan to check a provider's eligibility.,,,LA,PSM State Calls Requirements_functionality needs.xlsx,Alpha,,,
+psm-FR-2.11,,The PSM shall detect and ask specific questions of bordering-state providers.,,,WV,PSM State Calls Requirements_functionality needs.xlsx,Alpha,,,
+psm-FR-2.12,,"The PSM shall share NPI between individual providers, for group practices.",,,OH,PSM State Calls Requirements_functionality needs.xlsx,Alpha,,,
+psm-FR-2.13,,"The PSM shall limit enrollment to providers in the following categories: (1) in-state, (2) out-of-state in-network, (3) within a defined ""border"" region of neighboring states.",,,VT/WV,VTMedicaidProviderManual.pdf,Alpha,,,
+psm-FR-2.14,,"The PSM shall use consistent provider naming conventions to differentiate between first names, last names, and business or corporate names and to allow flexible searches based on the provider name.",,,"Pre-certification
+PM.PR1.11",pre-certification-requirements.md,Alpha,,,"Will all individual's names include generation (Jr., III, etc.) Currently we don't have a separate field for generation indication, but could use the last name field."
+psm-FR-2.15,,The PSM shall maintain a flag for providers who are eligible to use electronic funds transfer (EFT) and electronic claims submission.,2,Low,"Pre-certification
+PM.PR3.10",pre-certification-requirements.md,MVP - Dec,,,"Will PSM allow for provider application fee to be accepted/processed electronically?  Will PSM ask if provider owes state Medicaid agency monies that have not been paid and collect those monies or arrange for repayment at time of enrollment?  No, not currently a PSM function."
+psm-FR-2.16,,"The PSM shall accept, validate, and process transactions or user entries to update and maintain provider information.",1,High ,"Pre-certification
+PM.PR3.3",pre-certification-requirements.md,Alpha,,,
+psm-FR-2.17,,The PSM shall maintain providers’ drug enforcement administration (DEA) numbers.,,,"Pre-certification
+PM.PR3.7",pre-certification-requirements.md,Beta,,,
+psm-FR-2.18,,The PSM shall have the capability to ensure that providers that have a history of fraud are flagged with a higher risk level at the time of screening,,,MN,Original PSC Master Evaluation Matrix,Release 1,,,
+psm-FR-2.19,,"The PSM shall have the capability to capture critical attributes including licensing information, financial data, and any other data attributes which could impact a risk level.",,,MN,Original PSC Master Evaluation Matrix,Release 1,,,
+psm-FR-2.20,,"The PSM shall collect and maintain licensure information to include at a minimum, licensing state, license number, licensure begin and end dates.  ",1,Medium,MT,PMNT09,MVP - Sept,,,
+,"3.  Enable the SMA to provide accurate, streamlined, automated determination of provider eligibility, appeal and revalidation",,,,,,,,,
+psm-FR-3.1,,The PSM shall provide a rejection reason if an application is rejected.,,,LA,email from Jacques Kado on 7/11,Alpha,,,
+psm-FR-3.2,,The PSM shall have the capability to create a high-risk list to ensure that providers that are suspected or known to be fraudulent are flagged at the time of screening.,,,"Pre-certification
+PM.PR3.7",pre-certification-requirements.md,Beta,,,
+psm-FR-3.3,,The PSM shall flag and route records for action if multiple internal state assigned provider numbers are associated with a single provider.,,,"Pre-certification
+PM.PR1.4",pre-certification-requirements.md,Post R1,,,
+psm-FR-3.4,,"The PSM shall separate providers into risk categories limited, moderate, and high based on provider type, as established by CMS.",2,Medium,VT,GrnMtnCareEnrollInst.pdf,MVP - Sept,,,
+psm-FR-3.5,,"The PSM shall screen limited-risk providers by verifying that the provider or supplier meets all applicable federal regulations and state requirements for the provider or supplier type, conducting license verifications, including licensure verifications across state lines for physicians, non-physician practitioners, providers and suppliers, and conducting database checks on a pre-and post-enrollment basis to ensure that providers and suppliers continue to meet the enrollment criteria for their provider/supplier type.",,,VT,GrnMtnCareEnrollInst.pdf,Release 1,,,
+psm-FR-3.6,,The PSM shall conduct a fingerprint-based criminal background check for high-risk provider types.,,,VT,GrnMtnCareEnrollInst.pdf,Beta,,,Will process to conduct FCBC include coordination with state's program that is part of National Background Check Program?  Possible but no specific requirement for this external interface currently.  How will result be communicated to State agency's Fiscal Agent? Unknown at this point.  Will be part of the integration with the other components of MMIS.
+psm-FR-3.7,,"The PSM shall change a provider's risk level due to: imposition of a payment suspension within the previous 10 years; termination from billing Medicaid; exclusion by the OIG; revocation of billing privileges by a Medicare contractor within the previous 10 years (and such provider/supplier is attempting to establish additional Medicare billing privileges by enrolling as a new provider or supplier or establish billing privileges for a new practice location); exclusion from any federal health care program; subject to any final adverse action (as defined in 42 CFR 424.502) within the past 10 years; instances in which CMS lifts a temporary moratorium for a particular provider or supplier type and a provider or supplier that was prevented from enrolling based on the moratorium, applies for enrollment as a Medicare provider or supplier at any time within 6 months from the date the moratorium was lifted.",,,VT,GrnMtnCareEnrollInst.pdf,Release 1,,,
+psm-FR-3.8,,"The PSM shall compare monitoring statistics (e.g. license expirations that were not caught within a month, total number of sanctions) from one month to the next.",,,MO,Screening and Auditing Notes.docx,Post R1,,,
+psm-FR-3.9,,"The PSM shall have the capability to create a learning system to ensure that observed negative trends factor back into  screening rules so as to flag suspicious enrollments early in the screening process, ensuring the ability to detect and reduce/eliminate the incidence of false positives.",,,MN,Original PSC Master Evaluation Matrix,Post R1,,,
+psm-FR-3.10,,The PSM shall send letter confirming enrollment.,,,VT,VTMedicaidProviderManual.pdf,Beta,,,"How will this work if the State Medicaid agency has enrollment requirements outside of what is collected/processed via PSM?  What else is required from WV for the PSM?  It is possible for PSM to use workflow to configure outside enrollment - will need additional requirements.  Otherwise, content of the letter could be configurable to indicate what processes are completed."
+psm-FR-3.11,,"The PSM shall notify providers 90 days before their enrollment expires, so that they can go through revalidation.",,,VT,VTMedicaidProviderManual.pdf,Alpha,,,
+psm-FR-3.12,,The PSM shall automatically reject applications that do not include all mandatory information.,2,Medium,VT,VTMedicaidProviderManual.pdf,MVP - Sept,,,
+psm-FR-3.13,,"The PSM shall have the capability to track and support the screening of applications (and ongoing provider updates) for National Provider Identifier (NPIs), State licenses, Specialty Board certification as appropriate, review team visits when necessary, and any other State and/or Federal Requirement.",,,"Pre-certification
+PM.PR2.1",pre-certification-requirements.md,Release 1,,,
+psm-FR-3.14,,The PSM shall cross-reference license and sanction information with other state or federal agencies.,,,"Pre-certification
+PRM2.5",pre-certification-requirements.md,Release 1,,,
+psm-FR-3.15,,The PSM shall have the turnaround time for performing automated checks typical for a web based system,1,Low,MN,Original PSC Master Evaluation Matrix,MVP - Sept,,,
+psm-FR-3.16,,The PSM shall provide comprehensive verification of all (verifiable) data fields for all providers enrolled,,,MN,Original PSC Master Evaluation Matrix,Release 1,,,
+psm-FR-3.17,,The PSM shall improve efficiency of the Screening Solution in terms of cost and schedule to actually implement ,,,MN,Original PSC Master Evaluation Matrix,Release 1,,,
+psm-FR-3.18,,The PSM shall Improve effectiveness of the risk-screening model in detecting fraud based issues,,,MN,Original PSC Master Evaluation Matrix,Release 1,,,
+psm-FR-3.19,,The PSM shall Improve technical soundness of risk-scoring in flagging potential fraudulent patterns and tendencies,,,MN,Original PSC Master Evaluation Matrix,Release 1,,,
+psm-FR-3.20,,The PSM shall define a common workflow for collecting enrollment information of individual providers,,,MN,Original PSC Master Evaluation Matrix,Alpha,,,
+psm-FR-3.21,,The PSM shall save administrative/infrastructure cost by providing a multi-tenant provider screening solution,,,MN,Original PSC Master Evaluation Matrix,Release 1,,,
+psm-FR-3.22,,The PSM shall reduce the time needed by providers to submit new/renewal application information and resolve discrepancies.,,,MN,Original PSC Master Evaluation Matrix,Release 1,,,
+psm-FR-3.23,,The PSM shall reduce processing and transaction time for submitting and receiving queries to authoritative data sources regarding provider credentials and sanctions.,,,MN,Original PSC Master Evaluation Matrix,Release 1,,,
+psm-FR-3.24,,"The PSM shall validate, and/or verify that all data items that contain self-checking digits (e.g., National Provider Identifier) passes a specified check-digit test. ",1,High ,MT,DM75,MVP - Sept,,,
+psm-FR-3.25,,The PSM shall allow state reviewers to assign and queue applications.,,,MT,,,,,
+,4.  Configurable Setting,,,,,,,,,
+psm-FR-4.1,,"The PSM shall show a list of settings in which a provider might see clients/patients, including ""Other.""",,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Alpha,,,
+psm-FR-4.2,,The PSM shall allow applicants to choose multiple care settings.,,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Alpha,,,
+psm-FR-4.3,,"The PSM shall allow providers to update information and initiate re-screening process (e.g., in the following situations: name change, change of ownership/operator - whether or not it is the same practice location, address change, Federal Tax Identification Number change at same practice location, change from Social Security Number to Federal Tax Identification Number at same practice location, change from Federal Tax Identification Number to Social Security Number at same practice location, payment name or address change, and additional service location)",,,MO/WV,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Alpha,,,
+psm-FR-4.4,,"The PSM shall provide space for results of on-site visits, for moderate- and high-risk provider types.",,,VT,GrnMtnCareEnrollInst.pdf,Alpha,,,
+psm-FR-4.5,,"The PSM shall support the Extract, Transform and Load (ETL) processes from real-time  web services or batch processes.",2,High ,MT,DM79,MVP - Sept,,,
+psm-FR-4.6,,The PSM shall have the ability to enforce limits on the number of providers of a given type enrolled simultaneously.,,,SGC 2018-03-05,,Release 1,,,
+psm-FR-4.7,,The PSM shall support admin-configurable automated re-screening.  C.f. psm-FR-7.3.,,,SGC 2018-03-05,,Release 1,,,
+psm-FR-4.8,,The PSM shall support provider agents (a.k.a. service agents a.k.a. non-provider users) who act on a provider's behalf and whose authorization may be a subset of that provider's.,,,SGC 2018-03-05,,Beta,,,
+,5. Manage Enrollment,,,,,,,,,
+psm-FR-5.1,,The PSM shall issue Medicaid provider ID number to each approved provider.,,,VT,VTMedicaidProviderManual.pdf,Alpha,,,"Medicaid provider ID aka Atypical Provider Identifier (API).  Could be part of the help tip to include API.  If necessary, could change the Medicaid provider ID text field by adding  the following: (or Atypical Provider Identifier)."
+psm-FR-5.2,,The PSM shall allow providers to terminate their enrollment on a specified date.,4,Medium,VT,VTMedicaidProviderManual.pdf,MVP - Dec,,,PSM should capture a termination reason code.  Need a list of termination reason code from WV. Have requirement for termination screen but not implemented yet in PSM.  
+psm-FR-5.3,,The PSM shall require providers to give 30 days notice before terminating enrollment.,4,Low,VT,VTMedicaidProviderManual.pdf,MVP - Dec,,,
+psm-FR-5.4,,The PSM shall require PC Plus providers to give 90 days notice before terminating enrollment.,,,VT,VTMedicaidProviderManual.pdf,Beta,,,
+psm-FR-5.5,,"The PSM shall maintain the capability to limit billing and providers to certain benefit plans, services, by procedure codes, ranges of procedure codes, member age or by provider type(s) or as otherwise directed by the State.",,,"Pre-certification
+PM.PR2.7",pre-certification-requirements.md,Post R1,,,
+psm-FR-5.6,,The PSM shall require revalidation period to be configurable.,,,VT/WV,GrnMtnCareEnrollInst.pdf,Alpha,,,
+psm-FR-5.7,,PSM shall terminate enrollment if revalidation is not completed.  ,,,VT/WV,,Alpha,,,
+psm-FR-5.8,,The PSM shall capture a termination reason code that is provided by the State,,,WV,,Alpha,,,
+,"6. Retention, Reporting and Auditing",,,,,,,,,
+psm-FR-6.1,,The PSM shall download all monitoring risk scores for each month as a CSV,,,MO,Screening and Auditing Notes.docx,Beta,,,
+psm-FR-6.2,,The PSM shall maintain date-specific provider enrollment and demographic data.,,,"Pre-certification
+PM.PR1.7",pre-certification-requirements.md,Alpha,,,
+psm-FR-6.3,,"The PSM shall maintain an audit trail of all updates to the provider data, for a time period specified by the state.",,,"Pre-certification
+MITA PM.PR3.6",pre-certification-requirements.md,Beta,,,
+psm-FR-6.4,,The PSM shall remember previous rejected providers and reasons for rejection corresponding form fields,,,MN,Original PSC Master Evaluation Matrix,Beta,,,
+psm-FR-6.5,,"The PSM shall, to extent permitted by law, make screening data available for analytics and other reporting purposes.",,,LA,PSM State Calls Requirements_functionality needs.xlsx,Beta,,,"Does this include development of and tech support for common enrollment reports? Tech support for ad hoc reports?  Tech support report will be provided separately and not part of PSM.  Currently no reporting against database with PSM, this would be a separate requirement for ad-hoc report generation.  Question for WV:  what reports are you interested in?"
+psm-FR-6.6,,"The PSM shall keep a record of the date of each screening/monitoring event, the score, and the agencies decision for each provider.",,,MO,Screening and Auditing Notes.docx,Beta,,,
+psm-FR-6.7,,The PSM shall store monthly audit record for a provider even if their information has not changed.,,,MO,Screening and Auditing Notes.docx,Beta,,,
+psm-FR-6.8,,"The PSM shall provide an input to document the nature for the type of screening/monitoring event, the score, and the agencies decision for each provider.",,,WV,,Beta,,,
+,7. Usability,,,,,,,,,
+psm-FR-7.1,,The PSM shall provide per-field instructions on the application screen.,,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Beta,,,
+psm-FR-7.2,,The PSM shall provide detailed instructions for completing the application via a Help link.,,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Alpha,,,
+psm-FR-7.3,,The PSM shall not send re-screening results to admin for review if provider information has not changed.,,,MO,Screening and Auditing Notes.docx,Alpha,,,
+psm-FR-7.4,,The PSM shall provide a screen to verify entered information.,2,Low,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,
+psm-FR-7.5,,The PSM shall allow applicant to edit entered information.,2,Low,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,
+psm-FR-7.6,,The PSM shall allow applicant to print application for their records.,2,Low,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,
+psm-FR-7.7,,The PSM shall allow applicant to save a partial application as a draft.,2,Low,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,
+psm-FR-7.8,,The PSM shall indicate which fields are required.,1,Low,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,
+psm-FR-7.9,,The PSM shall prevent application submission if required fields are empty.,1,Low,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,MVP - Sept,,,
+psm-FR-7.10,,The PSM shall show integrated history of a provider record -- allow users to scroll back in history to see changes over time without needing to navigate to separate files.,,,LA,PSM State Calls Requirements_functionality needs.xlsx,Beta,,,
+psm-FR-7.11,,The PSM shall validate entered information as provider fills out application (not at the end of the process).,1,High ,OH,PSM State Calls Requirements_functionality needs.xlsx,MVP - Sept,,,
+psm-FR-7.12,,"The PSM shall provide a configurable time frame for a ""stale"" enrollment draft application. ",,,WV,,Beta,,,
+psm-FR-7.13,,The PSM shall support searching and pattern-matching based on all fields accepted as input (and based on all reasonable combinations of such fields).,,,SGC 2018-03-05,,,,,
+psm-FR-7.14,,"The PSM's user interface shall be as simple, comprehensible, navigable, reliable, robust in the face of error, and responsive as possible.",,,SGC 2018-03-05,,Beta,,,
+psm-FR-7.15,,The PSM shall provide instructions for using the application as an administrator via a help link or similar feature.,,,,,,,,
+,8.  Manage Provider Communication,,,,,,,,,
+psm-FR-8.1,,The PSM shall support communications to and from providers and track and monitor responses to the communications.,,,"Pre-certification
+PM.PR1.5",pre-certification-requirements.md,Beta,,,
+psm-FR-8.2,,"The PSM shall generate information requests, correspondence, or notifications based on the status of the application for enrollment.",,,"Pre-certification
+PM.PR1.8",pre-certification-requirements.md,Beta,,,
+psm-FR-8.3,,The PSM shall support automated criminal background checks for all providers as specified by the State.,,,"Pre-certification
+PM.PR2.9",pre-certification-requirements.md,Beta,,,
+psm-FR-8.4,,"The PSM shall produce notices to applicants of pending status, approval, or rejection of their applications.",,,"Pre-certification
+E&E.PR1.1",pre-certification-requirements.md,Beta,,,
+psm-FR-8.5,,"The PSM shall add a attestation, using configurable link or text, to the reading and understanding of the required state Medicaid agency materials prior to enrollment.  ",,,WV,,Release 1,,,
+,9.  Meets architecture guideline,,,,,,,,,
+psm-FR-9.1,,The PSM shall integrate provider-type business rules described in the Enrollment Information Guide into the system.,,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Release 1,,,
+psm-FR-9.2,,The PSM shall integrate records with MO HealthNet.,,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Post R1,,,
+psm-FR-9.3,,The PSM shall support a provider appeals process in compliance with federal guidelines (42 CFR 431.105),,,"Pre-certification
+PM.PR1.6",pre-certification-requirements.md,Release 1,,,
+psm-FR-9.4,,"The PSM shall verify provider eligibility in support of other system processes, i.e. payment of claims.",,,"Pre-certification
+PM.PR2.3",pre-certification-requirements.md,Release 1,,,
+psm-FR-9.5,,The PSM shall ensure proprietary interfaces and protocols between modules are not used.,1,Medium,MT,INR12,MVP - Sept,,,
+,10. Compliance,,,,,,,,,
+psm-FR-10.1,,The PSM shall validate HIPAA Taxonomy codes against http://www.wpc-edi.com/codes/taxonomy,,,MO,MISSOURI MEDICAID PROVIDER ENROLLMENT INFORMATION GUIDE.docx,Release 1,,,
+psm-FR-10.2,,The PSM shall be accessible in compliance with Section 508 of the Rehabilitation Act.,,,SGC 2018-03-05,,Beta,,,

--- a/requirements/csv-exports/reqs-ia.csv
+++ b/requirements/csv-exports/reqs-ia.csv
@@ -1,0 +1,22 @@
+Requirement ID Number,Requirement Category,Requirement Statement,Priority,Rank,Source,Source Document,Release,Design Reference,Acceptance Test Reference,Comment
+,1.  IA Component Name:  Conceptual Data Model (CDM),,,,,,,,,
+psm-IA-1.1,,The PSM shall demonstrate adoption of a CDM that depicts the business area high-level data and general relationships for intrastate exchange.,,,IA.CDM.1,,Beta,,,Evidence: CDM documentation
+psm-IA-1.2,,The PSM shall identify relationships between the PSM and other key entities in the Medicaid enterprise.,,,IA.CDM.2,,Post R1,,,
+,2.  IA Component Name:  Data Management Strategy (DMS),,,,,,,,,
+psm-IA-2.1,,"The PSM shall demonstrate the adoption of an intrastate metadata repository and contribute to the agency definition of the data entities, attributes, data models, and relationships sufficiently to convey the overall meaning and use of Medicaid data and information.",,,IA.DMS.2,,Release 1,,,
+psm-IA-2.2,,"The PSM shall update all historical claim data, recipient enrollment, provider enrollment, and other primary reference data on a scheduled basis.",,,IA.DMS.5,,Alpha,,,
+,3.  IA Component Name:  Data Standards (DS),,,,,,,,,
+psm-IA-3.1,,"The PSM shall, at a minimum, support transfer of provider screening data to and from MMIS and other entities.",,,IA.DS.10,,Beta,,,
+psm-IA-3.2,,"The PSM shall support consumption of data in multiple formats from many sources, such as vital statistics, MCO encounter data, benefit manager encounter data (pharmacy, dental, mental health), waiver program data, and census bureau.",1,High ,IA.DS.11,,MVP - Sept,,,Evidence: demonstrated by interfacing with LEIE data
+psm-IA-3.3,,"The PSM shall require, capture, and maintain the 10-digit national provider identifier.",1,Low,IA.DS.13,,MVP - Sept,,,
+psm-IA-3.4,,The PSM shall accept the national provider identifier in all standard electronic transactions mandated under HIPAA.,,,IA.DS.14,,Post R1,,,N/A
+psm-IA-3.5,,The PSM shall interface with the National Plan and Provider Enumerator System (NPPES) to verify the NPI of provider applicants.,,,IA.DS.15,,Beta,,,
+psm-IA-3.6,,The PSM shall not allow atypical providers to be assigned numbers that duplicate any number assigned by the NPPES.,,,IA.DS.16,,Alpha,,,
+psm-IA-3.7,,"The PSM shall provide the ability to link and de-link to other Medicaid provider IDs for the same provider, (e.g., numbers used before the NPI was established, erroneously issued prior numbers, multiple NPIs for different subparts, etc.). Captures/crosswalks subpart NPIs used by Medicare (but not Medicaid) to facilitate coordination of benefits (COB) claims processing.",,,IA.DS.17,,Post R1,,,
+psm-IA-3.8,,The PSM shall be capable of or support the production of a random sample of data that would be needed for audit purposes based on the state-established selection criteria. ,,,IA.DS.18, ,Post R1,,,
+psm-IA-3.9,,The PSM shall comply with the SMA's standardized structure and vocabulary data for automated electronic intrastate interchanges and interoperability.,,,IA.DS.9,,Alpha,,,
+,4.  IA Component Name:  Logical Data Model (LDM),,,,,,,,,
+psm-IA-4.1,,"The PSM shall support a  Logical Data Model (LDM) in the  identification of data classes, attributes, relationships, standards, and code sets for intrastate exchange.",,,IA.LDM.5,,MVP - Dec,,,
+psm-IA-4.2,,"The PSM shall maintain providers' data (e.g., links from providers to other entities, such as groups, managed care organizations, chains, networks, ownerships, and partnerships).",,,IA.LDM.6,,Alpha,,,
+psm-IA-4.3,,The PSM shall verify that all fields defined as numeric contain only numeric data.,4,Medium,TA.SP.1, ,MVP - Sept,,,
+psm-IA-4.4,,The PSM shall verify that all fields defined as alphabetic contain only alphabetic data.,4,Medium,TA.SP.2,,MVP - Sept,,,

--- a/requirements/csv-exports/reqs-ii.csv
+++ b/requirements/csv-exports/reqs-ii.csv
@@ -1,0 +1,23 @@
+Requirement ID Number,Requirement Category,Requirement Statement,Priority,Rank,Source,Source Document,Release,Design Reference,Acceptance Test Reference,Comment
+,1.  Technical Service Classification:  Business Process Management,,,,,,,,,
+psm-II-1.1,,The PSM shall use a mix of manual and automated business processes.,4,Low,TA.BPM.4,,MVP - Sept,,,
+,2.  Technical Service Classification:  Data Connectivity,,,,,,,,,
+psm-II-2.1,,The PSM shall perform advanced information monitoring and routes system alerts and alarms to communities of interest when the system detects unusual conditions.,,,TA.DC.7,,Beta,,,Log file and screen alert to the operator (e.g. lost connectivity to external system/database)
+psm-II-2.2,,The PSM shall use a standards for message format to ensure interoperability (e.g. XML JSON),,,TA.DC.9,,Alpha,,,
+psm-II-2.3,,"Transport interoperability - 
+The PSM shall comply with standard data transfer protocols as applicable to health IT systems, their constituent elements/modules, and services",2,High ,NEW1,,MVP - Sept,,,Currently using FHIR protocol 
+psm-II-2.4,,"Syntactic interoperability - 
+The PSM shall comply with national standards for data message formatting, as applicable to health IT systems, their constituent elements/modules, and services ",,,NEW2,,Alpha,,,
+psm-II-2.5,,"Semantic interoperability - 
+The PSM shall use standardized code sets to enable the processing and interpretation of received data as applicable to health IT systems.",,,NEW3,,Alpha,,,"Evidence: PSM is currently using NPI as a standardized code set demonstration, allowing loading of the provider type code "
+,3.  Technical Service Classification:  Service Oriented Architecture,,,,,,,,,
+psm-II-3.1,,"The PSM shall adopt MITA-recommended ESB, automated arrangement, coordination, and management of system.",,,TA.SOA.1,,Release 1,,,
+psm-II-3.2,,"The PSM shall conduct reliable messaging, including guaranteed message delivery (without duplicates) and support for non-deliverable messages.",,,TA.SOA.2,,Release 1,,,Evidence: documentation for ESB integration
+,4.  Technical Service Classification:  System Extensibility,,,,,,,,,
+psm-II-4.1,,The PSM shall use RESTful and/or SOAP-based web services for seamless coordination and integration with other U.S. Department of Health & Human Services (HHS) applications and intrastate agencies.,,,TA.SE.2,,MVP - Dec,,,
+psm-II-4.2,,"The PSM shall document all interfaces in an Interface Control Document (ICD), along with how those interfaces are maintained.",,,TA.SE.3,,MVP - Dec,,,
+psm-II-4.3,,"Loosely coupled APIs - 
+The PSM module dependencies shall be minimized to the greatest extent possible.",2,Medium,S&C.MS.14,,MVP - Sept,,,
+psm-II-4.4,,"Clearly documented - 
+The PSM shall provide detailed API documentation provided for every API. ",2,Medium,S&C.MS.14,,MVP - Sept,,,
+psm-II-4.5,,The PSM shall be configurable where feasible.,,,SGC 2018-03-05,,Release 1,,,

--- a/requirements/csv-exports/reqs-iu.csv
+++ b/requirements/csv-exports/reqs-iu.csv
@@ -1,0 +1,16 @@
+Requirement ID Number,Requirement Category,Requirement Statement,Priority,Rank,Source,Source Document,Release,Design Reference,Acceptance Test Reference,Comment
+,1.  Technical Service Classification:  Configuration Management,,,,,,,,,
+psm-IU-1.1,,The PSM shall use technology-neutral interfaces that localize and minimize impact of new technology insertion.,1,Low,TA.CM.4,,MVP - Sept,,,
+,2.  Technical Service Classification:  Data Access and Management,,,,,,,,,
+psm-IU-2.1,,The PSM shall maintain online access to at least four years of selected management reports and five years of annual reports.,,,TA.DAM.1,,Post R1,,,"Currently there is no reporting planned for PSM.  However, there is no plan to delete the data in the database."
+psm-IU-2.2,,"The PSM shall conduct information exchange (internally and externally) using MITA Framework, industry standards, and other nationally recognized standards.",2,High ,TA.DAM.2,,MVP - Sept,,,
+psm-IU-2.3,,The PSM shall develop data models that include mapping of information exchange with external organizations.,,,TA.DAM.3,,Alpha,,,
+psm-IU-2.4,,The PSM shall apply single source of information methodologies.,3,Medium,TA.DAM.7,,MVP - Sept,,,
+psm-IU-2.5,,The PSM shall provide full-text search capability,,,CMS ,,Beta,,,This is requested by Anshuman during the 8/10/17 PSM status meeting
+,3.  Technical Service Classification:  Decision Management,,,,,,,,,
+psm-IU-3.1,,The PSM of shall use standardized business rules definitions that reside in a separate application or rules engine.,,,TA.DM.1,,Alpha,,,
+psm-IU-3.2,,The PSM shall use rules editor that maintains the current version of standardized business rules definitions in a language that business people can interpret and transforms them into machine language to automate them.,,,TA.DM.2,,Alpha,,,
+,4.  Technical Service Classification:  Logging,,,,,,,,,
+psm-IU-4.1,,"The PSM shall support an authorized user access to user activity history and other management functions, including log-on approvals/ disapprovals and log search and playback.",,,TA.LG.1,,Beta,,,
+psm-IU-4.2,,The PSM shall define information sharing and event notification standards to allow aggregated and integrated information.,,,TA.LG.2,,Post R1,,,
+psm-IU-4.3,,The PSM shall provide an architecture diagram depicting how it is technically structured.,,,CMS,,MVP - Dec,,,This is requested by Anshuman during the 8/10/17 PSM status meeting

--- a/requirements/csv-exports/reqs-ph.csv
+++ b/requirements/csv-exports/reqs-ph.csv
@@ -1,0 +1,6 @@
+Requirement ID Number,Requirement Category,Requirement Statement,Priority,Rank,Source,Source Document,Release,Design Reference,Acceptance Test Reference,Comment
+,1.  CSF PH2: Provider claims are adjudicated accurately within established time parameters.,,,,,,,,,
+psm-PH-1.1,,The PSM shall verify that required data items are present and retained (See SMM 11375) including all data needed for State or Federal reporting requirements.,,,OM.PH2.10,,Release 1,,,
+psm-PH-1.2,,"The PSM shall check Provider Screening Applications to ensure that all required attachments, per the reference records or edits, have been received and maintained for audit purposes or have been submitted prior to the Provider Screening Applications and a prior authorization has been established.",,,OM.PH2.17,,Beta,,,
+psm-PH-1.3,,The PSM shall verify that all data necessary for legal requirements are retained.,,,OM.PH2.21,,Beta,,,
+psm-PH-1.4,,The PSM shall verify that all dates are valid and reasonable.,,,OM.PH2.6,,Alpha,,,

--- a/requirements/csv-exports/reqs-sc.csv
+++ b/requirements/csv-exports/reqs-sc.csv
@@ -1,0 +1,14 @@
+Requirement ID Number,Requirement Category,Requirement Statement,Priority,Rank,Source,Source Document,Release,Design Reference,Acceptance Test Reference,Comment
+,1.  S&C:  Business Results Condition,,,,,,,,,
+psm-SC-1.1,,"The PSM shall accommodate customer preferences for communications by email, text, mobile devices, or phones.",,,S&C.BRC.5,,Post R1,,,
+,2.  S&C:  Industry Standards Condition,,,,,,,,,
+psm-SC-2.1,,The PSM shall comply with standards and protocols adopted by the Secretary under sections 1104 and 1561 of the Affordable Care Act. ,,,S&C.ISC.6,,Release 1,,,N/A - 1104 and 1561 are for individuals and not providers
+,3.  S&C:  Interoperability Condition,,,,,,,,,
+psm-SC-3.1,,"The PSM shall support the architecture adopted to preserve the ability to efficiently, effectively, and appropriately exchange data with other participants in the health and human services enterprise.",,,S&C.IC.6,,MVP - Dec,,,Satified with the API requirements
+,4.  S&C:  Modularity Standard,,,,,,,,,
+psm-SC-4.0,,The PSM shall use regionally standardized business rule definitions in both human and machine-readable formats.,,,S&C.MS.10,,,,,No in the pre-cert check list but PSM will do this
+psm-SC-4.1,,The PSM shall contain modules that can be interchanged without major system design.,2,Medium,S&C.MS.14,,MVP - Sept,,,Evidence: have an architecture diagram showing rules engine is an separate component
+psm-SC-4.2,,The PSM shall use an intrastate rules engine separate from core programming with established interstate standardized business rules definitions.,2,Medium,S&C.MS.16,,MVP - Sept,,,Evidence: have an architecture diagram showing rules engine is an separate component
+psm-SC-4.3,,"The PSM design documents shall utilize a widely supported modeling language (e.g., UML, BPMN).",,,S&C.MS.18,,MVP - Dec,,,
+psm-SC-4.4,,The PSM shall support open standards between key interfaces have been considered for all and chosen where feasible.,1,Medium,S&C.MS.2,,MVP - Sept,,,
+psm-SC-4.5,,The PSM shall support Modularity verification through extensive testing that demonstrates compliance with  chosen interface standards and specifications.,,,S&C.MS.4,,Release 1,,,

--- a/requirements/csv-exports/reqs-sq.csv
+++ b/requirements/csv-exports/reqs-sq.csv
@@ -1,0 +1,8 @@
+Requirement ID Number,Requirement Category,Requirement Statement,Priority,Rank,Source,Source Document,Release,Design Reference,Acceptance Test Reference,Comment
+,1.  Software Quality and Maintainability,,,,,,,,,
+psm-SQ-1.1,,The PSM shall have an open source repository and source code base organized to be welcoming to outside contributors.,,,,,,,,
+psm-SQ-1.2,,"The PSM shall include and undergo automated testing at regular intervals, through continuous integration and deployment processes.  The PSM shall also undergo manual testing and QA as needed.",,,,,,,,
+psm-SQ-1.3,,"The PSM shall use modern source code dependency management techniques, and shall use up-to-date versions of upstream third-party dependencies and formats.",,,,,,,,
+psm-SQ-1.4,,"The PSM shall use documented build, test, release, and installation processes that are automated as much as possible, for both development and production use.",,,,,,,,
+psm-SQ-1.5,,"The PSM shall use D.R.Y. coding principles to avoid unnecessary complexity, inflexibility, redundancy, and denormalization in the source code and database schemas, and to use precise terminology in data structures and operations.",,,,,,,,
+psm-SQ-1.6,,The PSM shall use system resources efficiently and in proportion to operational demands and data size.,,,,,,,,

--- a/requirements/notes-on-potential-new-reqs.txt
+++ b/requirements/notes-on-potential-new-reqs.txt
@@ -1,0 +1,23 @@
+Notes on some issues that may warrant creating new reqs that fit them better.
+
+1. Issues related to fostering the user community (as opposed to the 
+developer/contributor community), and other outward facing promotional stuff:
+
+  394 - Systematize and advertise online PSM community of practice
+  395 - Create standalone PSM brochure website
+  439 - Auto-update standalone user docs website and PDF
+  458 - bundle user & developer docs for psm-dev
+
+2. Issues relating to code quality in terms of separation of concerns, 
+modularity, avoiding unnecessary coupling.
+
+  599 - Stop checking for access permissions for system-internal lookups
+  653 - Remove styles from labels
+
+3. Issues on being state-agnostic/generic, not hard-coding one state.
+
+  655 - Remove or generify UMPI field
+
+Karl thought 599, 653, and 655 were covered by SQ-1.5.  Paul when first
+making these notes was taking a narrower interpretation of D.R.Y. principles.
+Left in the notes here for follow-up as needed.

--- a/requirements/psm-reqs.el
+++ b/requirements/psm-reqs.el
@@ -1,0 +1,175 @@
+;;;; Emacs Lisp helpers for dealing with PSM requirements.
+
+(defvar psm-reqs
+  "An alist of PSM requirements.  Each element maps a symbol to a string:
+
+    '((id \"psm-FR-5.2\")
+      (category \"FR 5. Manage Enrollment\")
+      (description \"The PSM shall allow providers to terminate their ...\")
+      (comment \"PSM should capture a termination reason code. ...\"))
+  
+  Use `psm-load-reqs' to initialize this."
+  nil)
+
+(defun psm-load-reqs (file)
+  "Load PSM requirements from a FILE generated with 'show-reqs elisp'.
+E.g., run './show-reqs elisp > reqs.eld' at a shell prompt, and then
+run `M-x psm-load-reqs' in Emacs and give the path to 'reqs.eld' when
+prompted for a file name."
+  (interactive "fLoad PSM requirements from file: ")
+  (save-excursion
+    (let* ((large-file-warning-threshold nil)
+           (buf (find-file-noselect file)))
+      (set-buffer buf)
+      (goto-char (point-min))
+      (setq psm-reqs (read (current-buffer)))
+      (kill-buffer (current-buffer)))))
+
+(defun psm-get-req (req-name)
+  "Return the req object for req identifier REQ-NAME, else nil.
+REQ-NAME can be in non-canonical case."
+  (let ((req-name (psm-req-case-canonicalize-name req-name)))
+    (cl-some (lambda (candidate)
+               (when (string-equal
+                      req-name (cadr (assq 'id candidate)))
+                 candidate))
+             psm-reqs)))
+
+(defun psm-req-case-canonicalize-name (req-name)
+  "Return a canonicalized version of REQ-NAME.
+Canonicalized means ensuring that the \"psm-\" prefix
+is on the front and is lower-case, and that the
+two-letter subcode is upper case.  For example, this
+would convert \"PSM-fr-5.2\" to \"psm-FR-5.2\", and
+would convert \"fr-5.2\" to \"psm-FR-5.2\"."
+  (let ((new-req-name (copy-sequence req-name)))
+    (save-match-data
+      ;; I wish Elisp had `starts-with'.  There's
+      ;; `bash-completion-starts-with', in the emacs-bash-completion
+      ;; project, and its implementation is very simple:
+      ;;
+      ;;   (defun bash-completion-starts-with (str prefix)
+      ;;     "Return t if STR starts with PREFIX."
+      ;;     (let ((prefix-len (length prefix))
+      ;;   	(str-len (length str)))
+      ;;       (and
+      ;;        (>= str-len prefix-len)
+      ;;        (string= (substring str 0 prefix-len) prefix))))
+      ;;
+      ;; But this is not the place, and now is not the time.
+      (when (not (string-match "^psm-" new-req-name))
+        (setq new-req-name (concat "psm-" new-req-name))))
+    (aset new-req-name 0 (downcase (aref new-req-name 0)))
+    (aset new-req-name 1 (downcase (aref new-req-name 1)))
+    (aset new-req-name 2 (downcase (aref new-req-name 2)))
+    (aset new-req-name 4 (upcase (aref new-req-name 4)))
+    (aset new-req-name 5 (upcase (aref new-req-name 5)))
+    new-req-name))
+
+(defun psm-req-name-at-point ()
+  "Return the req name at point, canonicalized.
+The req name may have the \"psm-\" prefix but does not require it."
+  (let* ((raw (thing-at-point 'filename t))
+         (len (length raw)))
+    (when (< len 6)
+      (error "'%s' is too short to be a PSM req ID" raw))
+    (let ((case-fold-search t))
+      (save-match-data
+        (if (string-match "\\(psm-\\)?[A-Z][A-Z]-[0-9]+\\.[0-9]+" raw)
+            ;; The regexp above doesn't begin with "^" nor
+            ;; end with "$" because `thing-at-point' may
+            ;; include leading or trailing garbage.  E.g., in
+            ;; "psm-FR-1.1, psm-FR-1.2, psm-FR-1.3", calling
+            ;; with point on either of the first two would
+            ;; include the trailing comma.  Here we strip
+            ;; off stuff that isn't part of the ID.
+            (setq raw (match-string 0 raw))
+          (error "'%s' doesn't look like a PSM req ID" raw))))
+    (psm-req-case-canonicalize-name raw)))
+
+;; Went back and forth on using `cl-defstruct' for this.
+(defmacro psm-req-get (req field)
+  `(cadr (assq ,field ,req)))
+
+(defun psm-insert-req-summary (req-name)
+  "Insert a summary of REQ-NAME, preserving fill from bol to point."
+  (let* ((req  (psm-get-req req-name))
+         (desc (psm-req-get req 'description))
+         (cat  (psm-req-get req 'category))
+         (prefix (buffer-substring
+                  (point) (save-excursion (beginning-of-line) (point)))))
+      (insert desc "\n")
+      (let ((opoint (point-marker)))
+        (forward-line -1)
+        (fill-paragraph)
+        (goto-char opoint))
+      (insert prefix "<<< " cat " >>>\n")))
+
+(defun psm-show-req (&optional verbose)
+  "Show information of the requirement point is currently in.
+For example, if point is in the string \"psm-FR-5.2\",
+then display (using as little screen space as possible)
+the requirement's name, category, description, and any comment.
+
+If prefix argument VERBOSE is non-nil, show all details about
+the requirement (e.g., source, release, etc)."
+  (interactive "P")
+  (let* ((req-name                 (psm-req-name-at-point))
+         (req                      (psm-get-req req-name))
+         (req-id                   (psm-req-get req 'id))
+         (req-description          (psm-req-get req 'description))
+         (req-category             (psm-req-get req 'category))
+         (req-comment              (psm-req-get req 'comment))
+         (req-priority             (psm-req-get req 'priority))
+         (req-rank                 (psm-req-get req 'rank))
+         (req-source               (psm-req-get req 'source))
+         (req-source-doc           (psm-req-get req 'source-doc))
+         (req-release              (psm-req-get req 'release))
+         (req-design-ref           (psm-req-get req 'design-ref))
+         (req-acceptance-test-ref  (psm-req-get req 'acceptance-test-ref))
+         (buf              (get-buffer-create "*PSM req*")))
+    (save-excursion
+      (set-buffer buf)
+      (delete-region (point-min) (point-max))
+      (put-text-property 0 (length req-id) 'face
+                         '(:weight bold :underline t)
+                         req-id)
+      (insert (format "%s" req-id))
+      (insert (format "         (%s)\n\n" req-category))
+      (insert (format "%s\n\n" req-description))
+      (forward-char -2)
+      (let ((fill-prefix nil))
+        (fill-paragraph))
+      (goto-char (point-max))
+      ;; Comments are especially likely to be multi-line,
+      ;; so handle them specially.
+      (when (and req-comment (not (string-equal req-comment "")))
+        (insert (if verbose "Comment: " "COMMENT: ")
+                (format "%s\n\n" req-comment))
+        (forward-char -2)
+        (let ((fill-prefix "         "))
+          (fill-paragraph))
+        (goto-char (point-max)))
+      (when verbose
+        ;; Expect any other optional fields to be one line.
+        (dolist (field '(req-priority req-rank req-source req-source-doc
+                                      req-release req-design-ref
+                                      req-acceptance-test-ref))
+          (let ((val (symbol-value field))
+                (label (capitalize (substring (symbol-name field) 4))))
+            (when val
+              (insert label ": ")
+              (insert val "\n\n")))))
+      ;; Because display-buffer ignores trailing blank lines when
+      ;; calculating the optimum window size, we insert an invisible
+      ;; character at the end to force the spacing to be such that the
+      ;; description (and comment, if any) are vertically centered.
+      (insert ".")
+      (put-text-property (- (point) 1) (point) 'invisible t)
+      ;; Put point at the top, lest the displayed window default to
+      ;; the wrong part of the text.
+      (goto-char (point-min)) (end-of-line)
+      (display-buffer buf
+                      '(display-buffer-at-bottom
+                        . ((window-height
+                            . fit-window-to-buffer)))))))

--- a/requirements/psm_reqs.py
+++ b/requirements/psm_reqs.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Ingest PSM requirements from CSV files and make them available in Python.
+#
+# Copyright (C) 2018 Open Tech Strategies, LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+__doc__ = """Module for working with PSM requirements."""
+
+import csv
+import re
+from warnings import warn
+
+
+class PSMRequirement():
+    """Class representing one requirement."""
+    req_family_re = re.compile("psm-([A-Z][A-Z])-[0-9.]+")
+    def __init__(self,
+                 family,
+                 #                     # ----------------------------
+                 #                     #       CSV header name
+                 #                     # ----------------------------
+                 req_id,               # "Requirement ID Number"
+                 category,             # "Requirement Category"
+                 description,          # "Requirement Statement"
+                 priority,             # "Priority"
+                 rank,                 # "Rank"
+                 source,               # "Source"
+                 source_doc,           # "Source Document"
+                 release,              # "Release"
+                 design_ref,           # "Design Reference"
+                 acceptance_test_ref,  # "Acceptance Test Reference"
+                 comment               # "Comment"
+                 ):
+        """FAMILY is a two-letter string indicating the requirements
+        family, for example "FR", "IA", etc.  Every other parameter
+        corresponds self-explanatorily to a CSV field."""
+        self.family              = family
+        self.req_id              = req_id
+        self.category            = category
+        self.description         = description
+        self.priority            = priority
+        self.rank                = rank
+        self.source              = source
+        self.source_doc          = source_doc
+        self.release             = release
+        self.design_ref          = design_ref
+        self.acceptance_test_ref = acceptance_test_ref
+        self.comment             = comment
+        # Sanity check the req family.
+        m = self.req_family_re.match(self.req_id)
+        if m is None:
+            warn("WARNING: No requirement family found for \"%s\"" % self.req_id)
+        elif m.group(1) != family:
+            warn("WARNING: family \"%s\" does not match req \"%s\"" % (family, self.req_id))
+
+    def __str__(self):
+        # We don't include self.family because it's implicit in self.req_id.
+        return """\
+        Requirement ID Number:     "%s"
+        Requirement Category:      "%s"
+        Requirement Statement:     "%s"
+        Priority:                  "%s"
+        Rank:                      "%s"
+        Source:                    "%s"
+        Source Document:           "%s"
+        Release:                   "%s"
+        Design Reference:          "%s"
+        Acceptance Test Reference: "%s"
+        Comment:                   "%s"\n""" \
+            % (self.req_id.replace('"', '\\"'),
+               self.category.replace('"', '\\"'),
+               self.description.replace('"', '\\"'),
+               self.priority.replace('"', '\\"'),
+               self.rank.replace('"', '\\"'),
+               self.source.replace('"', '\\"'),
+               self.source_doc.replace('"', '\\"'),
+               self.release.replace('"', '\\"'),
+               self.design_ref.replace('"', '\\"'),
+               self.acceptance_test_ref.replace('"', '\\"'),
+               self.comment.replace('"', '\\"'))
+
+
+class PSMRequirementException(Exception):
+    "Exception raised if something is wrong about a requirement."
+    pass
+
+
+class PSMRequirementFamilyException(Exception):
+    "Exception raised if something is wrong about a requirement family."
+    pass
+
+
+def get_reqs(*csv_files):
+    """Return a dictionary of PSMRequirements based on CSV_FILES.
+    CSV_FILES is an array of (string) paths to CSV files.
+    Return a dict mapping PSM req IDs to PSMRequirement instances."""
+    reqs = {}
+    families_seen = set()
+    for csv_file_name in csv_files:
+        family = None # two-letter req family code, e.g, "FR", "IA", etc
+        m = re.match(".*reqs-([a-z][a-z])\.csv", csv_file_name)
+        if m is None:
+            raise PSMRequirementFamilyException(
+                "ERROR: unable to identify requirement family "
+                "from \"%s\"" % csv_file_name)
+        family = m.group(1).upper()
+        if family in families_seen:
+            raise PSMRequirementFamilyException(
+                "ERROR: encountered family '%s' more than once" % family)
+        else:
+            families_seen.add(family)
+        with open(csv_file_name) as csv_file:
+            csv_reader = csv.reader(csv_file)
+            next(csv_reader)  # toss one row to skip the headers
+            current_category = None
+            for row in csv_reader:
+                if row[1] != "":    # this is a category row
+                    if row[0] != "":
+                        warn("WARNING: category '%s' and req '%s' in same row" % (row[1], row[0]))
+                    current_category = family + " " + row[1]
+                elif row[0] != "":  # this is a requirement row
+                    if current_category is not None:
+                        row[1] = current_category
+                    else:
+                        warn("WARNING: requirement '%s' has no category" % (row[0]))
+                    req = PSMRequirement(family, *row)
+                    if req.req_id in reqs:
+                        # Can't happen, but let's be extra careful.
+                        raise PSMRequirementFamilyException(
+                            "ERROR: encountered req '%s' more than once" % req.req_id)
+                    reqs[req.req_id] = req
+                else:
+                    warn("WARNING: not really sure what this row is:")
+                    warn("%s" % PSMRequirement(family, *row))
+    return reqs
+

--- a/requirements/psm_reqs.py
+++ b/requirements/psm_reqs.py
@@ -104,7 +104,7 @@ class PSMRequirementFamilyException(Exception):
     pass
 
 
-def get_reqs(*csv_files):
+def get_reqs(csv_files):
     """Return a dictionary of PSMRequirements based on CSV_FILES.
     CSV_FILES is an array of (string) paths to CSV files.
     Return a dict mapping PSM req IDs to PSMRequirement instances."""

--- a/requirements/reqs2any
+++ b/requirements/reqs2any
@@ -19,10 +19,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 __doc__ = """\
-Usage:
-
-  $ reqs2any [ --output=OUTPUT_FORMAT ] CSV_FILE
-
 Convert a single CSV file of requirements to OUTPUT_FORMAT.  The two
 supported output formats so far are "human" (the default) and "elisp".
 
@@ -30,49 +26,32 @@ Note: This requires the psm_reqs.py module to be available in the
 Python import path (typically it is in the same directory).
 """
 
+import argparse
 import sys
-import getopt
 import psm_reqs
+
+
+def parse_args():
+    """Parse the arguments from the command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--output',
+        choices=['human', 'elisp'],
+        default='human',
+        dest='output_format'
+    )
+    parser.add_argument(
+        'csv_file',
+        nargs='+',
+    )
+    return parser.parse_args()
 
 
 def main():
     """Create wiki pages from a supplied CSV."""
-    output_format = None
+    args = parse_args()
 
-    try:
-        opts, args = getopt.getopt(sys.argv[1:], 'h?q',
-                                   ["help", "usage", "output="])
-    except getopt.GetoptError as err:
-        sys.stderr.write("ERROR: '%s'\n" % err)
-        usage(errout=True)
-        sys.exit(2)
-
-    for o, a in opts:
-        if o in ("-h", "-?", "--help", "--usage",):
-            print("%s" % __doc__)
-            sys.exit(0)
-        elif o in ("--output",):
-            output_format = a
-        else:
-            sys.stderr.write("ERROR: unrecognized option '%s'\n" % o)
-            sys.exit(1)
-
-    if output_format is None:
-        output_format = "human"
-
-    if not (output_format in ("human", "elisp",)):
-        sys.stderr.write("ERROR: unrecognized output format '%s'\n"
-                         % output_format)
-        sys.exit(1)
-
-    if len(args) < 1:
-        sys.stderr.write("ERROR: CSV input file(s) required\n")
-        sys.stderr.write("\n")
-        sys.stderr.write("%s" % __doc__)
-        sys.exit(1)
-
-    reqs = psm_reqs.get_reqs(*args)
-
+    reqs = psm_reqs.get_reqs(args.csv_file)
     # Note that we'll print the requirements in whatever order we
     # received them via CSV files, because iteration over dicts
     # in Python will now (or will soon) preserve insertion order:
@@ -85,10 +64,10 @@ def main():
     # However, that would not work quite the way we want, because,
     # for example, "psm-FR-3.3" would sort after "psm-FR-3.25".
     for req in reqs.values():
-        if output_format == "human":
+        if args.output_format == "human":
             print("%s" % req)
             print("===================================")
-        elif output_format == "elisp":
+        elif args.output_format == "elisp":
             # Every req has at least these fields.
             print("  ((id \"%s\")\n"
                   "   (category \"%s\")\n"
@@ -113,7 +92,7 @@ def main():
         else:
             sys.stderr.write("ERROR: unknown output format '%s' "
                              "should have been caught earlier\n"
-                             % output_format)
+                             % args.output_format)
             sys.exit(1)
 
 

--- a/requirements/reqs2any
+++ b/requirements/reqs2any
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Print out PSM reqs (obtained from CSV) in a specified format.
+#
+# Copyright (C) 2018 Open Tech Strategies, LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+__doc__ = """\
+Usage:
+
+  $ reqs2any [ --output=OUTPUT_FORMAT ] CSV_FILE
+
+Convert a single CSV file of requirements to OUTPUT_FORMAT.  The two
+supported output formats so far are "human" (the default) and "elisp".
+
+Note: This requires the psm_reqs.py module to be available in the
+Python import path (typically it is in the same directory).
+"""
+
+import sys
+import getopt
+import psm_reqs
+
+
+def main():
+    """Create wiki pages from a supplied CSV."""
+    output_format = None
+
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'h?q',
+                                   ["help", "usage", "output="])
+    except getopt.GetoptError as err:
+        sys.stderr.write("ERROR: '%s'\n" % err)
+        usage(errout=True)
+        sys.exit(2)
+
+    for o, a in opts:
+        if o in ("-h", "-?", "--help", "--usage",):
+            print("%s" % __doc__)
+            sys.exit(0)
+        elif o in ("--output",):
+            output_format = a
+        else:
+            sys.stderr.write("ERROR: unrecognized option '%s'\n" % o)
+            sys.exit(1)
+
+    if output_format is None:
+        output_format = "human"
+
+    if not (output_format in ("human", "elisp",)):
+        sys.stderr.write("ERROR: unrecognized output format '%s'\n"
+                         % output_format)
+        sys.exit(1)
+
+    if len(args) < 1:
+        sys.stderr.write("ERROR: CSV input file(s) required\n")
+        sys.stderr.write("\n")
+        sys.stderr.write("%s" % __doc__)
+        sys.exit(1)
+
+    reqs = psm_reqs.get_reqs(*args)
+
+    # Note that we'll print the requirements in whatever order we
+    # received them via CSV files, because iteration over dicts
+    # in Python will now (or will soon) preserve insertion order:
+    # https://mail.python.org/pipermail/python-dev/2017-December/151283.html
+    #
+    # We could also print them out sorted lexically by req ID, with:
+    #
+    #   for req in [reqs[key] for key in sorted(reqs)]:
+    #
+    # However, that would not work quite the way we want, because,
+    # for example, "psm-FR-3.3" would sort after "psm-FR-3.25".
+    for req in reqs.values():
+        if output_format == "human":
+            print("%s" % req)
+            print("===================================")
+        elif output_format == "elisp":
+            # Every req has at least these fields.
+            print("  ((id \"%s\")\n"
+                  "   (category \"%s\")\n"
+                  "   (description \"%s\")"
+                  % (req.req_id.replace('"', '\\"'),
+                     req.category.replace('"', '\\"'),
+                     req.description.replace('"', '\\"')))
+            # Each of these fields is optional
+            for elisp_symbol, req_field in (
+                    ("comment", req.comment,),
+                    ("priority", req.priority,),
+                    ("rank", req.rank,),
+                    ("source", req.source,),
+                    ("source-doc", req.source_doc,),
+                    ("release", req.release,),
+                    ("design-ref", req.design_ref,),
+                    ("acceptance-test-ref", req.acceptance_test_ref,),):
+                if (req_field is not None) and (req_field != ""):
+                    print("   (%s \"%s\")" % (elisp_symbol, req_field))
+            # Close out this req's sublist.
+            print("  )")
+        else:
+            sys.stderr.write("ERROR: unknown output format '%s' "
+                             "should have been caught earlier\n"
+                             % output_format)
+            sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements/show-reqs
+++ b/requirements/show-reqs
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+OUTPUT_FORMAT="${1}"
+
+if [ "${1}" != "human" -a "${1}" != "elisp" ]; then
+  echo 'Must pass "human" or "elisp" argument to indicate output format.'
+  exit 1
+fi
+
+if [ "${OUTPUT_FORMAT}" = "elisp" ]; then 
+  echo "("
+fi
+
+./reqs2any --output="${OUTPUT_FORMAT}" \
+   csv-exports/reqs-fr.csv             \
+   csv-exports/reqs-ii.csv             \
+   csv-exports/reqs-sc.csv             \
+   csv-exports/reqs-ia.csv             \
+   csv-exports/reqs-iu.csv             \
+   csv-exports/reqs-ad.csv             \
+   csv-exports/reqs-sq.csv             \
+   csv-exports/reqs-ph.csv
+
+if [ "${OUTPUT_FORMAT}" = "elisp" ]; then 
+  echo ")"
+fi


### PR DESCRIPTION
Make the PSM's Requirements Traceability Matrix (RTM) available in
various parseable formats, and map between requirement IDs and issues
(up through issue 740), all for the 'psm-dashboard' project.

This is really a squashing of commits c077cc0c - b07f2074 (by various
authors) on the 'rtm-issue-linking' branch, plus a few more changes.

Note this manually merges commit 548b2c486e (from master) to RTM.xlsx.
That commit added one requirement to RTM.xlsx.  We manually replicate
that change here, so that when this branch is merged to master, we can
just take the branch's version of RTM.xlsx (there are no other changes
to it since the branch was made).  Also, we put the new req into the
appropriate CSV export file here.