### PR TITLE
Require contact email for organizational applications: #770

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/cms.validation.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.validation.drl
@@ -5448,6 +5448,23 @@ dialect 'mvel'
         );
 end
 
+rule 'Enrollment Contact Email Address is Required'
+dialect 'mvel'
+    when
+        $enrollment: EnrollmentType()
+        ContactInformationType(emailAddress == null || emailAddress
+            matches "^[\\s]*$" ) from $enrollment.contactInformation 
+        $report: ErrorReporter()
+    then
+        $report.addError(
+            "/ContactInformation/EmailAddress",
+            "00001",
+            "Contact Email Address is required."
+        );
+
+end
+
+
 rule 'Enrollment Contact Email Address Format Check'
 dialect 'mvel'
 /*

--- a/psm-app/cms-business-process/src/main/resources/cms.validation.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.validation.drl
@@ -5448,10 +5448,26 @@ dialect 'mvel'
         );
 end
 
+rule 'Enrollment Personal Email Address is Required when Same As Above is Checked'
+dialect 'mvel'
+    when
+        $enrollment: EnrollmentType(ContactSameAsApplicant == "Y");
+        ContactInformationType(emailAddress == null || emailAddress
+            matches "^[\\s]*$" ) from $enrollment.contactInformation
+        $report: ErrorReporter()
+    then
+        $report.addError(
+            "/ProviderInformation/ApplicantInformation/PersonalInformation/ContactInformation/EmailAddress",
+            "00001",
+            "Personal Email Address is required when same as above is checked."
+        );
+end
+
+
 rule 'Enrollment Contact Email Address is Required'
 dialect 'mvel'
     when
-        $enrollment: EnrollmentType()
+        $enrollment: EnrollmentType(ContactSameAsApplicant == "N" || ContactSameAsApplicant == null)
         ContactInformationType(emailAddress == null || emailAddress
             matches "^[\\s]*$" ) from $enrollment.contactInformation 
         $report: ErrorReporter()

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
@@ -850,7 +850,7 @@
        <div class="row">
            <c:set var="formName" value="_15_contactEmail"></c:set>
            <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-           <label for="contactEmail">Contact Email Address</label>
+           <label for="contactEmail">Contact Email Address<span class="required">*</span></label>
            <input ${disableContact} type="text" class="normalInput" id="contactEmail" name="${formName}" value="${formValue}" maxlength="50"/>
        </div>
        <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
@@ -101,7 +101,7 @@
             <div class="row">
                 <c:set var="formName" value="_02_contactEmail"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="contactEmail">Contact Email Address</label>
+                <label for="contactEmail">Contact Email Address<span class="required">*</span></label>
                 <input id="contactEmail" ${disableContact} type="text" class="${disableContact} normalInput" name="${formName}" value="${formValue}" maxlength="50"/>
             </div>
             <div class="row">

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
@@ -39,10 +39,11 @@ public class DataCoverageStepDefinitions {
     }
 
     @Then("^I should be asked to enter Applicant Name, Contact Person, Contact phone$")
-    public void i_should_be_asked_to_enter_Applicant_Name_Contact_Person_Contact_phone() {
+    public void i_should_be_asked_to_enter_Applicant_Name_Contact_Person_Contact_phone_Contact_email() {
         organizationInfoPage.verifyApplicantNameAccepted();
         organizationInfoPage.verifyContactNameAccepted();
         organizationInfoPage.verifyContactPhoneAccepted();
+        organizationInfoPage.verifyContactEmailAccepted();
     }
 
     @Then("^I should be asked to enter Medicaid number$")

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -141,6 +141,7 @@ public class EnrollmentSteps {
     public void enterContactInfo() {
         organizationInfoPage.setContactName("Test Contact");
         organizationInfoPage.setContactPhone("4445556666");
+        organizationInfoPage.setContactEmail("scontact@example.com");
     }
 
     public String generateEffectiveDate() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationInfoPage.java
@@ -36,6 +36,10 @@ public class OrganizationInfoPage extends EnrollmentPage {
         }
     }
 
+    public void verifyContactEmailAccepted() {
+        $("#contactEmail").sendKeys("contact_email");
+    }
+
     public void verifyMedicaidNumberAccepted() {
         throw new PendingException("Issue #347 - Capture Medicaid Number for new Enrollments");
     }
@@ -94,6 +98,10 @@ public class OrganizationInfoPage extends EnrollmentPage {
 
     public void setContactPhone(String contactPhone) {
         $("[name='_15_contactPhone1']").sendKeys(contactPhone);
+    }
+
+    public void setContactEmail(String contactEmail) {
+        $("[name='_15_contactEmail']").sendKeys(contactEmail);
     }
 
     public void checkForFeinError() throws Exception {

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/data_coverage.feature
@@ -6,7 +6,7 @@ Feature: Data Coverage Checks
   Scenario: Captures Contact Info for Organization
     Given I have started an enrollment
     When  I am on the organization page
-    Then I should be asked to enter Applicant Name, Contact Person, Contact phone
+    Then I should be asked to enter Applicant Name, Contact Person, Contact phone, Contact email
 
   @psm-FR-2.9
   Scenario: Captures Medicaid number for Organization's contact


### PR DESCRIPTION
Since we are using the contact email address to send notifications, it
should be required.  Without it, submitting the enrollment gives the
user an unexplained "server error."

Update integration tests to include the contact email for organizational
applications now that this field is required.

Pulling this out from PR #771 to catch this problem before it causes more errors.  As it is now it's pretty easy to run into an exception on master that only shows up when an enrollment is actually submitted.  To test, create an organizational enrollment and leave the contact email blank.  You should get an error that prevents you from moving to the next page of the form.