### PR TITLE
Autofocus on username field in login page

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -38,7 +38,13 @@
 
               <div class="row">
                 <label for="username" class="label">Username</label>
-                <input id="username" name="username" type="text" class="text" value="${LAST_USERNAME}" maxlength="50"/>
+                <input id="username"
+                       name="username"
+                       type="text"
+                       class="text"
+                       value="${LAST_USERNAME}"
+                       maxlength="50"
+                       autofocus />
               </div>
               <div class="row">
                 <label for="password" class="label">Password</label>


### PR DESCRIPTION
Set the [HTML5 attribute `autofocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus) on the username field of the login page:

> specify that a form control should have input focus when the page loads

I think this is valuable generally, but particularly so for the development cycle of change-deploy-login-test-repeat.

I tested this by deploying, refreshing, and logging in without touching my mouse!

Issue #613 Use HTML5 instead of XHTML