### PR TITLE
Fix #815. Use username for revewers report

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -281,7 +281,7 @@ public class EnrollmentWebServiceBean extends BaseService implements EnrollmentW
                 saveTicket(user, enrollment, false); // retain status
                 // synchronize with DB
                 Enrollment ticket = providerEnrollmentService.getTicketDetails(user, ticketId);
-                businessProcessService.updateRequest(XMLAdapter.toXML(ticket), user.getUserId(), user.getRole().getDescription());
+                businessProcessService.updateRequest(XMLAdapter.toXML(ticket), user);
             } catch (Exception e) {
                 throw new PortalServiceException("Resubmit failed.", e);
             }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -229,14 +229,14 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         ProviderProfile profile = ticket.getDetails().clone();
 
         // set audit
-        profile.setModifiedBy(ticket.getSubmittedBy());
+        profile.setModifiedBy(ticket.getSubmittedBy().getUserId());
         profile.setModifiedOn(ticket.getStatusDate());
         profile.setReferenceTicketId(ticket.getTicketId());
 
         if (ticket.getRequestType().getDescription().equals(ViewStatics.ENROLLMENT_REQUEST)) {
             profile.setProfileStatus(findLookupByDescription(ProfileStatus.class, "Active"));
-            profile.setOwnerId(ticket.getSubmittedBy());
-            profile.setCreatedBy(ticket.getSubmittedBy());
+            profile.setOwnerId(ticket.getSubmittedBy().getUserId());
+            profile.setCreatedBy(ticket.getSubmittedBy().getUserId());
             profile.setCreatedOn(ticket.getStatusDate());
 
             profile.getEntity().setEnrolled("Y");
@@ -250,7 +250,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             saveRelatedEntities(profile);
         } else if (ticket.getRequestType().getDescription().equals(ViewStatics.IMPORT_REQUEST)) {
             profile.setProfileStatus(findLookupByDescription(ProfileStatus.class, "Active"));
-            profile.setOwnerId(ticket.getSubmittedBy());
+            profile.setOwnerId(ticket.getSubmittedBy().getUserId());
             profile.getEntity().setEnrolled("Y");
             insertProfile(0, profile);
         } else {
@@ -541,7 +541,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         }
 
         if (ticket.getTicketId() == 0) {
-            ticket.setCreatedBy(user.getUserId());
+            ticket.setCreatedBy(user);
             ticket.setCreatedOn(Calendar.getInstance().getTime());
         } else {
             // delete - insert
@@ -1144,8 +1144,8 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         if (!FULL_ACCESS.contains(user.getRole().getDescription())) {
             if (user.getProxyForNPI() == null) {
                 Query q = getEm().createQuery(
-                        "SELECT 1 FROM Enrollment t WHERE t.ticketId = :ticketId AND t.createdBy = :username");
-                q.setParameter("username", user.getUserId());
+                        "SELECT 1 FROM Enrollment t WHERE t.ticketId = :ticketId AND t.createdBy = :user");
+                q.setParameter("user", user);
                 q.setParameter("ticketId", ticketId);
                 List rs = q.getResultList();
                 if (rs.isEmpty()) {
@@ -2063,7 +2063,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             ProviderSearchCriteria criteria
     ) {
         if (!FULL_ACCESS.contains(user.getRole().getDescription())) {
-            buffer.append("AND t.createdBy = :username ");
+            buffer.append("AND t.createdBy = :user ");
         }
         if (criteria.getProfileId() > 0) {
             buffer.append("AND e.profileId = :profileId ");
@@ -2151,7 +2151,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             ProviderSearchCriteria criteria
     ) {
         if (!FULL_ACCESS.contains(user.getRole().getDescription())) {
-            query.setParameter("username", user.getUserId());
+            query.setParameter("user", user);
         }
         if (criteria.getProfileId() > 0) {
             query.setParameter("profileId", criteria.getProfileId());
@@ -2373,7 +2373,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             Enrollment ticket,
             boolean insertDetails
     ) throws PortalServiceException {
-        ticket.setLastUpdatedBy(user.getUserId());
+        ticket.setLastUpdatedBy(user);
         ProviderProfile details = ticket.getDetails();
         ticket = getEm().merge(ticket);
 
@@ -2398,7 +2398,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         saveAsDraft(user, ticket);
 
         // bypass JBPM process and approve directly!
-        ticket.setSubmittedBy(user.getUserId());
+        ticket.setSubmittedBy(user);
         Date now = Calendar.getInstance().getTime();
         ticket.setSubmissionDate(now);
         ticket.setStatusDate(now);

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
@@ -89,7 +89,7 @@
                       <tr class="reportRow">
                         <td>${enrollment.ticketId}</td>
                         <td><fmt:formatDate value="${enrollment.createdOn}" pattern="dd MMMM yyyy" /></td>
-                        <td>${enrollment.lastUpdatedBy}</td>
+                        <td>${enrollment.lastUpdatedBy.userId}</td>
                         <td><fmt:formatDate value="${enrollment.statusDate}" pattern="dd MMMM yyyy" /></td>
                         <td>${enrollment.status.description}</td>
                       </tr>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
@@ -89,7 +89,7 @@
                       <tr class="reportRow">
                         <td>${enrollment.ticketId}</td>
                         <td><fmt:formatDate value="${enrollment.createdOn}" pattern="dd MMMM yyyy" /></td>
-                        <td>${enrollment.lastUpdatedBy.userId}</td>
+                        <td>${enrollment.lastUpdatedBy.username}</td>
                         <td><fmt:formatDate value="${enrollment.statusDate}" pattern="dd MMMM yyyy" /></td>
                         <td>${enrollment.status.description}</td>
                       </tr>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
@@ -88,7 +88,7 @@ public class ApplicationsByReviewerReportController extends gov.medicaid.control
                 csvPrinter.printRecord(
                     enrollment.getTicketId(),
                     enrollment.getCreatedOn(),
-                    enrollment.getLastUpdatedBy().getUserId(),
+                    enrollment.getLastUpdatedBy().getUsername(),
                     enrollment.getStatusDate(),
                     enrollment.getStatus().getDescription()
                 );

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
@@ -88,7 +88,7 @@ public class ApplicationsByReviewerReportController extends gov.medicaid.control
                 csvPrinter.printRecord(
                     enrollment.getTicketId(),
                     enrollment.getCreatedOn(),
-                    enrollment.getLastUpdatedBy(),
+                    enrollment.getLastUpdatedBy().getUserId(),
                     enrollment.getStatusDate(),
                     enrollment.getStatus().getDescription()
                 );

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
@@ -7,6 +7,7 @@ import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser
 import org.springframework.mock.web.MockHttpServletResponse
 
+import gov.medicaid.entities.CMSUser
 import gov.medicaid.entities.Enrollment
 import gov.medicaid.entities.EnrollmentStatus
 import gov.medicaid.entities.SearchResult
@@ -26,7 +27,7 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
         return new Enrollment([
             ticketId: id,
             createdOn: toDate(createdOn),
-            lastUpdatedBy: lastUpdatedBy,
+            lastUpdatedBy: new CMSUser([userId: lastUpdatedBy]),
             statusDate: toDate(statusDate),
             status: new EnrollmentStatus([description: status])
         ])

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
@@ -27,7 +27,7 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
         return new Enrollment([
             ticketId: id,
             createdOn: toDate(createdOn),
-            lastUpdatedBy: new CMSUser([userId: lastUpdatedBy]),
+            lastUpdatedBy: new CMSUser([username: lastUpdatedBy]),
             statusDate: toDate(statusDate),
             status: new EnrollmentStatus([description: status])
         ])
@@ -76,7 +76,7 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
         given:
         def results = new SearchResult<Enrollment>()
         results.setItems([
-            makeEnrollment(1234, "2018-05-05 12:32:33 PST", "ADMIN", "2018-05-08 5:03:55 PST", "TEST")
+            makeEnrollment(1234, "2018-05-05 12:32:33 PST", "admin", "2018-05-08 5:03:55 PST", "TEST")
         ])
         1 * service.searchEnrollments(_) >> results
 
@@ -92,7 +92,7 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
         records[1].size() == 5
         records[1][0] == "1234"
         records[1][1] == "Sat May 05 20:32:33 UTC 2018"
-        records[1][2] == "ADMIN"
+        records[1][2] == "admin"
         records[1][3] == "Tue May 08 13:03:55 UTC 2018"
         records[1][4] == "TEST"
     }
@@ -100,10 +100,10 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
     private testData() {
         def results = new SearchResult<Enrollment>()
         results.setItems([
-            makeEnrollment(1234, "2018-05-05 12:32:33 PST", "ADMIN", "2018-05-08 5:03:55 PST", "TEST"),
+            makeEnrollment(1234, "2018-05-05 12:32:33 PST", "admin", "2018-05-08 5:03:55 PST", "TEST"),
             makeEnrollment(1235, "2018-05-04 12:32:33 PST", "p1", "2018-05-09 5:03:55 PST", "APPROVED"),
             makeEnrollment(1236, "2018-05-03 12:32:33 PST", "p1", "2018-05-10 5:03:55 PST", "DRAFT"),
-            makeEnrollment(1237, "2018-05-02 12:32:33 PST", "ADMIN", "2018-05-11 5:03:55 PST", "TEST")
+            makeEnrollment(1237, "2018-05-02 12:32:33 PST", "admin", "2018-05-11 5:03:55 PST", "TEST")
         ].sort{it.getCreatedOn()})
         results
     }

--- a/psm-app/db/changelog/db-changelog-1.0.xml
+++ b/psm-app/db/changelog/db-changelog-1.0.xml
@@ -409,4 +409,30 @@
     </rollback>
   </changeSet>
 
+  <changeSet author="" id="issue815-add-enrollment-user-fk">
+    <addForeignKeyConstraint baseColumnNames="created_by"
+      baseTableName="enrollments"
+      constraintName="enrollments_created_by_fkey"
+      referencedColumnNames="user_id"
+      referencedTableName="cms_user" />
+    <addForeignKeyConstraint baseColumnNames="submitted_by"
+      baseTableName="enrollments"
+      constraintName="enrollments_submitted_by_fkey"
+      referencedColumnNames="user_id"
+      referencedTableName="cms_user" />
+    <addForeignKeyConstraint baseColumnNames="changed_by"
+      baseTableName="enrollments"
+      constraintName="enrollments_changed_by_fkey"
+      referencedColumnNames="user_id"
+      referencedTableName="cms_user" />
+    <rollback>
+      <dropForeignKeyConstraint baseTableName="enrollments"
+        constraintName="enrollments_created_by_fkey"/>
+      <dropForeignKeyConstraint baseTableName="enrollments"
+        constraintName="enrollments_submitted_by_fkey"/>
+      <dropForeignKeyConstraint baseTableName="enrollments"
+        constraintName="enrollments_changed_by_fkey"/>
+    </rollback>
+  </changeSet>
+
 </databaseChangeLog>

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
@@ -117,14 +117,16 @@ public class Enrollment implements Serializable {
     /**
      * Username that submitted the request.
      */
-    @Column(name = "submitted_by")
-    private String submittedBy;
+    @ManyToOne
+    @JoinColumn(name = "submitted_by")
+    private CMSUser submittedBy;
 
     /**
      * Username that created this request.
      */
-    @Column(name = "created_by")
-    private String createdBy;
+    @ManyToOne
+    @JoinColumn(name = "created_by")
+    private CMSUser createdBy;
 
     @Column(name = "created_at")
     private Date createdOn;
@@ -132,8 +134,9 @@ public class Enrollment implements Serializable {
     /**
      * Username that last made changes to the ticket.
      */
-    @Column(name = "changed_by")
-    private String lastUpdatedBy;
+    @ManyToOne
+    @JoinColumn(name = "changed_by")
+    private CMSUser lastUpdatedBy;
 
     /**
      * Ticket details.
@@ -193,19 +196,19 @@ public class Enrollment implements Serializable {
         this.statusNote = statusNote;
     }
 
-    public String getSubmittedBy() {
+    public CMSUser getSubmittedBy() {
         return submittedBy;
     }
 
-    public void setSubmittedBy(String submittedBy) {
+    public void setSubmittedBy(CMSUser submittedBy) {
         this.submittedBy = submittedBy;
     }
 
-    public String getLastUpdatedBy() {
+    public CMSUser getLastUpdatedBy() {
         return lastUpdatedBy;
     }
 
-    public void setLastUpdatedBy(String lastUpdatedBy) {
+    public void setLastUpdatedBy(CMSUser lastUpdatedBy) {
         this.lastUpdatedBy = lastUpdatedBy;
     }
 
@@ -233,11 +236,11 @@ public class Enrollment implements Serializable {
         this.submissionDate = submissionDate;
     }
 
-    public String getCreatedBy() {
+    public CMSUser getCreatedBy() {
         return createdBy;
     }
 
-    public void setCreatedBy(String createdBy) {
+    public void setCreatedBy(CMSUser createdBy) {
         this.createdBy = createdBy;
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
@@ -126,7 +126,6 @@ public interface BusinessProcessService {
      */
     void updateRequest(
             EnrollmentType ticket,
-            String user,
-            String userRole
+            CMSUser user
     ) throws Exception;
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/XMLAdapter.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/XMLAdapter.java
@@ -110,7 +110,9 @@ public final class XMLAdapter {
 
         enrollment.setProcessInstanceId(ticket.getProcessInstanceId());
         enrollment.setProgressPage(ticket.getProgressPage());
-        enrollment.setSubmittedBy(ticket.getSubmittedBy());
+        if (ticket.getSubmittedBy() != null) {
+            enrollment.setSubmittedBy(ticket.getSubmittedBy().getUserId());
+        }
         enrollment.setSubmittedOn(BinderUtils.toCalendar(ticket.getSubmissionDate()));
         enrollment.setStatusDate(BinderUtils.toCalendar(ticket.getStatusDate()));
 


### PR DESCRIPTION
This involves adding a fk, so please look at the migrations @slifty to sanity check me.

@cecilia-donnelly this resolves #815 that you ran into when reviewing for #781, so you should see usernames instead of user ids in the applications by reviewer report.