### PR TITLE
Tell Hibernate to talk modern PostgreSQL

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
+++ b/psm-app/cms-business-process/src/main/resources/META-INF/persistence.xml
@@ -100,7 +100,7 @@
     <class>gov.medicaid.entities.StateType</class>
 
     <properties>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
+      <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQL94Dialect" />
       <property name="hibernate.hbm2ddl.auto" value="none" />
       <property name="hibernate.show_sql" value="true" />
       <property name="hibernate.format_sql" value="true" />


### PR DESCRIPTION
Hibernate knows how to talk to a number of different kinds of databases, and does so via dialects: classes which descend from and fulfill the contract of the abstract class Dialect. For PostgreSQL, Hibernate has added support for the features new versions of PostgreSQL expose by creating new dialects, so that users can switch between different versions of PostgreSQL just by switching dialects.

It turns out that the dialect I initially chose, way back in commit 7e7be38b9204699dfc2c345185eb9dc2fd044ae6 (part of PR #27), had a misleadingly general name: [`PostgreSQLDialect` is deprecated](https://docs.jboss.org/hibernate/orm/5.0/javadocs/org/hibernate/dialect/PostgreSQLDialect.html), and corresponds to either PostgreSQL 8.2 or 8.4 (it's not super clear which, but either way, quite old).

Our documentation says the PSM requires at least PostgreSQL 9.6, and given that, we can use a more modern dialect. WildFly 10 (which we're still building around; see also #520) provides Hibernate 5.0, and [the most recent PostgreSQL dialect supported in that version is 9.4](https://docs.jboss.org/hibernate/orm/5.0/javadocs/org/hibernate/dialect/PostgreSQL94Dialect.html). Notable additional functionality between `PostgreSQLDialect` and `PostgreSQL94Dialect` is better date/time support and the JSON data type.

(I should note that this is not driven by a need to have any of those additional features; just that every time I look at `persistence.xml` I see that deprecation warning and would like to clean it up.)

I tested this by deploying, logging in, and looking at a previously submitted enrollment application; I believe this to be a low-risk change, and I trust in the integration tests.

Issue #1 Support PostgreSQL or other open source database
Issue #36 Use Hibernate 5, instead of 4