### PR TITLE
Remove unused screening-related methods

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
@@ -16,8 +16,6 @@
 
 package gov.medicaid.services.impl;
 
-import java.util.Date;
-
 import gov.medicaid.entities.ScreeningSchedule;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ScreeningService;
@@ -115,9 +113,5 @@ public class ScreeningServiceBean extends BaseService implements ScreeningServic
 
     }
 
-    @Override
-    public void scheduleScreening(long id, Date date) throws PortalServiceException {
-
-    }
 }
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
@@ -91,27 +91,4 @@ public class ScreeningServiceBean extends BaseService implements ScreeningServic
             throw new PortalServiceException("Could not database complete operation.", e);
         }
     }
-
-    @Override
-    public void performScreeningById(long enrollmentId) throws PortalServiceException {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public void scheduleMediCareProgramDataChange(int time) throws PortalServiceException {
-
-    }
-
-    @Override
-    public void scheduleRevalidation(int time, long userId) throws PortalServiceException {
-
-    }
-
-    @Override
-    public void scheduleScreening(int time) throws PortalServiceException {
-
-    }
-
 }
-

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
@@ -95,12 +95,6 @@ public class ScreeningServiceBean extends BaseService implements ScreeningServic
     }
 
     @Override
-    public void performScreening(long userId) throws PortalServiceException {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
     public void performScreeningById(long enrollmentId) throws PortalServiceException {
         // TODO Auto-generated method stub
 

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -283,7 +283,6 @@
         parent="BaseController">
     <property name="businessProcessService" ref="BusinessProcessService"/>
     <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-    <property name="screeningService" ref="ScreeningService"/>
     <property name="helpService" ref="HelpService"/>
     <property name="eventService" ref="EventService"/>
     <property name="lookupService" ref="LookupService"/>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -603,26 +603,6 @@ public class EnrollmentController extends BaseController {
     }
 
     /**
-     * This action will initiated an immediate screening of the enrollment.
-     *
-     * @param id the profile ID
-     * @return the status
-     * @endpoint "/agent/enrollment/screen"
-     */
-    @RequestMapping("/agent/enrollment/screen")
-    @ResponseBody
-    public StatusDTO initiateOnDemandScreening(@RequestParam("id") long id) {
-        StatusDTO statusDTO = new StatusDTO();
-        try {
-            screeningService.performScreening(id);
-            statusDTO.setSuccess(true);
-        } catch (PortalServiceException ex) {
-            statusDTO.setMessage(USER_ERROR_MSG);
-        }
-        return statusDTO;
-    }
-
-    /**
      * This action will initiated a screening of the enrollment at the given
      * date.
      *

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -60,7 +60,6 @@ import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 import gov.medicaid.services.ProviderTypeService;
-import gov.medicaid.services.ScreeningService;
 import org.jbpm.task.query.TaskSummary;
 import org.springframework.beans.propertyeditors.CustomDateEditor;
 import org.springframework.web.bind.WebDataBinder;
@@ -108,8 +107,6 @@ public class EnrollmentController extends BaseController {
 
     private BusinessProcessService businessProcessService;
 
-    private ScreeningService screeningService;
-
     private HelpService helpService;
 
     private EventService eventService;
@@ -133,9 +130,6 @@ public class EnrollmentController extends BaseController {
     @PostConstruct
     protected void init() {
         super.init();
-        if (screeningService == null) {
-            throw new PortalServiceConfigurationException("screeningService is not configured correctly.");
-        }
         if (enrollmentService == null) {
             throw new PortalServiceConfigurationException("enrollmentService is not configured correctly.");
         }
@@ -608,10 +602,6 @@ public class EnrollmentController extends BaseController {
 
     public void setEventService(EventService eventService) {
         this.eventService = eventService;
-    }
-
-    public void setScreeningService(ScreeningService screeningService) {
-        this.screeningService = screeningService;
     }
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -602,36 +602,6 @@ public class EnrollmentController extends BaseController {
         return "redirect:/ops/viewDashboard";
     }
 
-    /**
-     * This action will initiated a screening of the enrollment at the given
-     * date.
-     *
-     * @param id   the profile ID
-     * @param date the date of the requested screening
-     * @return the status
-     * @throws IllegalArgumentException if date is null or is a date in the past
-     * @endpoint "/agent/enrollment/schedule"
-     */
-    @RequestMapping("/agent/enrollment/schedule")
-    @ResponseBody
-    public StatusDTO initiateScheduledScreening(
-            @RequestParam("id") long id,
-            @RequestParam("date") Date date
-    ) {
-        if (date == null || date.before(new Date())) {
-            throw new IllegalArgumentException("A valid future date must be specified.");
-        }
-
-        StatusDTO statusDTO = new StatusDTO();
-        try {
-            screeningService.scheduleScreening(id, date);
-            statusDTO.setSuccess(true);
-        } catch (PortalServiceException ex) {
-            statusDTO.setMessage(USER_ERROR_MSG);
-        }
-        return statusDTO;
-    }
-
     public void setHelpService(HelpService helpService) {
         this.helpService = helpService;
     }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -603,37 +603,6 @@ public class EnrollmentController extends BaseController {
     }
 
     /**
-     * This action will reject the current enrollment of the profile with the
-     * given ID.
-     *
-     * @param id     the profile ID
-     * @param reason the reason
-     * @return the status result
-     * @throws IllegalArgumentException if reason is null/empty
-     * @endpoint "/agent/enrollment/reject"
-     */
-    @RequestMapping("/agent/enrollment/reject")
-    @ResponseBody
-    public StatusDTO reject(
-            @RequestParam("id") long id,
-            @RequestParam("reason") String reason
-    ) {
-        if (reason == null || reason.trim().length() == 0) {
-            throw new IllegalArgumentException("A reason must be provided.");
-        }
-
-        StatusDTO statusDTO = new StatusDTO();
-        try {
-            completeReview(id, null, true, reason);
-            statusDTO.setMessage("Request has been sent, you will be notified once it is processed.");
-        } catch (PortalServiceException ex) {
-            statusDTO.setMessage(USER_ERROR_MSG);
-        }
-
-        return statusDTO;
-    }
-
-    /**
      * This action will initiated an immediate screening of the enrollment.
      *
      * @param id the profile ID

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -16,8 +16,6 @@
 
 package gov.medicaid.services;
 
-import java.util.Date;
-
 import javax.jws.WebService;
 
 import gov.medicaid.entities.ScreeningSchedule;
@@ -86,12 +84,4 @@ public interface ScreeningService {
     void saveScreeningSchedule(
             ScreeningSchedule screeningSchedule
     ) throws PortalServiceException;
-
-    /**
-     * Schedules screening for the given ticket.
-     * @param id the ticket to schedule
-     * @param date the schedule date.
-     * @throws PortalServiceException - If there are any errors during the execution of this method
-     */
-    void scheduleScreening(long id, Date date) throws PortalServiceException;
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -34,15 +34,6 @@ import gov.medicaid.entities.ScreeningSchedule;
  */
 @WebService
 public interface ScreeningService {
-
-    /**
-     * This method performs the screening.
-     *
-     * @param userId - the user ID
-     * @throws PortalServiceException - If there are any errors during the execution of this method
-     */
-    void performScreening(long userId) throws PortalServiceException;
-
     /**
      * This method performs the screening by ID.
      *

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -33,39 +33,6 @@ import gov.medicaid.entities.ScreeningSchedule;
 @WebService
 public interface ScreeningService {
     /**
-     * This method performs the screening by ID.
-     *
-     * @param enrollmentId - the enrollment ID
-     * @throws PortalServiceException - If there are any errors during the execution of this method
-     */
-    void performScreeningById(long enrollmentId) throws PortalServiceException;
-
-    /**
-     * This method schedules the medicaid program data change.
-     *
-     * @param time - the time
-     * @throws PortalServiceException - If there are any errors during the execution of this method
-     */
-    void scheduleMediCareProgramDataChange(int time) throws PortalServiceException;
-
-    /**
-     * This method schedules a revalidation.
-     *
-     * @param time - the time
-     * @param userId - the user ID
-     * @throws PortalServiceException - If there are any errors during the execution of this method
-     */
-    void scheduleRevalidation(int time, long userId) throws PortalServiceException;
-
-    /**
-     * This method schedules a screening.
-     *
-     * @param time - the time
-     * @throws PortalServiceException - If there are any errors during the execution of this method
-     */
-    void scheduleScreening(int time) throws PortalServiceException;
-
-    /**
      * This method gets the screening schedule.
      *
      * @return the screening schedule


### PR DESCRIPTION
In working on various screening-related tasks, I found that there was quite a bit of dead code around screening. It seems that automatic screening was a feature that the original developers began but did not finish; we knew that the feature was unimplemented from observing the behavior of the automatic screening schedule, but we didn't notice the initial scaffolding code.

None of that code is ever called (that is, I could find no references to the endpoints in our JSPs or JavaScript), and even if it were, the code has no effect. Delete it.

Issue #355 Improve UI in screening log
Issue #740 Re-screen approved providers monthly
Issue #761 Save screening results in the database