### PR TITLE
Add a Screenings page

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
@@ -78,9 +78,8 @@ public class ScreeningServiceBean extends BaseService implements ScreeningServic
      * This method saves the screening schedule.
      *
      * @param screeningSchedule - the screening schedule
-     *
      * @throws IllegalArgumentException - If screeningSchedule is null
-     * @throws PortalServiceException - If there are any errors during the execution of this method
+     * @throws PortalServiceException   - If there are any errors during the execution of this method
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
     public void saveScreeningSchedule(ScreeningSchedule screeningSchedule) throws PortalServiceException {

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
@@ -28,6 +28,7 @@ import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
 import javax.persistence.PersistenceException;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -105,5 +106,12 @@ public class ScreeningServiceBean extends BaseService implements ScreeningServic
                         hintEntityGraph("Screening with matches")
                 )
         );
+    }
+
+    @Override
+    public List<AutomaticScreening> getAllScreenings() {
+        return getEm()
+                .createQuery("FROM AutomaticScreening", AutomaticScreening.class)
+                .getResultList();
     }
 }

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_filter_panel.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_filter_panel.jsp
@@ -1,0 +1,47 @@
+<%--
+  The filter panel for: admin user login > Screenings > All/Passed/Failed/etc.
+--%>
+<%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
+<div
+  id="screeningsTabFilterPanel"
+  <c:choose>
+    <c:when test="${searchCriteria.showFilterPanel}">
+      style="display: block"
+    </c:when>
+    <c:otherwise>
+      style="display: none"
+    </c:otherwise>
+  </c:choose>
+  class="filterPanel screeningsTabFilterPanel"
+>
+
+  <div class="floatW">
+    <div class="leftCol">
+      <div class="row">
+        <input id="recentScreeningsFilterInput" type="checkbox" value="" />
+        <label style="width:90%">
+          Most recent screenings (per provider and screening type)
+        </label>
+      </div>
+    </div>
+    <div class="rightCol">
+      <div class="row">
+        <input id="rescreeningsFilterInput" type="checkbox" value="" />
+        <label style="width:90%">
+          Re-screenings
+        </label>
+      </div>
+    </div>
+  </div>
+
+  <a
+    id="screeningsTabFilterBtn"
+    href="javascript:;"
+    class="purpleBtn showResultBtn"
+  >
+    Filter
+  </a>
+
+</div>
+<div class="clearFixed"></div>
+<!-- /.filterPanel -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_tab_section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_tab_section.jsp
@@ -1,0 +1,43 @@
+<%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
+<div class="tabHead">
+  <div class="tabR">
+    <div class="tabM">
+      <a
+        class="tab allTab
+          <c:if test="${active_screenings_tab=='all'}">active</c:if>"
+        href="#"
+      >
+        <span class="aR">
+          <span class="aM">All</span>
+        </span>
+      </a>
+      <a
+        class="tab failedTab
+          <c:if test="${active_screenings_tab=='failed'}">active</c:if>"
+        href="#"
+      >
+        <span class="aR">
+          <span class="aM">Failed</span>
+        </span>
+      </a>
+      <a
+        class="tab passedTab
+          <c:if test="${active_screenings_tab=='passed'}">active</c:if>"
+        href="#"
+      >
+        <span class="aR">
+          <span class="aM">Passed</span>
+        </span>
+      </a>
+      <a
+        class="tab errorsTab
+          <c:if test="${active_screenings_tab=='errors'}">active</c:if>"
+        href="#"
+      >
+        <span class="aR">
+          <span class="aM">Errors</span>
+        </span>
+      </a>
+    </div>
+  </div>
+</div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
@@ -1,0 +1,60 @@
+<%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
+<table
+  id="screeningsTable"
+  class="generalTable"
+>
+  <thead>
+    <tr>
+      <th>
+        Date
+        <span class="sep"></span>
+      </th>
+      <th>
+        NPI
+        <span class="sep"></span>
+      </th>
+      <th>
+        Provider
+        <span class="sep"></span>
+      </th>
+      <th>
+        Provider Type
+        <span class="sep"></span>
+      </th>
+      <th>
+        Screening Type
+        <span class="sep"></span>
+      </th>
+      <th>
+        Reason
+        <span class="sep"></span>
+      </th>
+      <th>
+        Result
+        <span class="sep"></span>
+      </th>
+      <th class="alignCenter">
+        Action
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <c:forEach var="screening" items="${screenings}">
+      <tr>
+        <td>${screening.date}</td>
+        <td>${screening.npi}</td>
+        <td>${screening.providerName}</td>
+        <td>${screening.providerType}</td>
+        <td>${screening.screeningType}</td>
+        <td>${screening.reason}</td>
+        <td>${screening.result}</td>
+        <td class="alignCenter nopad">
+          <a href="#">Auto Screen</a>
+          <span class="sep">|</span>
+          <a href="#">Manual Screen</a>
+        </td>
+      </tr>
+    </c:forEach>
+  </tbody>
+</table>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
@@ -1,0 +1,117 @@
+<%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
+<!DOCTYPE html>
+<html lang="en-US">
+  <c:set var="title" value="Screenings"/>
+  <c:set var="adminPage" value="true" />
+  <c:set var="activeTabScreenings" value="true" />
+  <h:handlebars template="includes/html_head" context="${pageContext}" />
+  <body>
+    <div id="wrapper">
+      <h:handlebars template="includes/header" context="${pageContext}"/>
+      <div id="mainContent">
+        <div class="contentWidth">
+          <div class="mainNav">
+            <h:handlebars template="includes/logo" context="${pageContext}"/>
+            <h:handlebars template="includes/nav" context="${pageContext}"/>
+          </div>
+          <div class="breadCrumb">
+            Screenings
+          </div>
+          <div class="head">
+            <h1 class="text">Screenings</h1>
+          </div>
+          <div class="clearFixed"></div>
+
+            <div class="detailPanel screeningsDateRange">
+              <form
+                action="${ctx}/agent/screenings"
+                :method "get"
+              >
+                <div class="row rowDateRange">
+                  <span class="dateWrapper floatL">
+                    <input
+                      name="startDate"
+                      id="startDate"
+                      class="date hasDatePicker inputBox"
+                      title="Start Date"
+                      placeholder="Start Date"
+                      class="date"
+                      type="text"
+                      value=""
+                    />
+                  </span>
+                  <span class="floatL">-</span>
+                  <span class="dateWrapper floatL">
+                    <input
+                      name="endDate"
+                      id="endDate"
+                      class="date hasDatePicker inputBox"
+                      title="End Date"
+                      placeholder="End Date"
+                      class="date"
+                      type="text"
+                      value=""
+                    />
+                  </span>
+                  <input
+                    type="submit"
+                    value="Update Dates"
+                    class="purpleBtn screeningsTabDatesBtn"
+                  />
+                </div>
+              </form>
+            </div>
+
+          <div class="tabSection" id="enrollmentSection">
+            <c:set var="active_screenings_tab" value="all"/>
+            <%@ include file="/WEB-INF/pages/admin/includes/screenings_tab_section.jsp" %>
+            <!-- /.tabHead -->
+            <div class="tabContent">
+              <div class="pagination">
+                <%@ include file="/WEB-INF/pages/admin/includes/page_left_navigation.jsp" %>
+                <%@ include file="/WEB-INF/pages/admin/includes/enrollment_buttons.jsp" %>
+              </div>
+                <%@ include file="/WEB-INF/pages/admin/includes/screenings_filter_panel.jsp" %>
+              <c:choose>
+              <c:when test="${screenings.size() == 0}">
+                <div class="tableWrapper">
+                  <div class="tableContainer"></div>
+                  <div class="tabFoot">
+                    <div class="tabR">
+                      <div class="tabM red">
+                        No matched data found.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </c:when>
+              <c:otherwise>
+                <div class="tableWrapper">
+                  <div class="tableContainer">
+                    <%@ include file="/WEB-INF/pages/admin/includes/screenings_table.jsp" %>
+                  </div>
+                  <!-- /.tableContainer -->
+                  <div class="tabFoot">
+                    <div class="tabR">
+                      <div class="tabM">
+                        <%@ include file="/WEB-INF/pages/admin/includes/page_navigation.jsp" %>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- /.tabFoot -->
+                </div>
+              </c:otherwise>
+              </c:choose>
+            </div>
+          </div>
+          <!-- /.tabSection -->
+
+        </div>
+      </div>
+      <!-- /#mainContent -->
+
+      <h:handlebars template="includes/footer" context="${pageContext}"/>
+    </div>
+    <!-- /#wrapper -->
+  </body>
+</html>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -109,7 +109,7 @@ input,select,textarea{
 }
 .nav ul{
   float:left;
-  width:50%;
+  width:60%;
 }
 .nav ul li{
   display: inline;
@@ -138,7 +138,7 @@ input,select,textarea{
 }
 .mainNav .searchWidget{
   float:right;
-  width:49%;
+  width:39%;
 }
 .mainNav .searchWidget a{
   float:right;
@@ -4065,6 +4065,16 @@ form .error{
 }
 .screeningResultFail {
   color: #d00;
+}
+.screeningsDateRange {
+  margin: 20px 0px 0px;
+}
+.screeningsTabFilterPanel {
+  min-height: 0;
+}
+.screeningsTabDatesBtn {
+  margin-top: 4px;
+  margin-left: 10px;
 }
 
 .legend {

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -19,20 +19,20 @@
           </li>
 
           {{#if isServiceAdministrator}}
-          <li class="{{#if activeTabScreenings }} active {{/if}}">
-            <a class="screeningsLink" href="{{ctx}}/agent/screenings">SCREENINGS</a>
-            {{#if activeTabScreenings }} <span class="arrow"></span> {{/if}}
-          </li>
+            <li class="{{#if activeTabScreenings }} active {{/if}}">
+              <a class="screeningsLink" href="{{ctx}}/agent/screenings">SCREENINGS</a>
+              {{#if activeTabScreenings }} <span class="arrow"></span> {{/if}}
+            </li>
 
-          <li class="{{#if activeTab5 }} active {{/if}}">
-            <a class="reportsLink" href="{{ctx}}/admin/reports">REPORTS</a>
-            {{#if activeTab5 }} <span class="arrow"></span> {{/if}}
-          </li>
+            <li class="{{#if activeTab5 }} active {{/if}}">
+              <a class="reportsLink" href="{{ctx}}/admin/reports">REPORTS</a>
+              {{#if activeTab5 }} <span class="arrow"></span> {{/if}}
+            </li>
 
-          <li class="{{#if activeTab4 }} active {{/if}}">
-            <a class="functionsLink" href="{{ctx}}/admin/viewProviderTypes">FUNCTIONS</a>
-            {{#if activeTab4 }} <span class="arrow"></span> {{/if}}
-          </li>
+            <li class="{{#if activeTab4 }} active {{/if}}">
+              <a class="functionsLink" href="{{ctx}}/admin/viewProviderTypes">FUNCTIONS</a>
+              {{#if activeTab4 }} <span class="arrow"></span> {{/if}}
+            </li>
           {{/if}}
 
           <li class="last {{#if activeTab3 }} active {{/if}}">

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -19,6 +19,11 @@
           </li>
 
           {{#if isServiceAdministrator}}
+          <li class="{{#if activeTabScreenings }} active {{/if}}">
+            <a class="screeningsLink" href="{{ctx}}/agent/screenings">SCREENINGS</a>
+            {{#if activeTabScreenings }} <span class="arrow"></span> {{/if}}
+          </li>
+
           <li class="{{#if activeTab5 }} active {{/if}}">
             <a class="reportsLink" href="{{ctx}}/admin/reports">REPORTS</a>
             {{#if activeTab5 }} <span class="arrow"></span> {{/if}}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AutomaticScreeningController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AutomaticScreeningController.java
@@ -1,5 +1,6 @@
 package gov.medicaid.controllers.admin;
 
+import gov.medicaid.controllers.dto.ScreeningDTO;
 import gov.medicaid.entities.AutomaticScreening;
 import gov.medicaid.entities.LeieAutomaticScreening;
 import gov.medicaid.entities.dto.ViewStatics;
@@ -8,10 +9,13 @@ import gov.medicaid.services.ScreeningService;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.util.stream.Collectors;
+
 @Controller
-@RequestMapping("/agent/automatic-screening/*")
+@RequestMapping("/agent/")
 public class AutomaticScreeningController extends BaseServiceAdminController {
     private final ScreeningService screeningService;
 
@@ -19,7 +23,7 @@ public class AutomaticScreeningController extends BaseServiceAdminController {
         this.screeningService = screeningService;
     }
 
-    @RequestMapping("/{automaticScreeningId}")
+    @RequestMapping("/automatic-screening/{automaticScreeningId}")
     public ModelAndView viewScreening(
             @PathVariable long automaticScreeningId
     ) {
@@ -57,6 +61,38 @@ public class AutomaticScreeningController extends BaseServiceAdminController {
         mv.addObject("screening_date", screening.getCreatedAt());
         mv.addObject("search_term", screening.getNpiSearchTerm());
         mv.addObject("exclusions", screening.getMatches());
+        return mv;
+    }
+
+    private ScreeningDTO getScreeningDetails(AutomaticScreening screening) {
+        // TODO: Accessing provider details is WIP.
+        // Entity entity = screening.getEnrollment().getDetails().getEntity();
+        // entity.getNpi();
+        // entity.getName();
+        // entity.getProviderType().getDescription();
+
+        ScreeningDTO dto = new ScreeningDTO();
+        dto.date = screening.getCreatedAt();
+        dto.npi = "...";
+        dto.providerName = "...";
+        dto.providerType = "...";
+        dto.reason = "New Enrollment";
+        dto.screeningType = "LEIE";
+        dto.result = screening.getResult();
+        return dto;
+    }
+
+    @RequestMapping(value = "/screenings", method = RequestMethod.GET)
+    public ModelAndView view() {
+        ModelAndView mv = new ModelAndView("admin/screenings");
+
+        mv.addObject(
+                "screenings",
+                screeningService.getAllScreenings()
+                        .stream()
+                        .map(this::getScreeningDetails)
+                        .collect(Collectors.toList())
+        );
         return mv;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ScreeningDTO.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ScreeningDTO.java
@@ -1,0 +1,43 @@
+package gov.medicaid.controllers.dto;
+
+import gov.medicaid.entities.AutomaticScreening;
+
+import java.time.LocalDateTime;
+
+public class ScreeningDTO {
+    public LocalDateTime date;
+    public String npi;
+    public String providerName;
+    public String providerType;
+    public String screeningType;
+    public String reason;
+    public AutomaticScreening.Result result;
+
+    public LocalDateTime getDate() {
+        return date;
+    }
+
+    public String getNpi() {
+        return npi;
+    }
+
+    public String getProviderName() {
+        return providerName;
+    }
+
+    public String getProviderType() {
+        return providerType;
+    }
+
+    public String getScreeningType() {
+        return screeningType;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public AutomaticScreening.Result getResult() {
+        return result;
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -50,6 +50,11 @@ public class AdminStepDefinitions {
         generalSteps.clickLinkAssertTitle(".autoScreeningResultLink", "Screening Log");
     }
 
+    @When("^I am on the Screenings page$")
+    public void i_am_on_the_screenings_page() {
+        generalSteps.clickLinkAssertTitle(".screeningsLink", "Screenings");
+    }
+
     @Then("^I am on the Personal Information page$")
     public void i_am_on_the_personal_information_page() {
         adminSteps.checkOnPersonalInformationPage();

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -66,3 +66,8 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     And I am on the Screening Log page
     Then I should have no accessibility issues
+
+  Scenario: Admin Screenings Page
+    Given I am logged in as an admin
+    And I am on the Screenings page
+    Then I should have no accessibility issues

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -21,6 +21,7 @@ import javax.jws.WebService;
 import gov.medicaid.entities.AutomaticScreening;
 import gov.medicaid.entities.ScreeningSchedule;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -58,4 +59,6 @@ public interface ScreeningService {
     Optional<AutomaticScreening> findScreening(
             long screeningId
     );
+
+    List<AutomaticScreening> getAllScreenings();
 }


### PR DESCRIPTION
Add a Screenings page for service admins.  Various aspects of this page are not yet functional (see [this comment](https://github.com/SolutionGuidance/psm/issues/758#issuecomment-392119196) on the issue).  Currently it shows a list of all screenings, their dates, and the result.  Eventually it will become the UI for handling automatic monthly re-screenings of approved providers.

Tested by having a look at the new page (the filter panel will show/hide), and by successfully running the new accessibility test for the page.

![screenshot-2018-5-29 screenings](https://user-images.githubusercontent.com/1091693/40685276-c8023fe2-6361-11e8-82cc-d2d20ff0d428.png)

Issue #758: UI for monthly re-screening of approved providers