### PR TITLE
Fix quotes for issuing boards; see #865

### DIFF
--- a/psm-app/db/seeds/issuing_boards.csv
+++ b/psm-app/db/seeds/issuing_boards.csv
@@ -1,8 +1,8 @@
-code, description
-"B1", "AANA"
-"B2", "NARM"
-"B3", "ANCC"
-"B4", "AOTA"
-"B5", "ADA"
-"B6", "ABMS"
-"B7", "ABPS"
+code,description
+"B1","AANA"
+"B2","NARM"
+"B3","ANCC"
+"B4","AOTA"
+"B5","ADA"
+"B6","ABMS"
+"B7","ABPS"


### PR DESCRIPTION
We can't have spaces in csv seed files (see discussion in #865).  The `issuing_boards` seed file still has them - or did until now!

To test, start an enrollment for a provider type that has a subspecialty, like Nurse Practitioner.  The issuing board in the dropdown should not have a leading `"` in the name.

Correct:
![screenshot-2018-6-7 license information](https://user-images.githubusercontent.com/1497818/41122794-501bae02-6a62-11e8-996a-9d12eb3a67d4.png)

Incorrect:
![screenshot-2018-6-7 license information 1](https://user-images.githubusercontent.com/1497818/41122860-83c5c224-6a62-11e8-9a42-fa604069c188.png)

