### PR TITLE
Add a line graph to Risk Levels report

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
@@ -6,6 +6,7 @@
   <c:set var="adminPage" value="true" />
   <c:set var="reportPage" value="true" />
   <c:set var="includeD3" value="true" />
+  <c:set var="pageScripts" value="${[ctx.concat('/js/admin/riskLevelsReport.js')]}" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">
@@ -27,6 +28,17 @@
               class="downloadRiskLevels"
             >Download this report</a>
           </div>
+
+          <div id="riskLevelsLineGraph" class="lineGraphContainer">
+            <em>Loading...</em>
+          </div>
+
+          <p>
+            This report covers only the applications that have been reviewed
+            (approved or denied), and not applications that have been
+            submitted but not yet reviewed.
+          </p>
+
           <div class="reportTable dashboardPanel">
             <div class="tableData">
               <div class="tableTitle">
@@ -42,10 +54,22 @@
                   </tr>
                 </thead>
                 <c:forEach var="month" items="${months}">
-                  <tr>
-                    <td>${month.month}</td>
+                  <tr class="reportRow">
+                    <td
+                      class="reportDatum"
+                      reportField="month"
+                      reportValue="${month.month}"
+                    >
+                      ${month.month}
+                    </td>
                     <c:forEach var="riskLevel" items="${riskLevels}">
-                      <td>${month.getNum(riskLevel)}</td>
+                      <td
+                        class="reportDatum"
+                        reportField="${riskLevel.toLowerCase()}"
+                        reportValue="${month.getNum(riskLevel)}"
+                      >
+                        ${month.getNum(riskLevel)}
+                      </td>
                     </c:forEach>
                   </tr>
                 </c:forEach>

--- a/psm-app/frontend/src/main/js/admin/riskLevelsReport.js
+++ b/psm-app/frontend/src/main/js/admin/riskLevelsReport.js
@@ -1,0 +1,37 @@
+window.addEventListener("load", function drawDraftsLineGraph() {
+  "use strict";
+  var reportJson = reportUtils.tableToJson($(".reportTable"));
+
+  var pointsLimited = reportJson.reduce(
+    reportUtils.extractPoints.bind(undefined, "month", "limited"),
+    []
+  );
+
+  var pointsModerate = reportJson.reduce(
+    reportUtils.extractPoints.bind(undefined, "month", "moderate"),
+    []
+  );
+
+  var pointsHigh = reportJson.reduce(
+    reportUtils.extractPoints.bind(undefined, "month", "high"),
+    []
+  );
+
+  var colorLimited = d3.schemeCategory10[0];
+  var colorModerate = d3.schemeCategory10[1];
+  var colorHigh = d3.schemeCategory10[3];
+
+  var lines = [
+    reportUtils.makeLineData("Limited Risk", colorLimited, pointsLimited),
+    reportUtils.makeLineData("Moderate Risk", colorModerate, pointsModerate),
+    reportUtils.makeLineData("High Risk", colorHigh, pointsHigh),
+  ];
+
+  reportUtils.drawMonthsLineGraph(
+    "#riskLevelsLineGraph",
+    "",
+    "Number of Applications",
+    lines,
+    reportUtils.getAxisDomains(lines)
+  );
+});


### PR DESCRIPTION
These changes are on top of those in PR #838 and should be reviewed after that PR lands and this is rebased on master.

Tested by checking the page to confirm that the graph reflects the data.

![screenshot-2018-6-1 risk levels 1](https://user-images.githubusercontent.com/1091693/40861080-cc14e44e-65b5-11e8-8814-ea71edcf5abf.png)

Issue 786: Add report based on CMS provider risk level