### PR TITLE
Improve the screening results page (screening log page)

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/automatic_screening_leie.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/automatic_screening_leie.jsp
@@ -42,19 +42,20 @@
                 <span class="screening-date">
                   ${screening_date}
                 </span>
-            </div>
-            <div>
-              NPI searched:
-              <span class="search-term">
-                ${search_term}
-              </span>
-            </div>
-            <div class="matched-exclusions">
-              <div>There were ${fn:length(exclusions)} matches.</div>
-              <c:forEach var="exclusion" items="${exclusions}">
-                <hr>
-                <h:leie_exclusion exclusion="${exclusion}"/>
-              </c:forEach>
+              </div>
+              <div>
+                NPI searched:
+                <span class="search-term">
+                  ${search_term}
+                </span>
+              </div>
+              <div class="matched-exclusions">
+                <div>There were ${fn:length(exclusions)} matches.</div>
+                <c:forEach var="exclusion" items="${exclusions}">
+                  <hr>
+                  <h:leie_exclusion exclusion="${exclusion}"/>
+                </c:forEach>
+              </div>
             </div>
           </div>
         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/automatic_screening_leie.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/automatic_screening_leie.jsp
@@ -28,29 +28,67 @@
                 Review
               </a>
             </c:if>
-            <span>LEIE Automatic Screening Log</span>
+            <span>Results from Automatic LEIE Screening</span>
           </div>
-          <h1>Automatic Screening Log</h1>
+          <h1>Results from Automatic LEIE Screening</h1>
           <div class="tabSection" id="enrollmentSection">
             <div class="detailPanel">
-              <div>
+
+              <c:choose>
+                <c:when test="${screening_result == 'ERROR'}">
+                  <div class="row screeningResult">
+                    A connection error occurred.
+                  </div>
+                  <div class="row">
+                    <strong>
+                      <a
+                        href="javascript:alert('Retrying the LEIE screening has not been implemented yet.');">
+                        Retry the automatic LEIE screening</a>
+                      or
+                      <a href="https://exclusions.oig.hhs.gov/">
+                        search the LEIE manually</a>.
+                    </strong>
+                  </div>
+                </c:when>
+                <c:when test="${screening_result == 'PASS'}">
+                  <div class="row screeningResultPass">
+                    This provider does not appear in the LEIE and may be
+                    approved.
+                  </div>
+                </c:when>
+                <c:otherwise>
+                  <div class="row screeningResultFail">
+                    This provider appears in the LEIE and should be rejected.
+                  </div>
+                </c:otherwise>
+              </c:choose>
+
+              <div class="row">
                 Screening result:
                 <span class="screening-result">${screening_result}</span>
               </div>
-              <div>
+              <div class="row">
                 Checked at:
                 <span class="screening-date">
                   ${screening_date}
                 </span>
               </div>
-              <div>
+              <div class="row">
                 NPI searched:
                 <span class="search-term">
                   ${search_term}
                 </span>
               </div>
-              <div class="matched-exclusions">
-                <div>There were ${fn:length(exclusions)} matches.</div>
+              <div class="row matched-exclusions">
+                <c:set var="count" value="${fn:length(exclusions)}" />
+                <c:choose>
+                  <c:when test="${count == 1}">
+                    <div>There was ${count} match.</div>
+                  </c:when>
+                  <c:otherwise>
+                    <div>There were ${count} matches.</div>
+                  </c:otherwise>
+                </c:choose>
                 <c:forEach var="exclusion" items="${exclusions}">
                   <hr>
                   <h:leie_exclusion exclusion="${exclusion}"/>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4039,6 +4039,19 @@ form .error{
   color: #d00;
 }
 
+.screeningResult,
+.screeningResultPass,
+.screeningResultFail {
+  font-weight: bold;
+  font-size: large;
+}
+.screeningResultPass {
+  color: #3a7b0f;
+}
+.screeningResultFail {
+  color: #d00;
+}
+
 /* END OF SERVICE ADMIN STYLES -------------------------------------------------- */
 
 


### PR DESCRIPTION
Improve the screening results page so that it is easier to read and understand, and make it specific to the kind of screening that was done.  (Eventually the elements of this page should dynamically reflect the kind of screening results shown, but for now, since the LEIE is the only results we show, let it be LEIE specific.)

"Before" screenshots are on the issue #355 .
"After" Screenshots:

![screenshot-2018-5-9 screening results 3](https://user-images.githubusercontent.com/1091693/39840789-98663346-53ae-11e8-8992-d79ad5892efb.png)

![screenshot-2018-5-9 screening results 2](https://user-images.githubusercontent.com/1091693/39840790-98a02ff6-53ae-11e8-84ee-7fd4a7141dc0.png)

![screenshot-2018-5-9 screening results 1](https://user-images.githubusercontent.com/1091693/39840791-98c29d5c-53ae-11e8-844b-4dfc93ded3f1.png)



Resolves #355: Improve UI in screening log