### PR TITLE
Add date of birth field to PSM FHIR API

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityToFhir.java
@@ -37,6 +37,7 @@ public class EntityToFhir implements Function<Entity, DomainResource> {
         practitioner.addIdentifier(ssn(person));
         practitioner.addIdentifier(npi(person));
         practitioner.addName(name(person));
+        practitioner.setBirthDate(person.getDob());
         return practitioner;
     }
 

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EntityToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EntityToFhirTest.groovy
@@ -157,6 +157,26 @@ class EntityToFhirTest extends Specification {
         !name.hasPeriod()
     }
 
+    def "Individual's date of birth is set correctly"() {
+        given:
+        individual.setDob(new Date(1985, 6, 25))
+
+        when:
+        def result = transformer.apply(individual) as Practitioner
+
+        then:
+        result.hasBirthDate()
+        result.getBirthDate() == new Date(1985, 6, 25)
+    }
+
+    def "Individual's date of birth is not set"() {
+        when:
+        def result = transformer.apply(individual) as Practitioner
+
+        then:
+        !result.hasBirthDate()
+    }
+
     def "Organization without ID gets ID 0"() {
         when:
         def result = transformer.apply(organization)


### PR DESCRIPTION
For issue #846, we need to add several fields to the PSM's FHIR API. This pull request adds in the date-of-birth field. It's a pretty simple addition--just one line of code--with two basic tests to back things up.