### PR TITLE
Add line graph for Reviewed Documents report

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
@@ -6,6 +6,7 @@
   <c:set var="adminPage" value="true" />
   <c:set var="reportPage" value="true" />
   <c:set var="includeD3" value="true" />
+  <c:set var="pageScripts" value="${[ctx.concat('/js/admin/reviewedDocumentsReport.js')]}" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">
@@ -27,6 +28,11 @@
               class="downloadReviewedDocuments"
             >Download this report</a>
           </div>
+
+          <div id="reviewedDocumentsLineGraph" class="lineGraphContainer">
+            <em>Loading...</em>
+          </div>
+
           <div class="reportTable dashboardPanel">
             <div class="tableData">
               <div class="tableTitle">
@@ -40,9 +46,21 @@
                   </tr>
                 </thead>
                 <c:forEach var="month" items="${months}">
-                  <tr>
-                    <td>${month.month}</td>
-                    <td>${month.numDocuments}</td>
+                  <tr class="reportRow">
+                    <td
+                      class="reportDatum"
+                      reportField="month"
+                      reportValue="${month.month}"
+                    >
+                      ${month.month}
+                    </td>
+                    <td
+                      class="reportDatum"
+                      reportField="documents"
+                      reportValue="${month.numDocuments}"
+                    >
+                      ${month.numDocuments}
+                    </td>
                   </tr>
                 </c:forEach>
               </table>

--- a/psm-app/frontend/src/main/js/admin/reviewedDocumentsReport.js
+++ b/psm-app/frontend/src/main/js/admin/reviewedDocumentsReport.js
@@ -1,0 +1,21 @@
+window.addEventListener("load", function drawDraftsLineGraph() {
+  "use strict";
+  var reportJson = reportUtils.tableToJson($(".reportTable"));
+
+  var points = reportJson.reduce(
+    reportUtils.extractPoints.bind(undefined, "month", "documents"),
+    []
+  );
+
+  var color = d3.schemeCategory10[0];
+
+  var lines = [reportUtils.makeLineData("Reviewed Documents", color, points)];
+
+  reportUtils.drawMonthsLineGraph(
+    "#reviewedDocumentsLineGraph",
+    "",
+    "Reviewed Documents",
+    lines,
+    reportUtils.getAxisDomains(lines)
+  );
+});


### PR DESCRIPTION
Add a line graph to the Reviewed Documents report.  Tested by checking the page to see that the line graph reflects the data (all zeros in my database, so not much to see).

![screenshot-2018-5-31 reviewed documents](https://user-images.githubusercontent.com/1091693/40812032-c28b762c-6501-11e8-8ee4-58059c33c6e1.png)


Issue #785 Report for number of system documents ... reviewed