### PR TITLE
Fix #889.  Add checks for SSNs in groups

### DIFF
--- a/psm-app/cms-business-process/src/test/groovy/gov/medicaid/process/enrollment/DmfScreeningHandlerTest.groovy
+++ b/psm-app/cms-business-process/src/test/groovy/gov/medicaid/process/enrollment/DmfScreeningHandlerTest.groovy
@@ -6,10 +6,19 @@ import org.drools.runtime.process.WorkItem
 import org.drools.runtime.process.WorkItemManager
 
 import gov.medicaid.domain.model.ApplicantInformationType
+import gov.medicaid.domain.model.BeneficialOwnerType
+import gov.medicaid.domain.model.DesignatedContactType
+import gov.medicaid.domain.model.DesignatedContactInformationType
 import gov.medicaid.domain.model.EnrollmentProcess
 import gov.medicaid.domain.model.EnrollmentType
+import gov.medicaid.domain.model.GroupMemberType
 import gov.medicaid.domain.model.IndividualApplicantType
+import gov.medicaid.domain.model.MemberInformationType
+import gov.medicaid.domain.model.OwnershipInformationType
+import gov.medicaid.domain.model.PersonType
 import gov.medicaid.domain.model.ProviderInformationType
+import gov.medicaid.domain.model.QualifiedProfessionalType
+import gov.medicaid.domain.model.QualifiedProfessionalsType
 import gov.medicaid.entities.AutomaticScreening
 import gov.medicaid.entities.Enrollment
 import spock.lang.Specification
@@ -25,7 +34,7 @@ class DmfScreeningHandlerTest extends Specification {
         handler = new DmfScreeningHandler(service, entityManager)
     }
 
