### PR TITLE
Add EFT Acceptance Indicator to API

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhir.java
@@ -1,0 +1,43 @@
+package gov.medicaid.api.transformers;
+
+import gov.medicaid.entities.Affiliation;
+import gov.medicaid.entities.Enrollment;
+import gov.medicaid.entities.Entity;
+import gov.medicaid.entities.Organization;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.BooleanType;
+import org.hl7.fhir.dstu3.model.Task;
+import java.util.List;
+
+import java.util.function.Function;
+
+public class EnrollmentAcceptsEftToFhir
+        implements Function<Enrollment, Task.ParameterComponent> {
+    @Override
+    public Task.ParameterComponent apply(Enrollment enrollment) {
+        boolean isEftAccepted = isEftAccepted(enrollment);
+        return new Task.ParameterComponent(
+                new CodeableConcept().setText("Accepts EFT"),
+                new BooleanType(isEftAccepted)
+        );
+    }
+
+    // If any primary affiliations accept EFT, this enrollment is considered
+    // to accept EFT.
+    private boolean isEftAccepted(Enrollment enrollment) {
+        List<Affiliation> affiliations = enrollment.getDetails().getAffiliations();
+        if (affiliations != null) {
+            for (Affiliation affiliation : affiliations) {
+                if ("Y".equals(affiliation.getPrimaryInd())) {
+                    Entity entity = affiliation.getEntity();
+                    if (entity instanceof Organization) {
+                        if (((Organization) entity).isEftAccepted()) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
@@ -26,6 +26,11 @@ public class EnrollmentToFhir implements Function<Enrollment, Task> {
                         enrollment.getDetails().getEntity().getProviderType()
                 )
         );
+
+        task.addInput(
+                new EnrollmentAcceptsEftToFhir().apply(enrollment)
+        );
+
         task.addContained(requester);
 
         return task;

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhirTest.groovy
@@ -1,0 +1,97 @@
+package gov.medicaid.api.transformers
+
+import gov.medicaid.entities.Affiliation
+import gov.medicaid.entities.Enrollment
+import gov.medicaid.entities.EnrollmentStatus
+import gov.medicaid.entities.Organization
+import gov.medicaid.entities.Person
+import gov.medicaid.entities.ProviderProfile
+import gov.medicaid.entities.ProviderType
+import spock.lang.Specification
+
+class EnrollmentAcceptsEftToFhirTest extends Specification {
+    EnrollmentAcceptsEftToFhir transformer
+    Enrollment enrollment
+
+    def setup() {
+        transformer = new EnrollmentAcceptsEftToFhir()
+        enrollment = new Enrollment()
+        enrollment.ticketId = 123
+        enrollment.status = new EnrollmentStatus()
+        enrollment.status.description = "Pending"
+        enrollment.details = new ProviderProfile()
+        enrollment.details.entity = new Person()
+        enrollment.details.entity.id = 456
+        enrollment.details.entity.providerType = new ProviderType()
+        enrollment.details.entity.providerType.description = "Audiologist"
+    }
+
+    void addAffiliation(Map args, Enrollment enrollment) {
+        def organization = new Organization()
+        organization.setEftAccepted(args.eftAccepted)
+
+        def affiliation = new Affiliation()
+        affiliation.setEntity(organization)
+        if (args.primary) {
+            affiliation.setPrimaryInd("Y")
+        }
+
+        def affiliations = enrollment.details.getAffiliations()
+        if (affiliations == null) {
+            affiliations = new ArrayList<Affiliation>()
+        }
+
+        affiliations.add(affiliation)
+        enrollment.details.setAffiliations(affiliations)
+    }
+
+    def "No primary affiliation does not accept EFT"() {
+        given:
+        addAffiliation(enrollment, eftAccepted: false, primary: false)
+        addAffiliation(enrollment, eftAccepted: true, primary: false)
+
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.value.booleanValue() == false
+    }
+
+    def "Enrollment without affiliations does not accept EFT"() {
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.value.booleanValue() == false
+    }
+
+    def "Primary affiliation without EFT does not accept EFT"() {
+        given:
+        addAffiliation(enrollment, eftAccepted: false, primary: true)
+
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.value.booleanValue() == false
+    }
+
+    def "Primary affiliation with EFT does accept EFT"() {
+        given:
+        addAffiliation(enrollment, eftAccepted: true, primary: true)
+
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.value.booleanValue() == true
+    }
+
+    def "Transforming null throws"() {
+        when:
+        transformer.apply(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+}

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentToFhirTest.groovy
@@ -6,11 +6,20 @@ import gov.medicaid.entities.Person
 import gov.medicaid.entities.ProviderProfile
 import gov.medicaid.entities.ProviderType
 import org.hl7.fhir.dstu3.model.Task
+import org.hl7.fhir.dstu3.model.Task.ParameterComponent
 import spock.lang.Specification
 
 class EnrollmentToFhirTest extends Specification {
     EnrollmentToFhir transformer
     Enrollment enrollment
+
+    def getInputByType(inputs, name) {
+        for (ParameterComponent input : inputs) {
+            if (input.getType().getText() == name)
+                return input;
+        }
+        return null;
+    }
 
     def setup() {
         transformer = new EnrollmentToFhir()
@@ -60,8 +69,18 @@ class EnrollmentToFhirTest extends Specification {
 
         then:
         result.hasInput()
-        result.input.size() == 1
-        result.input.first().value.toString() == "Audiologist"
+        def input = getInputByType(result.input, "Provider Type")
+        input.value.toString() == "Audiologist"
+    }
+
+    def "Accepts EFT is set as input"() {
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.hasInput()
+        def input = getInputByType(result.input, "Accepts EFT")
+        input.value.booleanValue() == false
     }
 
     def "Enrollment ID is set as identifier"() {


### PR DESCRIPTION
This is the first of a series of modifications to the provider API.  It adds a new field indicating whether the applying provider accepts EFT payments.  Because the FHIR standard does not have a place to actually convey this information, it is wrapped as an input.

This PR includes some changes to past tests which were a bit too rigid / did not allow for more than one input attribute.

There was some discussion as to whether the logic for summarizing organizational affiliation EFT acceptance into a single "accepts EFT" boolean belonged in the model or at the API transformation level.  Ultimately we decided that at this point our models are used exclusively for hibernate interaction, and this was not the right time to change that pattern.