### PR TITLE
Use direct connection between Enrollment and User: #863

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -171,7 +171,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             throw new PortalServiceException("Cannot change status because it is not in pending state.");
         }
 
-        CMSUser submittingUser = getUserByEnrollment(ticket);
+        CMSUser submittingUser = ticket.getSubmittedBy();
         Map<String, Object> vars = new HashMap<>();
         String emailAddress = submittingUser.getEmail();
         notificationService.sendNotification(emailAddress, EmailTemplate.REJECTED_ENROLLMENT, vars);
@@ -182,25 +182,6 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         saveTicket(user, ticket, false);
     }
 
-    /**
-     * Look up the user who submitted an enrollment
-     *
-     * TODO: this is not the appropriate location for this functionality
-     * If / when a refactor to how we do our models is done, this should
-     * live inside of the Enrollment model.
-     *
-     * @param  enrollment The enrollment object whose creator we want to look up
-     * @return            The CMS user object associated with the user who made the enrollment
-     */
-    private CMSUser getUserByEnrollment(Enrollment enrollment) {
-        return getEm().createQuery(
-            "FROM CMSUser where username = :username",
-            CMSUser.class
-        ).setParameter(
-            "username",
-            enrollment.getSubmittedBy()
-        ).getSingleResult();
-    }
 
     /**
      * This is the service method to be called after the process has completed


### PR DESCRIPTION
As prefigured in the TODO comment @slifty left, remove the no-longer-needed
`getUserByEnrollment` method, in favor of getting the user directly, now
that `getSubmittedBy` returns the user instead of the user_id string.

To test, review an application as an administrator and click "Reject."  It should work now!