### PR TITLE
376 fix right justified colons on forms

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp
@@ -1,18 +1,15 @@
 <div class="row">
     <label>Contact Name</label>
-    <span class="floatL"><b>:</b></span>
     <span id="contactName">${requestScope['_02_contactName']}</span>
 </div>
 
 <div class="row">
     <label>Contact Email Address</label>
-    <span class="floatL"><b>:</b></span>
     <span id="contactEmail">${requestScope['_02_contactEmail']}</span>
 </div>
 
 <div class="row">
     <label>Contact Phone Number</label>
-    <span class="floatL"><b>:</b></span>
     <span>
         ${requestScope['_02_contactPhone1']}
         <c:if test="${requestScope['_02_contactPhone2'] ne ''}"> - </c:if>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/person_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/person_info.jsp
@@ -1,32 +1,26 @@
     <div class="leftCol">
         <div class="row">
             <label>First Name</label>
-            <span class="floatL"><b>:</b></span>
             <span id="firstName">${requestScope['_02_firstName']}</span>
         </div>
         <div class="row">
             <label>Middle Name</label>
-            <span class="floatL"><b>:</b></span>
             <span id="middleName">${requestScope['_02_middleName']}</span>
         </div>
         <div class="row">
             <label>Last Name</label>
-            <span class="floatL"><b>:</b></span>
             <span id="lastName">${requestScope['_02_lastName']}</span>
         </div>
         <div class="row">
             <label>NPI</label>
-            <span class="floatL"><b>:</b></span>
             <span id="npi">${requestScope['_02_npi']}</span>
         </div>
         <div class="row">
             <label>Social Security Number</label>
-            <span class="floatL"><b>:</b></span>
             <span id="ssn">${requestScope['_02_ssn']}</span>
         </div>
         <div class="row">
             <label>Date of Birth</label>
-            <span class="floatL"><b>:</b></span>
             <span id="dob">${requestScope['_02_dob']}</span>
         </div>
     </div>
@@ -34,7 +28,6 @@
     <div class="rightCol">
         <div class="row">
             <label>Email Address</label>
-            <span class="floatL"><b>:</b></span>
             <span id="email">${requestScope['_02_email']}</span>
         </div>
     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/practice_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/practice_type.jsp
@@ -1,7 +1,6 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div class="row">
     <label>Do you maintain your own private practice?</label>
-    <span class="floatL"><b>:</b></span>
     <span id="maintainsOwnPrivatePractice"><c:choose>
         <c:when test="${requestScope['_04_maintainsOwnPrivatePractice'] eq 'Y'}">Yes</c:when>
         <c:when test="${requestScope['_04_maintainsOwnPrivatePractice'] eq 'N'}">No</c:when>
@@ -9,7 +8,6 @@
 </div>
 <div class="row">
     <label>Are you employed and/or independently contracted by a group practice?</label>
-    <span class="floatL"><b>:</b></span>
     <span id="employedOrContractedByGroup"><c:choose>
         <c:when test="${requestScope['_04_employedOrContractedByGroup'] eq 'Y'}">Yes</c:when>
         <c:when test="${requestScope['_04_employedOrContractedByGroup'] eq 'N'}">No</c:when>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
@@ -3,27 +3,22 @@
 
 <div class="row">
     <label>Primary Practice Name</label>
-    <span class="floatL"><b>:</b></span>
     <span id="primaryPracticeName">${requestScope['_06_name']}</span>
 </div>
 <div class="row">
     <label>Group NPI/UMPI</label>
-    <span class="floatL"><b>:</b></span>
     <span id="groupNPI">${requestScope['_06_npi']}</span>
 </div>
 <div class="row">
     <label>State Medicaid ID</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_06_stateMedicaidId']}</span>
 </div>
 <div class="row">
     <label>Effective Date</label>
-    <span class="floatL"><b>:</b></span>
     <span id="effectiveDate">${requestScope['_06_effectiveDate']}</span>
 </div>
 <div class="row">
     <label>Practice Address</label>
-    <span class="floatL"><b>:</b></span>
     <h:address name="practice"
         streetAddress="${requestScope['_06_addressLine1']}"
         extendedAddress="${requestScope['_06_addressLine2']}"
@@ -34,14 +29,12 @@
 </div>
 <div class="row">
     <label>Practice Phone Number</label>
-    <span class="floatL"><b>:</b></span>
     <span id="practicePhoneNumber">
     ${requestScope['_06_phone1']}<c:if test="${requestScope['_06_phone2'] ne ''}"> - </c:if>${requestScope['_06_phone2']}<c:if test="${requestScope['_06_phone3'] ne ''}"> - </c:if>${requestScope['_06_phone3']}<c:if test="${requestScope['_06_phone4'] ne ''}"> ext. </c:if>${requestScope['_06_phone4']}
     </span>
 </div>
 <div class="row">
     <label>Practice Fax Number</label>
