### PR TITLE
Add line graph to Provider Types report

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
@@ -3,7 +3,9 @@
 <html lang="en-US">
   <c:set var="title" value="Provider Types"/>
   <c:set var="adminPage" value="true" />
+  <c:set var="reportPage" value="true" />
   <c:set var="includeD3" value="true" />
+  <c:set var="pageScripts" value="${[ctx.concat('/js/admin/providerTypesReport.js')]}" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
 
   <body>
@@ -50,6 +52,11 @@
               </form>
             </div>
           </div>
+
+          <div id="providerTypesLineGraph" class="lineGraphContainer">
+            <em>Loading...</em>
+          </div>
+
           <div class="reportTable dashboardPanel">
             <c:forEach var="month" items="${months}">
               <div class="tableData">
@@ -62,13 +69,25 @@
                       <thead>
                         <tr>
                           <th>Provider Type</th>
-                          <th class="providerTypesNum">Number Reviewed</th>
+                          <th class="providerTypesNum">Applications Reviewed</th>
                         </tr>
                       </thead>
                       <c:forEach var="providerType" items="${month.providerTypes}">
-                        <tr>
-                          <td>${providerType.description}</td>
-                          <td>${month.getEnrollments(providerType).size()}</td>
+                        <tr class="reportRow">
+                          <td
+                            class="reportDatum"
+                            reportField="providerType"
+                            reportValue="${providerType.description}"
+                          >
+                            ${providerType.description}
+                          </td>
+                          <td
+                            class="reportDatum"
+                            reportField="applicationsReviewed"
+                            reportValue="${month.getEnrollments(providerType).size()}"
+                          >
+                            ${month.getEnrollments(providerType).size()}
+                          </td>
                         </tr>
                       </c:forEach>
                     </table>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
@@ -42,7 +42,7 @@
                 <thead>
                   <tr>
                     <th>Month</th>
-                    <th>Number Reviewed</th>
+                    <th>Applications Reviewed</th>
                     <th>Mean Review Time</th>
                     <th>Median Review Time</th>
                   </tr>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4067,8 +4067,24 @@ form .error{
   color: #d00;
 }
 
