### PR TITLE
Fix PDF Export where Remittance Sequence is incorrect

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
@@ -315,7 +315,8 @@ public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
             PDFHelper.addLabelValueCell(practiceInfo, "State Tax ID", PDFHelper.value(model, ns, "stateTaxId"));
             PDFHelper.addLabelValueCell(practiceInfo, "Fiscal Year End", PDFHelper.getFiscalYear(model, ns));
             PDFHelper.addLabelValueCell(practiceInfo, "Accepts EFT", PDFHelper.getBoolean(model, ns, "eftAccepted"));
-            PDFHelper.addLabelValueCell(practiceInfo, "Remittance Sequence", PDFHelper.value(model, ns, "remittanceSequence"));
+            PDFHelper.addLabelValueCell(practiceInfo, "Remittance Sequence", RemittanceSequenceOrder.
+                    valueOf(PDFHelper.value(model, ns, "remittanceSequence")).getDescription());
         }
 
         document.add(practiceInfo);

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RemittanceSequenceOrder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RemittanceSequenceOrder.java
@@ -27,20 +27,34 @@ public enum RemittanceSequenceOrder {
     /**
      * By enrollee name.
      */
-    BY_ENROLLEE_NAME,
+    BY_ENROLLEE_NAME(""),
 
     /**
      * By patient account.
      */
-    PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER,
+    PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER("Patient Account or Own Reference Number Order"),
 
     /**
      * By transaction control.
      */
-    DHS_TRANSACTION_CONTROL_ORDER,
+    DHS_TRANSACTION_CONTROL_ORDER("DHS Transaction Control Number Order"),
 
     /**
      * By MHCP ID.
      */
-    RECIPIENT_MHCP_ID_NUMBER_ORDER;
+    RECIPIENT_MHCP_ID_NUMBER_ORDER("Recipient MHCP ID Number Order");
+
+    private String description;
+
+    RemittanceSequenceOrder(String desc) {
+        this.setDescription(desc);
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    private void setDescription(String desc) {
+        this.description = desc;
+    }
 }


### PR DESCRIPTION
#167: Exporting enrollment to PDF: "Remittance Sequence" is not
substituted