### PR TITLE
Fix NPE on null isEftAccepted

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhir.java
@@ -31,7 +31,8 @@ public class EnrollmentAcceptsEftToFhir
                 if ("Y".equals(affiliation.getPrimaryInd())) {
                     Entity entity = affiliation.getEntity();
                     if (entity instanceof Organization) {
-                        if (((Organization) entity).isEftAccepted()) {
+                        if (Boolean.TRUE.equals(
+                                ((Organization) entity).isEftAccepted())) {
                             return true;
                         }
                     }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhirTest.groovy
@@ -87,6 +87,17 @@ class EnrollmentAcceptsEftToFhirTest extends Specification {
         result.value.booleanValue() == true
     }
 
+    def "Primary affiliation with no data on EFT does not accept EFT"() {
+        given:
+        addAffiliation(enrollment, eftAccepted: null, primary: true)
+
+        when:
+        def result = transformer.apply(enrollment)
+
+        then:
+        result.value.booleanValue() == false
+    }
+
     def "Transforming null throws"() {
         when:
         transformer.apply(null)


### PR DESCRIPTION
The only place the PSM asks if an organization accepts EFT payments is for individual providers who own a private practice. [An individual provider attached to a group practice is not asked whether or not that group practice accepts EFT, and nor are organizational providers](https://github.com/SolutionGuidance/psm/issues/411#issuecomment-352091723).

The code to include EFT data in the FHIR API assumes that every organization either does or does not accept EFT; that approach doesn't work for organizations for which we have no data.

Fix the null pointer exception resulting from that incomplete understanding of the world by assuming that an organization which does not have any data for EFT does not accept EFT. This may not be the approach we want to stick with in the long run, but it's a reasonable approach until we make that decision.

Issue #441 Add a "do you accept EFT" checkbox
Issue #846 Add new fields to FHIR API
PR #859 Add EFT Acceptance Indicator to API
Resolves #881 FHIR API returns 404 when no value for EFT accepted