### PR TITLE
Fix hyperlink text

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
@@ -118,7 +118,7 @@
     </table>
     <div class="clearFixed"></div>
     <div class="tableBottom">
-        <a href="javascript:;" id="addLicense">+ Add Another License/Certification</a>
+        <a href="javascript:;" id="addLicense">+ Add A License/Certification</a>
     </div>
     <div class="tl"></div>
     <div class="tr"></div>


### PR DESCRIPTION
This fixes the hyperlink which allows a provider to add a
License/Certification to an enrollment application.

Providers may add new enrollment applications, or edit existing
enrollment applications. Each enrollment application requires
at least one License/Certification. A provider may add several
License/Certifications.

Before this commit, the hyperlink text read:
"+ Add Another License/Certification". That text is not applicable to
a new enrollment application which contains no License/Certifications.

This changes the hyperlink text to read:
"+ Add A License/Certification". This text is applicable to both new
and existing enrollment applications.

Fixes #155 Tell user to add "a" (first), not "another"
           license/certification