### PR TITLE
Quick Fix - NPI search box not populated after search

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_quick.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollments_quick.jsp
@@ -10,6 +10,7 @@
 <html lang="en-US">
   <c:set var="title" value="Search Results"/>
   <c:set var="adminPage" value="true" />
+  <c:set var="quickSearchNpi" value="${param.npi}" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -60,7 +60,7 @@
           <div class="inputContainer">
             <form action="{{ctx}}/provider/search/quick" method="get">
               <button class="search" title="Search" aria-label="Search"></button>
-              <input type="text" name="npi" placeholder="Search Keyword" value="{{#if param.npi }}{{param.npi}}{{/if}}" title="Search Keyword" />
+              <input type="text" name="npi" placeholder="Search Keyword" value="{{#if quickSearchNpi }}{{quickSearchNpi}}{{/if}}" title="Search Keyword" />
             </form>
           </div>
         </div>


### PR DESCRIPTION
Fixing a small annoyance when working on #612, that after a quick search, there was code that indicated an intention to populate the search box with the queried npi, but it didn't work after the move to handlebars.  This fixes that.