### PR TITLE
Fix #822.  Add provider information to Applications By Reviewer Report.

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
@@ -74,12 +74,14 @@
           </div>
           <c:choose>
             <c:when test="${fn:length(enrollments) gt 0}">
-              <div class="reportTable tableData dashboardPanel">
+              <div class="reportTable tableData">
                 <div class="tableData">
                   <table class="generalTable">
                     <thead>
                       <tr>
                         <th>Application ID</th>
+                        <th>Provider Name</th>
+                        <th>Provider Type</th>
                         <th>Submission Date</th>
                         <th>Reviewed By</th>
                         <th>Review Date</th>
@@ -93,6 +95,8 @@
                             ${enrollment.ticketId}
                           </a>
                         </td>
+                        <td>${enrollment.details.entity.name}</td>
+                        <td>${enrollment.details.entity.providerType.description}</td>
                         <td><fmt:formatDate value="${enrollment.createdOn}" pattern="dd MMMM yyyy" /></td>
                         <td>${enrollment.lastUpdatedBy.username}</td>
                         <td><fmt:formatDate value="${enrollment.statusDate}" pattern="dd MMMM yyyy" /></td>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
@@ -80,6 +80,8 @@ public class ApplicationsByReviewerReportController extends gov.medicaid.control
 
             csvPrinter.printRecord(
                 "Application ID",
+                "Provider Name",
+                "Provider Type",
                 "Submission Date",
                 "Reviewed By",
                 "Review Date",
@@ -87,6 +89,8 @@ public class ApplicationsByReviewerReportController extends gov.medicaid.control
             for (Enrollment enrollment : enrollments) {
                 csvPrinter.printRecord(
                     enrollment.getTicketId(),
+                    enrollment.getDetails().getEntity().getName(),
+                    enrollment.getDetails().getEntity().getProviderType().getDescription(),
                     enrollment.getCreatedOn(),
                     enrollment.getLastUpdatedBy().getUsername(),
                     enrollment.getStatusDate(),
@@ -108,6 +112,16 @@ public class ApplicationsByReviewerReportController extends gov.medicaid.control
         criteria.setCreateDateEnd(endDate);
         criteria.setAscending(true);
         criteria.setSortColumn("created_at");
-        return enrollmentService.searchEnrollments(criteria).getItems();
+
+        List<Enrollment> results = enrollmentService.searchEnrollments(criteria).getItems();
+
+        results.stream()
+            .forEach(e -> {
+                e.setDetails(
+                    enrollmentService.getProviderDetailsByTicket(e.getTicketId(), true)
+                );
+            });
+
+        return results;
     }
 }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
@@ -10,6 +10,9 @@ import org.springframework.mock.web.MockHttpServletResponse
 import gov.medicaid.entities.CMSUser
 import gov.medicaid.entities.Enrollment
 import gov.medicaid.entities.EnrollmentStatus
+import gov.medicaid.entities.Person
+import gov.medicaid.entities.ProviderProfile
+import gov.medicaid.entities.ProviderType
 import gov.medicaid.entities.SearchResult
 import gov.medicaid.services.ProviderEnrollmentService
 import spock.lang.Specification
@@ -30,6 +33,15 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
             lastUpdatedBy: new CMSUser([username: lastUpdatedBy]),
             statusDate: toDate(statusDate),
             status: new EnrollmentStatus([description: status])
+        ])
+    }
+
+    private makeProviderProfile(providerName, providerType) {
+        return new ProviderProfile([
+            entity: new Person([
+                name: providerName,
+                providerType: new ProviderType([description: providerType])
+            ])
         ])
     }
 
@@ -64,12 +76,14 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
 
         then:
         records[0][0] == "Application ID"
-        records[0][1] == "Submission Date"
-        records[0][2] == "Reviewed By"
-        records[0][3] == "Review Date"
-        records[0][4] == "Status"
+        records[0][1] == "Provider Name"
+        records[0][2] == "Provider Type"
+        records[0][3] == "Submission Date"
+        records[0][4] == "Reviewed By"
+        records[0][5] == "Review Date"
+        records[0][6] == "Status"
         records.size == 1
-        records[0].size() == 5
+        records[0].size() == 7
     }
 
     def "csv with an enrollments"() {
@@ -79,6 +93,7 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
             makeEnrollment(1234, "2018-05-05 12:32:33 PST", "admin", "2018-05-08 5:03:55 PST", "TEST")
         ])
         1 * service.searchEnrollments(_) >> results
+        1 * service.getProviderDetailsByTicket(1234, true) >> makeProviderProfile("Provider", "Type");
 
         def response = new MockHttpServletResponse()
 
@@ -89,12 +104,14 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
 
         then:
         records.size == 2
-        records[1].size() == 5
+        records[1].size() == 7
         records[1][0] == "1234"
-        records[1][1] == "Sat May 05 20:32:33 UTC 2018"
-        records[1][2] == "admin"
-        records[1][3] == "Tue May 08 13:03:55 UTC 2018"
-        records[1][4] == "TEST"
+        records[1][1] == "Provider"
+        records[1][2] == "Type"
+        records[1][3] == "Sat May 05 20:32:33 UTC 2018"
+        records[1][4] == "admin"
+        records[1][5] == "Tue May 08 13:03:55 UTC 2018"
+        records[1][6] == "TEST"
     }
 
     private testData() {


### PR DESCRIPTION
Test by looking at new columns in Applications By Reviewer Report.  Could add checks on the data being there to avoid NPEs, but I believe this data is basically required for all applications even though the object model doesn't enforce it at this time.