-    <span class="floatL"><b>:</b></span>
     <c:set var="formName" value="_06_faxNumber"></c:set>
     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
     <span id="practiceFaxNumber">
@@ -50,7 +43,6 @@
 </div>
 <div class="row">
     <label>Reimbursement Address</label>
-    <span class="floatL"><b>:</b></span>
     <c:if test="${requestScope['_06_reimbursementSameAsPrimary'] eq 'Y'}">
         <span id="billingSameAsPrimary">Same As Above</span>
     </c:if>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
@@ -3,22 +3,18 @@
 
 <div class="row">
     <label>Private Practice Name</label>
-    <span class="floatL"><b>:</b></span>
     <span id="privatePracticeName">${requestScope['_05_name']}</span>
 </div>
 <div class="row">
     <label>Effective Date</label>
-    <span class="floatL"><b>:</b></span>
     <span id="effectiveDate">${requestScope['_05_effectiveDate']}</span>
 </div>
 <div class="row">
     <label>Group NPI/UMPI</label>
-    <span class="floatL"><b>:</b></span>
     <span id="groupNPI">${requestScope['_05_npi']}</span>
 </div>
 <div class="row">
     <label>Practice Address</label>
-    <span class="floatL"><b>:</b></span>
     <h:address name="practice"
         streetAddress="${requestScope['_05_addressLine1']}"
         extendedAddress="${requestScope['_05_addressLine2']}"
@@ -29,14 +25,12 @@
 </div>
 <div class="row">
     <label>Practice Phone Number</label>
-    <span class="floatL"><b>:</b></span>
     <span id="practicePhoneNumber">
     ${requestScope['_05_phone1']}<c:if test="${requestScope['_05_phone2'] ne ''}"> - </c:if>${requestScope['_05_phone2']}<c:if test="${requestScope['_05_phone3'] ne ''}"> - </c:if>${requestScope['_05_phone3']}<c:if test="${requestScope['_05_phone4'] ne ''}"> ext. </c:if>${requestScope['_05_phone4']}
     </span>
 </div>
 <div class="row">
     <label>Practice Fax Number</label>
-    <span class="floatL"><b>:</b></span>
     <c:set var="formName" value="_05_faxNumber"></c:set>
     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
     <span id="practiceFaxNumber">
@@ -45,7 +39,6 @@
 </div>
 <div class="row">
     <label>Billing Address</label>
-    <span class="floatL"><b>:</b></span>
     <c:if test="${requestScope['_05_billingSameAsPrimary'] eq 'Y'}">
         <span id="billingSameAsPrimary">Same As Above</span>
     </c:if>
@@ -63,17 +56,14 @@
     <label>
       <abbr title="Federal Employer Identification Number">FEIN</abbr>
     </label>
-    <span class="floatL"><b>:</b></span>
     <span id="fein">${requestScope['_05_fein']}</span>
 </div>
 <div class="row">
     <label>MN Tax ID</label>
-    <span class="floatL"><b>:</b></span>
     <span id="stateTaxId">${requestScope['_05_stateTaxId']}</span>
 </div>
 <div class="row">
     <label>Fiscal Year End</label>
-    <span class="floatL"><b>:</b></span>
     <span id="fiscalYearEnd">
         ${requestScope['_05_fye1']}
         <c:if test="${requestScope['_05_fye2'] ne ''}">/</c:if>
@@ -82,12 +72,10 @@
 </div>
 <div class="row">
     <label>Do you accept <abbr title="Electronic Funds Transfer">EFT</abbr>?</label>
-    <span class="floatL"><b>:</b></span>
     <span id="eftAccepted">${requestScope['_05_eftAccepted'] ? 'Yes' : 'No'}</span>
 </div>
 <div class="row">
     <label>Remittance Sequence</label>
-    <span class="floatL"><b>:</b></span>
     <span id="remittanceSequence"><c:choose>
         <c:when test="${requestScope['_05_remittanceSequence'] eq 'PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER'}">
             Patient Account or Own Reference Number Order

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/tribal_information.jsp
@@ -5,7 +5,6 @@
     <div class="wholeCol">
         <div class="row">
             <label>Is applicant a provider at a Public Health Service (PHS) Indian Hospital?</label>
-            <span class="floatL"><b>:</b></span>
             <span id="worksOnReservation"><c:choose>
                 <c:when test="${requestScope['_13_worksOnReservation'] eq 'Y'}">Yes</c:when>
                 <c:when test="${requestScope['_13_worksOnReservation'] eq 'N'}">No</c:when>


### PR DESCRIPTION
Remove colons between labels and fields, on the following page:

On the provider 'View Enrollment Details' page:

- 'Personal Info' tab
- 'Practice Info' tab
- 'License Info' tab

	
Issue #376 Remove colons between form labels and fields