### PR TITLE
Add provider Address and Telecom fields to PSM FHIR API

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
@@ -1,37 +1,17 @@
 package gov.medicaid.api.transformers;
 
-import gov.medicaid.entities.Affiliation;
 import gov.medicaid.entities.Enrollment;
-import gov.medicaid.entities.dto.ViewStatics;
-import org.hl7.fhir.dstu3.model.*;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.hl7.fhir.dstu3.model.DomainResource;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.Task;
 import java.util.function.Function;
 
 public class EnrollmentToFhir implements Function<Enrollment, Task> {
     @Override
     public Task apply(Enrollment enrollment) {
-        DomainResource requester = new EntityToFhir().apply(
-                enrollment.getDetails().getEntity()
+        DomainResource requester = new ProviderProfileToFhir().apply(
+                enrollment.getDetails()
         );
-
-        if(requester instanceof Practitioner){
-            ArrayList<Address> addresses = new ArrayList<>();
-            EntityAddressToFhirAddress addressTranslator = new EntityAddressToFhirAddress();
-
-            List<Affiliation> practitionerAffiliations = enrollment.getDetails().getAffiliations();
-            for (Affiliation affiliation : practitionerAffiliations) {
-                if (ViewStatics.DISCRIMINATOR_LOCATION.equals(affiliation.getObjectType())) {
-                    Address affiliationAddress = addressTranslator.apply(affiliation.getEntity().getContactInformation().getAddress());
-                    addresses.add(affiliationAddress);
-                }
-            }
-
-            Practitioner practitioner = (Practitioner)requester;
-            practitioner.setAddress(addresses);
-            requester = practitioner;
-        }
 
         Task task = new Task();
         task.setId(Long.toString(enrollment.getTicketId()));

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityAddressToFhirAddress.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityAddressToFhirAddress.java
@@ -1,22 +1,24 @@
 package gov.medicaid.api.transformers;
 
-import gov.medicaid.entities.Address;
+import org.hl7.fhir.dstu3.model.Address;
 
 import java.util.function.Function;
 
-public class EntityAddressToFhirAddress implements Function<Address, org.hl7.fhir.dstu3.model.Address> {
+public class EntityAddressToFhirAddress implements Function<gov.medicaid.entities.Address, Address> {
     @Override
-    public org.hl7.fhir.dstu3.model.Address apply(Address address) {
-        org.hl7.fhir.dstu3.model.Address fhirAddress = new org.hl7.fhir.dstu3.model.Address();
-        if(address != null){
-            fhirAddress.setState(address.getState());
-            fhirAddress.setCity(address.getCity());
-            fhirAddress.setPostalCode(address.getZipcode());
-            fhirAddress.setDistrict(address.getCounty());
-            fhirAddress.addLine(address.getLine1());
-            fhirAddress.addLine(address.getLine2());
-            fhirAddress.addLine(address.getAttentionTo());
+    public Address apply(gov.medicaid.entities.Address address) {
+        Address fhirAddress = new Address();
+        if (address == null) {
+            fhirAddress.setUse(Address.AddressUse.NULL);
+            return fhirAddress;
         }
+        fhirAddress.setState(address.getState());
+        fhirAddress.setCity(address.getCity());
+        fhirAddress.setPostalCode(address.getZipcode());
+        fhirAddress.setDistrict(address.getCounty());
+        fhirAddress.addLine(address.getLine1());
+        fhirAddress.addLine(address.getLine2());
+        fhirAddress.addLine(address.getAttentionTo());
         return fhirAddress;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityAddressToFhirAddress.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityAddressToFhirAddress.java
@@ -1,0 +1,22 @@
+package gov.medicaid.api.transformers;
+
+import gov.medicaid.entities.Address;
+
+import java.util.function.Function;
+
+public class EntityAddressToFhirAddress implements Function<Address, org.hl7.fhir.dstu3.model.Address> {
+    @Override
+    public org.hl7.fhir.dstu3.model.Address apply(Address address) {
+        org.hl7.fhir.dstu3.model.Address fhirAddress = new org.hl7.fhir.dstu3.model.Address();
+        if(address != null){
+            fhirAddress.setState(address.getState());
+            fhirAddress.setCity(address.getCity());
+            fhirAddress.setPostalCode(address.getZipcode());
+            fhirAddress.setDistrict(address.getCounty());
+            fhirAddress.addLine(address.getLine1());
+            fhirAddress.addLine(address.getLine2());
+            fhirAddress.addLine(address.getAttentionTo());
+        }
+        return fhirAddress;
+    }
+}

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityNumberToContactPoint.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityNumberToContactPoint.java
@@ -1,0 +1,14 @@
+package gov.medicaid.api.transformers;
+
+import org.hl7.fhir.dstu3.model.ContactPoint;
+
+import java.util.function.Function;
+
+public class EntityNumberToContactPoint implements Function<String, ContactPoint> {
+    @Override
+    public ContactPoint apply(String number) {
+        ContactPoint fhirNumber = new ContactPoint();
+        fhirNumber.setValue(number);
+        return fhirNumber;
+    }
+}

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/ProviderProfileToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/ProviderProfileToFhirTest.groovy
@@ -6,13 +6,13 @@ import gov.medicaid.entities.Person
 import org.hl7.fhir.dstu3.model.Practitioner
 import spock.lang.Specification
 
-class EntityToFhirTest extends Specification {
-    EntityToFhir transformer
+class ProviderProfileToFhirTest extends Specification {
+    ProviderProfileToFhir transformer
     Person individual
     Organization organization
 
     def setup() {
-        transformer = new EntityToFhir()
+        transformer = new ProviderProfileToFhir()
         individual = new Person()
         organization = new Organization()
     }
@@ -207,7 +207,7 @@ class EntityToFhirTest extends Specification {
 
         then:
         result.getIdentifier().size() == 1
-        result.getIdentifier().first().system == EntityToFhir.EIN_OID
+        result.getIdentifier().first().system == ProviderProfileToFhir.EIN_OID
         result.getIdentifier().first().value == "00-1234567"
     }
 
@@ -224,7 +224,7 @@ class EntityToFhirTest extends Specification {
             i -> i.getSystem() == "http://hl7.org/fhir/sid/us-npi"
         })
         result.getIdentifier().stream().anyMatch({
-            i -> i.getSystem() == EntityToFhir.EIN_OID
+            i -> i.getSystem() == ProviderProfileToFhir.EIN_OID
         })
         result.getIdentifier().size() == 2
     }


### PR DESCRIPTION
As per issue #846, we need to add several new fields to the PSM FHIR API. This pull request adds code for two of those fields: provider address and telecom (phone number).

The existing structure of the FHIR API returns a `Practitioner` object, which has several subfields--including `Address` and `Telecom`, which we use here. These fields accept a list of the appropriate object (`Address` for the Address field and `ContactPoint` for the Telecom field), and we use this to return data from all affiliations of an individual Practitioner.

Currently, the FHIR spec for `Address` is limited by the fact that there is no way to distinguish an individual address as a primary address. Right now, the code for this pull request does not address this limitation; more discussion can be seen over on the #846 issue.

To convert addresses and phone numbers from the PSM backend to the FHIR spec, there are two new Transformers: `EntityAddressToFhirAddress.java` for addresses and `EntityNumberToContactPoint.java` for phone numbers/contact points. All fields (save for internal ID, which was agreed as not necessary for the API in the conversation around #846) are transferred over to the FHIR spec. The code does not make any assumptions about information not included in the PSM's backend objects.

This PR is tagged as WIP due to the lack of written tests; these should be added with time.