### PR TITLE
Issue #822 - Add link to enrollment from results

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
@@ -87,7 +87,11 @@
                     </thead>
                     <c:forEach var="enrollment" items="${enrollments}">
                       <tr class="reportRow">
-                        <td>${enrollment.ticketId}</td>
+                        <td>
+                          <a href="${ctx}/provider/enrollment/view?id=${enrollment.ticketId}">
+                            ${enrollment.ticketId}
+                          </a>
+                        </td>
                         <td><fmt:formatDate value="${enrollment.createdOn}" pattern="dd MMMM yyyy" /></td>
                         <td>${enrollment.lastUpdatedBy}</td>
                         <td><fmt:formatDate value="${enrollment.statusDate}" pattern="dd MMMM yyyy" /></td>

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ApplicationsByReviewerReportStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ApplicationsByReviewerReportStepDefinitions.java
@@ -24,6 +24,11 @@ public class ApplicationsByReviewerReportStepDefinitions {
         applicationsByReviewerSteps.searchApplicationsInReviewWithClearedDates();
     }
 
+    @Given("^I click on enrollment '(\\d+)'$")
+    public void i_click_on_enrollment(int enrollmentId) {
+        applicationsByReviewerSteps.clickOnEnrollment(enrollmentId);
+    }
+
     @Then("^I should see no applications by reviewer results$")
     public void i_should_see_no_applications_by_reviewer_results() {
         applicationsByReviewerSteps.checkNoApplicationsByReviewerResults();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ApplicationsByReviewerReportSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ApplicationsByReviewerReportSteps.java
@@ -32,4 +32,9 @@ public class ApplicationsByReviewerReportSteps {
     public void downloadApplicationsByReviewerReport() {
         applicationsByReviewerPage.click$(".downloadApplicationsByReviewerLink");
     }
+
+    @Step
+    public void clickOnEnrollment(int enrollmentId) {
+        applicationsByReviewerPage.clickOnEnrollment(enrollmentId);
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ApplicationsByReviewerPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ApplicationsByReviewerPage.java
@@ -6,6 +6,11 @@ import net.thucydides.core.annotations.DefaultUrl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
 @DefaultUrl("http://localhost:8080/cms/admin/reports/applications-by-reviewer")
 public class ApplicationsByReviewerPage extends PsmPage {
     public void checkOnPage() {
@@ -35,5 +40,15 @@ public class ApplicationsByReviewerPage extends PsmPage {
 
     public void checkHasNoResults() {
         assertThat($("#wrapper .noResults").getText()).contains("No results found");
+    }
+
+    public void clickOnEnrollment(int enrollmentId) {
+        Optional<WebElement> link =
+            getDriver().findElements(By.cssSelector("#wrapper .tableData .generalTable tr td a")).stream()
+                .filter(a -> a.getText().equals("" + enrollmentId))
+            .findFirst();
+
+        assertThat(link.isPresent()).isTrue();
+        link.get().click();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -1,6 +1,7 @@
 package gov.medicaid.features.service_admin.steps;
 
 import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import gov.medicaid.features.general.steps.GeneralSteps;
 import net.thucydides.core.annotations.Steps;
@@ -47,5 +48,10 @@ public class AdminStepDefinitions {
         i_am_on_the_review_enrollment_page();
         // assert fails because the page is opened in a separate tab
         generalSteps.clickLinkAssertTitle(".autoScreeningResultLink", "Screening Log");
+    }
+
+    @Then("^I am on the Personal Information page$")
+    public void i_am_on_the_personal_information_page() {
+        adminSteps.checkOnPersonalInformationPage();
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
@@ -1,7 +1,10 @@
 package gov.medicaid.features.service_admin.steps;
 
 import gov.medicaid.features.PsmPage;
+import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
+
 import net.thucydides.core.annotations.Step;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -11,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AdminSteps {
 
     private PsmPage psmPage;
+
+    private OrganizationInfoPage organizationInfoPage;
 
     @Step
     public void openWriteNoteModal() {
@@ -24,5 +29,10 @@ public class AdminSteps {
         WebElement viewLink = row.findElement(By.className("viewLink"));
         psmPage.click(viewLink);
         assertThat(psmPage.getTitle().contains("Organization Information"));
+    }
+
+    @Step
+    public void checkOnPersonalInformationPage() {
+        assertThat(organizationInfoPage.isPersonalEnrollment());
     }
 }

--- a/psm-app/integration-tests/src/test/resources/features/report/applications_by_reviewer.feature
+++ b/psm-app/integration-tests/src/test/resources/features/report/applications_by_reviewer.feature
@@ -13,6 +13,13 @@ Feature: Applications by Reviewer Report
     And I search for applications by reviewer between '01/01/2017' and '12/01/2017'
     Then I should see applications by reviewer results
 
+  Scenario: View Applications by Reviewer Enrollment
+    Given I am logged in as an admin
+    And I am on the applications by reviewer page
+    And I search for applications by reviewer between '01/01/2017' and '12/01/2017'
+    And I click on enrollment '1006'
+    Then I am on the Personal Information page
+
   Scenario: Search Applications by Reviewer Page without Dates with Results
     Given I am logged in as an admin
     And I am on the applications by reviewer page


### PR DESCRIPTION
Small fix for one part of #822.  Just make the application id clickable in the applications by reviewer report.  This is the only report that feedback is appropriate for at this time.