-.lineGraphContainer {
-  height: 750px;
+.legend {
+  margin: 1.5rem 3rem;
+}
+.legendItem {
+  display: inline-block;
+  padding: 0px;
+  margin: 4px;
+  font-size: 12px;
+}
+.legendColorSwatch {
+  display: inline-block;
+  padding: 0;
+  margin: 0 5px 0 8px;
+  height: 13px;
+  width: 13px;
+}
+.legendItemText {
+  display: inline-block;
 }
 
 /* END OF SERVICE ADMIN STYLES -------------------------------------------------- */

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4086,6 +4086,9 @@ form .error{
 .legendItemText {
   display: inline-block;
 }
+.lineGraphNote {
+  margin: 12px;
+}
 
 /* END OF SERVICE ADMIN STYLES -------------------------------------------------- */
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
@@ -98,7 +98,7 @@ public class ProviderTypesReportController extends gov.medicaid.controllers.Base
         try {
             CSVPrinter csvPrinter = new CSVPrinter(response.getWriter(), CSVFormat.DEFAULT);
 
-            csvPrinter.printRecord("Month Reviewed", "Provider Type", "Number Reviewed");
+            csvPrinter.printRecord("Month Reviewed", "Provider Type", "Applications Reviewed");
 
             for (Month month : months) {
                 for (ProviderType providerType : month.getProviderTypes()) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/TimeToReviewReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/TimeToReviewReportController.java
@@ -67,7 +67,7 @@ public class TimeToReviewReportController extends gov.medicaid.controllers.BaseC
 
             csvPrinter.printRecord(
                 "Month",
-                "Number Reviewed",
+                "Applications Reviewed",
                 "Mean Review Time",
                 "Median Review Time"
             );

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ProviderTypesReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ProviderTypesReportControllerTest.groovy
@@ -99,7 +99,7 @@ class ProviderTypesReportControllerTest extends Specification {
         then:
         records[0][0] == "Month Reviewed"
         records[0][1] == "Provider Type"
-        records[0][2] == "Number Reviewed"
+        records[0][2] == "Applications Reviewed"
         records.size == 1
         records[0].size() == 3
     }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/TimeToReviewReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/TimeToReviewReportControllerTest.groovy
@@ -51,7 +51,7 @@ class TimeToReviewReportControllerTest extends Specification {
 
         then:
         records[0][0] == "Month"
-        records[0][1] == "Number Reviewed"
+        records[0][1] == "Applications Reviewed"
         records[0][2] == "Mean Review Time"
         records[0][3] == "Median Review Time"
         records.size == 1

--- a/psm-app/frontend/src/main/js/admin/draftsReport.js
+++ b/psm-app/frontend/src/main/js/admin/draftsReport.js
@@ -11,8 +11,10 @@ window.addEventListener("load", function drawDraftsLineGraph() {
     };
   });
 
+  var color = d3.schemeCategory10[0];
+
   var lines = [
-    reportUtils.makeLineData("Draft Applications", "#0d4478", draftsPoints),
+    reportUtils.makeLineData("Draft Applications", color, draftsPoints),
   ];
 
   reportUtils.drawMonthsLineGraph(

--- a/psm-app/frontend/src/main/js/admin/providerTypesReport.js
+++ b/psm-app/frontend/src/main/js/admin/providerTypesReport.js
@@ -1,0 +1,117 @@
+window.addEventListener("load", function drawProviderTypesLineGraph() {
+  "use strict";
+
+  // Parse the html tables into JSON data.
+  // 'reportJson' becomes an array of objects with the keys 'month',
+  // 'providerType', and 'applicationsReviewed'.
+  var reportJson = [];
+  $(".reportTable")
+    .find(".tableData")
+    .each(function handleTable(idx, tableWrapper) {
+      var month = $(tableWrapper)
+        .find(".tableTitle h2")
+        .text();
+
+      var reportRows = $(tableWrapper).find(".reportRow");
+      if (reportRows.length === 0) {
+        reportJson.push({ month: month });
+      } else {
+        reportRows.each(function handleRow(idx, row) {
+          var dataEntry = {
+            month: month,
+          };
+
+          $(row)
+            .find(".reportDatum")
+            .each(function handleDatum(idx, datum) {
+              dataEntry[$(datum).attr("reportField")] = $(datum).attr(
+                "reportValue"
+              );
+            });
+
+          reportJson.push(dataEntry);
+        });
+      }
+    });
+
+  /**
+   * Convert the data into an object that maps provider types to
+   * objects that map months to provider type counts.
+   * E.g. { "Dentist": { "2018-05-31": 4, ... }, ...}
+   */
+  var byType = reportJson.reduce(function toByType(result, d) {
+    if (result[d.providerType]) {
+      result[d.providerType][d.month] = Number(d.applicationsReviewed);
+    } else if (d.providerType && d.applicationsReviewed) {
+      var obj = {};
+      obj[d.month] = Number(d.applicationsReviewed);
+      result[d.providerType] = obj;
+    }
+
+    return result;
+  }, {});
+
+  var types = Object.keys(byType);
+
+  /**
+   * Add up the totals for each type, for sorting purposes.
+   * @return array of arrays  E.g. [["Dentist", 12], ...]
+   */
+  var typeTotals = types.map(function getTotals(type) {
+    var typeData = byType[type];
+    var months = Object.keys(typeData);
+    var total = months.reduce(function total(total, month) {
+      var count = typeData[month];
+      return total + count;
+    }, 0);
+
+    return [type, total];
+  });
+
+  // Sort by totals, descending.
+  typeTotals.sort(function sortTypes(a, b) {
+    return a[1] < b[1];
+  });
+
+  // Get the ten types with the largest totals, and sort them alphabetically.
+  var topTen = typeTotals.slice(0, 9).sort(function sortAlphabetically(a, b) {
+    return a[0] > b[0];
+  });
+
+  var months = reportJson.map(function getMonth(d) {
+    return d.month;
+  });
+
+  // Generate line data for the top ten types.
+  var lines = topTen.map(function makeLine(typeTotal, i) {
+    var type = typeTotal[0];
+    var points = months.map(function makePoints(month) {
+      if (!byType[type][month]) {
+        return { x: month, y: 0 };
+      } else {
+        return { x: month, y: byType[type][month] };
+      }
+    });
+
+    var color = d3.schemeCategory10[i];
+
+    return reportUtils.makeLineData(type, color, points);
+  });
+
+  reportUtils.drawMonthsLineGraph(
+    "#providerTypesLineGraph",
+    "",
+    "Applications Reviewed",
+    lines,
+    reportUtils.getAxisDomains(lines)
+  );
+
+  if (typeTotals.length > 10) {
+    d3.select(".legend")
+      .append("div")
+      .attr("class", "lineGraphNote")
+      .text(
+        "Only the ten most frequently reviewed provider types are shown on the graph."
+      );
+  }
+});

--- a/psm-app/frontend/src/main/js/admin/reportUtils.js
+++ b/psm-app/frontend/src/main/js/admin/reportUtils.js
@@ -300,6 +300,27 @@ var reportUtils = (function makeReportUtils() {
         .attr("stroke-width", 2)
         .attr("fill", "none");
     });
+
+    // Render legend.
+
+    var legend = d3
+      .select(elementId)
+      .append("div")
+      .attr("class", "legend");
+
+    lines.forEach(function addLegendItem(line) {
+      var item = legend.append("div").attr("class", "legendItem");
+
+      item
+        .append("div")
+        .attr("class", "legendColorSwatch")
+        .attr("style", "background: " + line.color + ";");
+
+      item
+        .append("div")
+        .attr("class", "legendItemText")
+        .text(line.label);
+    });
   }
 
   // Return an object that provides public access to certain functions.

--- a/psm-app/frontend/src/main/js/admin/timeToReviewReport.js
+++ b/psm-app/frontend/src/main/js/admin/timeToReviewReport.js
@@ -12,15 +12,18 @@ window.addEventListener("load", function drawTimeToReviewLineGraph() {
     []
   );
 
+  var meanColor = d3.schemeCategory10[0];
+  var medianColor = d3.schemeCategory10[1];
+
   var lines = [
-    reportUtils.makeLineData("Median", "orange", medianPoints),
-    reportUtils.makeLineData("Mean", "#0d4478", meanPoints),
+    reportUtils.makeLineData("Mean", meanColor, meanPoints),
+    reportUtils.makeLineData("Median", medianColor, medianPoints),
   ];
 
   reportUtils.drawMonthsLineGraph(
     "#timeToReviewLineGraph",
     "",
-    "Time to Review in Days (Mean in Blue and Median in Orange)",
+    "Time to Review in Days",
     lines,
     reportUtils.getAxisDomains(lines)
   );


### PR DESCRIPTION
Add a line graph to the Provider Types report, and add a color legend to all line graphs.  Currently that's Time to Review, Draft Applications, and Provider Types reports.

Tested by viewing the three reports, and confirming that the line graph reflects filtering on the provider types report.

![screenshot-2018-5-31 provider types](https://user-images.githubusercontent.com/1091693/40801918-2aed6876-64e2-11e8-8ed5-31c5b735f5b9.png)

Issue #784: Add Reporting based on provider types/taxonomies