### PR TITLE
Refactor enrollment method helpers

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
@@ -26,7 +26,6 @@ import gov.medicaid.domain.rules.CMSKnowledgeUtility;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.EnrollmentStatus;
-import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.dto.ViewStatics;
 import gov.medicaid.process.enrollment.AcceptedHandler;
 import gov.medicaid.process.enrollment.EnrollmentMonitor;
@@ -238,36 +237,6 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
 
     private EntityManagerFactory getEmf() {
         return emf;
-    }
-
-    /**
-     * Starts the renewal process.
-     *
-     * @param ticket         the renewal request
-     * @param currentProfile the current profile for this provider
-     * @return the process instance id.
-     * @throws Exception for any errors encountered
-     */
-    private long renew(
-            EnrollmentType ticket,
-            EnrollmentType currentProfile
-    ) throws Exception {
-        return enroll(ticket);
-    }
-
-    /**
-     * Starts the update process.
-     *
-     * @param ticket         the update request
-     * @param currentProfile the current profile for this provider
-     * @return the process instance id.
-     * @throws Exception for any errors encountered
-     */
-    private long update(
-            EnrollmentType ticket,
-            EnrollmentType currentProfile
-    ) throws Exception {
-        return enroll(ticket);
     }
 
     /**
@@ -526,15 +495,11 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
                     ticket.setProcessInstanceId(processInstance);
 
                 } else if (ViewStatics.RENEWAL_REQUEST.equals(ticket.getRequestType().getDescription())) {
-                    ProviderProfile baseProfile = providerService.getProviderDetails(user, ticket.getDetails()
-                            .getProfileId());
-                    long processInstance = renew(XMLAdapter.toXML(ticket), XMLAdapter.toXML(baseProfile));
+                    long processInstance = enroll(XMLAdapter.toXML(ticket));
                     ticket.setProcessInstanceId(processInstance);
 
                 } else if (ViewStatics.UPDATE_REQUEST.equals(ticket.getRequestType().getDescription())) {
-                    ProviderProfile baseProfile = providerService.getProviderDetails(user, ticket.getDetails()
-                            .getProfileId());
-                    long processInstance = update(XMLAdapter.toXML(ticket), XMLAdapter.toXML(baseProfile));
+                    long processInstance = enroll(XMLAdapter.toXML(ticket));
                     ticket.setProcessInstanceId(processInstance);
                 }
             } catch (Exception e) {

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
@@ -490,15 +490,7 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
             ticket.setStatusDate(Calendar.getInstance().getTime());
 
             try {
-                if (ViewStatics.ENROLLMENT_REQUEST.equals(ticket.getRequestType().getDescription())) {
-                    long processInstance = enroll(XMLAdapter.toXML(ticket));
-                    ticket.setProcessInstanceId(processInstance);
-
-                } else if (ViewStatics.RENEWAL_REQUEST.equals(ticket.getRequestType().getDescription())) {
-                    long processInstance = enroll(XMLAdapter.toXML(ticket));
-                    ticket.setProcessInstanceId(processInstance);
-
-                } else if (ViewStatics.UPDATE_REQUEST.equals(ticket.getRequestType().getDescription())) {
+                if (isEnrollmentRequest(ticket)) {
                     long processInstance = enroll(XMLAdapter.toXML(ticket));
                     ticket.setProcessInstanceId(processInstance);
                 }
@@ -513,6 +505,17 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
         } catch (Exception e) {
             throw new PortalServiceException("Submission caused an error, see logs for details.", e);
         }
+    }
+
+    private boolean isEnrollmentRequest(Enrollment ticket) {
+        List<String> enrollmentRequestTypes = Arrays.asList(
+                ViewStatics.ENROLLMENT_REQUEST,
+                ViewStatics.RENEWAL_REQUEST,
+                ViewStatics.UPDATE_REQUEST
+        );
+        return enrollmentRequestTypes.contains(
+                ticket.getRequestType().getDescription()
+        );
     }
 
     /**

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
@@ -159,7 +159,9 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
      * @return the process instance id
      * @throws Exception for any errors encountered
      */
-    public long enroll(EnrollmentType enrollment) throws Exception {
+    public long enroll(
+            EnrollmentType enrollment
+    ) throws Exception {
         StatefulKnowledgeSession ksession = null;
         UserTransaction utx = context.getUserTransaction();
         boolean owner = false;
@@ -261,7 +263,10 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
      * @return the process instance id.
      * @throws Exception for any errors encountered
      */
-    public long update(EnrollmentType ticket, EnrollmentType currentProfile) throws Exception {
+    public long update(
+            EnrollmentType ticket,
+            EnrollmentType currentProfile
+    ) throws Exception {
         return enroll(ticket);
     }
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
@@ -159,7 +159,7 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
      * @return the process instance id
      * @throws Exception for any errors encountered
      */
-    public long enroll(
+    private long enroll(
             EnrollmentType enrollment
     ) throws Exception {
         StatefulKnowledgeSession ksession = null;
@@ -248,7 +248,7 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
      * @return the process instance id.
      * @throws Exception for any errors encountered
      */
-    public long renew(
+    private long renew(
             EnrollmentType ticket,
             EnrollmentType currentProfile
     ) throws Exception {
@@ -263,7 +263,7 @@ public class BusinessProcessServiceBean extends BaseService implements BusinessP
      * @return the process instance id.
      * @throws Exception for any errors encountered
      */
-    public long update(
+    private long update(
             EnrollmentType ticket,
             EnrollmentType currentProfile
     ) throws Exception {

--- a/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
@@ -40,15 +40,6 @@ public interface BusinessProcessService {
     void submitTicket(CMSUser user, long ticketId) throws PortalServiceException;
 
     /**
-     * Starts a new enrollment process.
-     *
-     * @param enrollment the enrollment requested
-     * @return the process instance id
-     * @throws Exception for any errors encountered
-     */
-    long enroll(EnrollmentType enrollment) throws Exception;
-
-    /**
      * Retrieves the available tasks for the given user and roles.
      *
      * @param username the user to get the tasks for
@@ -88,32 +79,6 @@ public interface BusinessProcessService {
             ProviderInformationType updates,
             boolean reject,
             String comment
-    ) throws Exception;
-
-    /**
-     * Starts the renewal process.
-     *
-     * @param ticket         the renewal request
-     * @param currentProfile the current profile for this provider
-     * @return the process instance id.
-     * @throws Exception for any errors encountered
-     */
-    long renew(
-            EnrollmentType ticket,
-            EnrollmentType currentProfile
-    ) throws Exception;
-
-    /**
-     * Starts the update process.
-     *
-     * @param ticket         the update request
-     * @param currentProfile the current profile for this provider
-     * @return the process instance id.
-     * @throws Exception for any errors encountered
-     */
-    long update(
-            EnrollmentType ticket,
-            EnrollmentType currentProfile
     ) throws Exception;
 
     /**


### PR DESCRIPTION
In preparation for adding audit logging around automatic screenings, and out of a general desire to have easier-to-understand code, refactor some of the code around submitting a new enrollment application and remove some not-so-helpful helper methods.

More details in the commit messages.

There should be no functional changes as a result of this PR. The least-obvious thing to me was whether or not there was value in doing the profile lookups previously involved in an update or a renewal; I traced the code and satisfied myself that the implicit permissions check I removed happens more than once in the process of submitting that update or renewal, and so this one is safe to remove; I'd appreciate someone double-checking my work on that!

Issue #740 Re-screen approved providers monthly