-    def buildMockModel() {
+    def buildMockModelForIndividual() {
         new EnrollmentProcess([
             enrollment: new EnrollmentType([
                 objectId: "1",
@@ -40,6 +49,61 @@ class DmfScreeningHandlerTest extends Specification {
         ])
     }
 
+    // This organization structure is complete for testing purposes
+    // but actually can't exist via the normal workflow
+    def buildMockModelForOrganization() {
+        new EnrollmentProcess([
+            enrollment: new EnrollmentType([
+                objectId: "1",
+                providerInformation: new ProviderInformationType([
+                    qualifiedProfessionals: new QualifiedProfessionalsType([
+                        qualifiedProfessional: [
+                            new QualifiedProfessionalType([socialSecurityNumber: "123456789"]),
+                            new QualifiedProfessionalType([socialSecurityNumber: "223456789"])
+                        ]
+                    ]),
+                    designatedContactInformation: new DesignatedContactInformationType([
+                        designatedContact: [
+                            new DesignatedContactType([socialSecurityNumber: "323456789"]),
+                            new DesignatedContactType([socialSecurityNumber: "223456789"])  // duplicate SSN purposeful
+                        ]
+                    ]),
+                    memberInformation: new MemberInformationType([
+                        groupMember: [
+                            new GroupMemberType([socialSecurityNumber: "423456789"]),
+                            new GroupMemberType([socialSecurityNumber: "523456789"])
+                        ]
+                    ]),
+                    ownershipInformation: new OwnershipInformationType([
+                        beneficialOwner: [
+                            new BeneficialOwnerType([
+                                personInformation: new PersonType([
+                                    socialSecurityNumber: "623456789"
+                                ])
+                            ])
+                        ]
+                    ])
+                ])
+            ])
+        ])
+    }
+
+    def notFoundResult(ssn) {
+        """{
+               "ssn": "$ssn",
+               "full_name": null,
+               "dmf_record_present": false
+           }"""
+    }
+
+    def foundResult(ssn) {
+        """{
+               "ssn": "$ssn",
+               "full_name": "Jane M Smith Jr.",
+               "dmf_record_present": true
+           }"""
+    }
+
     def "Individual enrollment screened - not found"() {
         given:
 
@@ -49,16 +113,11 @@ class DmfScreeningHandlerTest extends Specification {
         workItem.results >> results
 
         when:
-        workItem.getParameter("model") >> buildMockModel()
+        workItem.getParameter("model") >> buildMockModelForIndividual()
         1 * entityManager.find(Enrollment.class, 1) >>
                 new Enrollment()
 
-        1 * service.getResult("123456789") >>
-                '''{
-                "ssn": "123456789",
-                "full_name": null,
-                "dmf_record_present": false
-             }'''
+        1 * service.getResult("123456789") >> notFoundResult("123456789")
 
         handler.executeWorkItem(workItem, Mock(WorkItemManager))
 
@@ -84,7 +143,7 @@ class DmfScreeningHandlerTest extends Specification {
         workItem.results >> results
 
         when:
-        workItem.getParameter("model") >> buildMockModel()
+        workItem.getParameter("model") >> buildMockModelForIndividual()
         1 * entityManager.find(Enrollment.class, 1) >>
                 new Enrollment()
 
@@ -119,16 +178,11 @@ class DmfScreeningHandlerTest extends Specification {
         workItem.results >> results
 
         when:
-        workItem.getParameter("model") >> buildMockModel()
+        workItem.getParameter("model") >> buildMockModelForIndividual()
         1 * entityManager.find(Enrollment.class, 1) >>
                 new Enrollment()
 
-        1 * service.getResult("123456789") >>
-                '''{
-                "ssn": "123456789",
-                "full_name": "Jane M Smith Jr.",
-                "dmf_record_present": true
-             }'''
+        1 * service.getResult("123456789") >> foundResult("123456789")
 
         handler.executeWorkItem(workItem, Mock(WorkItemManager))
 
@@ -153,11 +207,122 @@ class DmfScreeningHandlerTest extends Specification {
         workItem.results >> results
 
         when:
-        workItem.getParameter("model") >> buildMockModel()
+        workItem.getParameter("model") >> buildMockModelForIndividual()
         1 * entityManager.find(Enrollment.class, 1) >>
                 new Enrollment()
 
         1 * service.getResult("123456789") >> { throw new IOException("Testing") }
+
+        handler.executeWorkItem(workItem, Mock(WorkItemManager))
+
+        then:
+
+        1 * entityManager.merge(*_) >> { arguments ->
+            def enrollment = arguments[0]
+            assert enrollment.automaticScreenings.size == 1
+            assert enrollment.automaticScreenings[0].result == AutomaticScreening.Result.ERROR
+            assert enrollment.automaticScreenings[0].matches.size() == 0
+        }
+        workItem.results["model"].enrollment.providerInformation.verificationStatus == null
+    }
+
+    def "Group enrollment screened - not found"() {
+        given:
+
+        def workItem = Mock(WorkItem)
+        def results = new HashMap()
+
+        workItem.results >> results
+
+        when:
+        workItem.getParameter("model") >> buildMockModelForOrganization()
+        1 * entityManager.find(Enrollment.class, 1) >>
+                new Enrollment()
+
+        1 * service.getResult("123456789") >> notFoundResult("123456789")
+        1 * service.getResult("223456789") >> notFoundResult("223456789")
+        1 * service.getResult("323456789") >> notFoundResult("323456789")
+        1 * service.getResult("423456789") >> notFoundResult("423456789")
+        1 * service.getResult("523456789") >> notFoundResult("523456789")
+        1 * service.getResult("623456789") >> notFoundResult("623456789")
+
+        handler.executeWorkItem(workItem, Mock(WorkItemManager))
+
+        then:
+
+        1 * entityManager.merge(*_) >> { arguments ->
+            def enrollment = arguments[0]
+            assert enrollment.automaticScreenings.size == 1
+            assert enrollment.automaticScreenings[0].result == AutomaticScreening.Result.PASS
+            assert enrollment.automaticScreenings[0].matches.size() == 6
+            assert enrollment.automaticScreenings[0].matches[0].ssn == "123456789"
+            assert enrollment.automaticScreenings[0].matches[1].ssn == "223456789"
+            assert enrollment.automaticScreenings[0].matches[2].ssn == "323456789"
+            assert enrollment.automaticScreenings[0].matches[3].ssn == "423456789"
+            assert enrollment.automaticScreenings[0].matches[4].ssn == "523456789"
+            assert enrollment.automaticScreenings[0].matches[5].ssn == "623456789"
+        }
+        workItem.results["model"].enrollment.providerInformation.verificationStatus.notInDmf == "Y"
+    }
+
+    def "Group enrollment screened - two found"() {
+        given:
+
+        def workItem = Mock(WorkItem)
+        def results = new HashMap()
+
+        workItem.results >> results
+
+        when:
+        workItem.getParameter("model") >> buildMockModelForOrganization()
+        1 * entityManager.find(Enrollment.class, 1) >>
+                new Enrollment()
+
+        1 * service.getResult("123456789") >> notFoundResult("123456789")
+        1 * service.getResult("223456789") >> notFoundResult("223456789")
+        1 * service.getResult("323456789") >> foundResult("323456789")
+        1 * service.getResult("423456789") >> notFoundResult("423456789")
+        1 * service.getResult("523456789") >> foundResult("523456789")
+        1 * service.getResult("623456789") >> notFoundResult("623456789")
+
+        handler.executeWorkItem(workItem, Mock(WorkItemManager))
+
+        then:
+
+        1 * entityManager.merge(*_) >> { arguments ->
+            def enrollment = arguments[0]
+            assert enrollment.automaticScreenings.size == 1
+            assert enrollment.automaticScreenings[0].result == AutomaticScreening.Result.FAIL
+            assert enrollment.automaticScreenings[0].matches.size() == 6
+            assert enrollment.automaticScreenings[0].matches[0].ssn == "123456789"
+            assert enrollment.automaticScreenings[0].matches[1].ssn == "223456789"
+            assert enrollment.automaticScreenings[0].matches[2].ssn == "323456789"
+            assert enrollment.automaticScreenings[0].matches[3].ssn == "423456789"
+            assert enrollment.automaticScreenings[0].matches[4].ssn == "523456789"
+            assert enrollment.automaticScreenings[0].matches[5].ssn == "623456789"
+        }
+        workItem.results["model"].enrollment.providerInformation.verificationStatus.notInDmf == "N"
+    }
+
+    def "Group enrollment screened - error"() {
+        given:
+
+        def workItem = Mock(WorkItem)
+        def results = new HashMap()
+
+        workItem.results >> results
+
+        when:
+        workItem.getParameter("model") >> buildMockModelForOrganization()
+        1 * entityManager.find(Enrollment.class, 1) >>
+                new Enrollment()
+
+        1 * service.getResult("123456789") >> notFoundResult("123456789")
+        1 * service.getResult("223456789") >> notFoundResult("223456789")
+        1 * service.getResult("323456789") >> foundResult("323456789")
+        1 * service.getResult("423456789") >> notFoundResult("423456789")
+        1 * service.getResult("523456789") >> { throw new IOException("Testing") }
+        0 * service.getResult("623456789") >> notFoundResult("623456789") // To ensure it got shored by error
 
         handler.executeWorkItem(workItem, Mock(WorkItemManager))
 

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -71,9 +71,17 @@ Feature: General Accessibility Checks for Admins
     Then I should have no accessibility issues
 
   # This depends implicitly on the individual enrollment submission tests
-  Scenario: Admin Review Enrollment DMF Page
+  Scenario: Admin Review Enrollment DMF Page - Individual
     Given I am logged in as an admin
     And I am on the Pending page
     And I open the Review Enrollment page for NPI '0000000006'
+    And I open the DMF Details page
+    Then I should have no accessibility issues
+
+  # This depends implicitly on the group enrollment submission tests
+  Scenario: Admin Review Enrollment DMF Page - Group
+    Given I am logged in as an admin
+    And I am on the Pending page
+    And I open the Review Enrollment page for NPI '1234567893'
     And I open the DMF Details page
     Then I should have no accessibility issues

--- a/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
@@ -23,6 +23,7 @@ import gov.medicaid.domain.model.AgencyInformationType;
 import gov.medicaid.domain.model.ApplicantInformationType;
 import gov.medicaid.domain.model.AttachedDocumentsType;
 import gov.medicaid.domain.model.ContactInformationType;
+import gov.medicaid.domain.model.DesignatedContactInformationType;
 import gov.medicaid.domain.model.EnrollmentProcess;
 import gov.medicaid.domain.model.EnrollmentStatusChangeType;
 import gov.medicaid.domain.model.EnrollmentStatusHistoryType;
@@ -588,5 +589,19 @@ public class XMLUtility {
             provider.setQualifiedProfessionals(new QualifiedProfessionalsType());
         }
         return provider.getQualifiedProfessionals();
+    }
+
+    /**
+     * Null safe get for the designated contact information.
+     *
+     * @param enrollment the object to get the property from
+     * @return the required property
+     */
+    public static DesignatedContactInformationType nsGetDesignatedContactInformation(EnrollmentType enrollment) {
+        ProviderInformationType provider = nsGetProvider(enrollment);
+        if (provider.getDesignatedContactInformation() == null) {
+            provider.setDesignatedContactInformation(new DesignatedContactInformationType());
+        }
+        return provider.getDesignatedContactInformation();
     }
 }


### PR DESCRIPTION
This PR changes the DMF check to look through the entire enrollment for socials that can be checked.

Test via making a group enrollment with multiple members, and see the different DMF calls that will add up to one failure/sucess.