### PR TITLE
Hotfix: Removed previously migrated entities

### DIFF
--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -1,6 +1,3 @@
-DROP SEQUENCE IF EXISTS
-  hibernate_sequence
-CASCADE;
 DROP TABLE IF EXISTS
   accepted_agreements,
   addresses,
@@ -37,7 +34,6 @@ DROP TABLE IF EXISTS
   pay_to_provider_types,
   pay_to_providers,
   people,
-  persistent_logins,
   profile_statuses,
   provider_approved_categories_of_service,
   provider_category_of_service_approvals,


### PR DESCRIPTION
The seed sql incorrectly still included drop checks for the two
items that are now migrated.  since the hibernate_sequence and
persistent_logins are created by migrations, they should not be
deleted by the seed sql.