### PR TITLE
WIP 847 - Implement read / write authentication

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/PsmApiServlet.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/PsmApiServlet.java
@@ -3,10 +3,12 @@ package gov.medicaid.api;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.RestfulServer;
+import gov.medicaid.api.interceptors.BasicSecurityInterceptor;
+import gov.medicaid.api.interceptors.TaskResourceAuthorizationInterceptor;
 import gov.medicaid.services.ProviderEnrollmentService;
+import gov.medicaid.services.RegistrationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
-
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import java.util.Collections;
@@ -17,6 +19,9 @@ public class PsmApiServlet extends RestfulServer {
 
     @Autowired
     private ProviderEnrollmentService providerEnrollmentService;
+
+    @Autowired
+    private RegistrationService registrationService;
 
     @Override
     protected void initialize() throws ServletException {
@@ -39,6 +44,7 @@ public class PsmApiServlet extends RestfulServer {
         this.setDefaultPrettyPrint(true);
         this.setDefaultResponseEncoding(EncodingEnum.JSON);
 
+        setUpInterceptors();
         setResourceProviders(Collections.singletonList(
                 new TaskResourceProvider(providerEnrollmentService)
         ));
@@ -48,4 +54,24 @@ public class PsmApiServlet extends RestfulServer {
     public void setProviderEnrollmentService(ProviderEnrollmentService providerEnrollmentService) {
         this.providerEnrollmentService = providerEnrollmentService;
     }
+
+    public void setRegistrationService(RegistrationService registrationService) {
+        this.registrationService = registrationService;
+    }
+
+    private void setUpInterceptors() {
+        addBasicSecurityInterceptor();
+        addTaskResourceAuthorizationInterceptor();
+    }
+
+    private void addBasicSecurityInterceptor() {
+        BasicSecurityInterceptor basicSecurity = new BasicSecurityInterceptor(registrationService);
+        registerInterceptor(basicSecurity);
+    }
+
+    private void addTaskResourceAuthorizationInterceptor() {
+        TaskResourceAuthorizationInterceptor taskResourceAuthorization = new TaskResourceAuthorizationInterceptor();
+        registerInterceptor(taskResourceAuthorization);
+    }
+
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/BasicSecurityInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/BasicSecurityInterceptor.java
@@ -1,0 +1,96 @@
+package gov.medicaid.api.interceptors;
+
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.interceptor.InterceptorAdapter;
+import gov.medicaid.entities.CMSUser;
+import gov.medicaid.services.RegistrationService;
+import org.apache.commons.codec.binary.Base64;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+public class BasicSecurityInterceptor extends InterceptorAdapter {
+    /**
+     * Registration Service (used for authentication.)
+     */
+    private final RegistrationService registrationService;
+
+    public BasicSecurityInterceptor(RegistrationService registrationService) {
+        this.registrationService = registrationService;
+    }
+
+    /**
+     * This interceptor implements HTTP Basic Auth, which specifies that
+     * a username and password are provided in a header called Authorization.
+     */
+    @Override
+    public boolean incomingRequestPostProcessed(
+            RequestDetails theRequestDetails,
+            HttpServletRequest theRequest,
+            HttpServletResponse theResponse)
+            throws AuthenticationException {
+        String authHeader = theRequest.getHeader("Authorization");
+        String username = getUsernameFromBasicAuthHeader(authHeader);
+        String password = getPasswordFromBasicAuthHeader(authHeader);
+        if (authenticateUser(username, password)
+         && setCurrentUser(theRequestDetails, username)) {
+            return true;
+        } else {
+            throw generateAuthenticationException("Invalid username or password");
+        }
+    }
+
+    private boolean authenticateUser(String username, String password) {
+        try {
+            return registrationService.authenticate(username, password);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Register the current CMS user in the request details userdata.
+     * Returns false if the user cannot be set.
+     *
+     * @param theRequestDetails The RequestDetails object to store the user in
+     * @param username          The username to be looked up
+     */
+    private boolean setCurrentUser(
+            RequestDetails theRequestDetails,
+            String username) {
+        try {
+            CMSUser currentUser = registrationService.findByUsername(username);
+            Map<Object, Object> userData = theRequestDetails.getUserData();
+            userData.put("currentUser", currentUser);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+
+    private String getUsernameFromBasicAuthHeader(String authHeader) throws AuthenticationException {
+        if (authHeader == null || authHeader.startsWith("Basic ") == false) {
+            throw generateAuthenticationException("Invalid or missing authorization header");
+        }
+        String base64 = authHeader.substring("Basic ".length());
+        String base64decoded = new String(Base64.decodeBase64(base64));
+        String[] parts = base64decoded.split(":", 2);
+        return parts[0];
+    }
+
+    private String getPasswordFromBasicAuthHeader(String authHeader) throws AuthenticationException {
+        if (authHeader == null || authHeader.startsWith("Basic ") == false) {
+            throw generateAuthenticationException("Invalid or missing authorization header");
+        }
+        String base64 = authHeader.substring("Basic ".length());
+        String base64decoded = new String(Base64.decodeBase64(base64));
+        String[] parts = base64decoded.split(":", 2);
+        return parts[1];
+    }
+
+    private AuthenticationException generateAuthenticationException(String message) {
+        return (new AuthenticationException(message))
+            .addAuthenticateHeaderForRealm("psm");
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/TaskResourceAuthorizationInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/TaskResourceAuthorizationInterceptor.java
@@ -1,0 +1,30 @@
+package gov.medicaid.api.interceptors;
+
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor;
+import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
+import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRuleBuilder;
+import ca.uhn.fhir.rest.server.interceptor.auth.RuleBuilder;
+import gov.medicaid.entities.CMSUser;
+import java.util.List;
+
+public class TaskResourceAuthorizationInterceptor extends AuthorizationInterceptor {
+
+    @Override
+    public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
+
+        IAuthRuleBuilder rules = new RuleBuilder();
+        CMSUser user = (CMSUser) theRequestDetails.getUserData().get("currentUser");
+        if (user.getApiRead()) {
+            rules = rules.allow().read().allResources().withAnyId().andThen();
+        }
+        if (user.getApiWrite()) {
+            rules = rules.allow().write().allResources().withAnyId().andThen();
+        }
+
+        // Deny everything that has not been granted
+        rules.denyAll();
+        return rules.build();
+    }
+
+}


### PR DESCRIPTION
As per Issue #847 we need basic authentication on top of our API. This implementation uses HTTP Basic Auth.  Replacing this authentication with something else (e.g. OAuth2) is as simple as creating a new authentication interceptor.

There are two new interceptors in the FHIR Rest server.  The first makes sure the user is logged in at all.  The second specifies what resources the user is allowed to read and write.

Some high level information about FHIR interceptors can bee seen in their [server security documentation](http://hapifhir.io/doc_rest_server_security.html).  It is possible that their RuleSet object may be a useful tool down the line if / when there is a need for more granular permission controls.