### PR TITLE
Fix #108.  Remove last vestiges of Lorem Ipsum.

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
@@ -28,9 +28,6 @@
                     <h3>Import Profiles</h3>
                     <p>
                       In order to process renewals, you must first import your existing profiles.
-                      <br/>
-                      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-                      dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
                     </p>
                     <div class="">
                       <a href="<c:url value="/provider/onboarding/list" />" class="purpleBtn">
@@ -46,6 +43,7 @@
               <div class="br"></div>
             </div>
             -->
+
             <div class="detailPanel">
               <div class="section" id="updateProfile">
                 <div class="wholeCol">
@@ -53,14 +51,10 @@
                     <h3>Additional Enrollments</h3>
                     <p>
                       You also have the option to create new enrollments.
-                      <br/>
-                      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-                      dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
                     </p>
                     <div class="">
                       <h:create-enrollment-button cssClass="purpleBtn"/>
                     </div>
-
                   </div>
                 </div>
               </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -89,8 +89,7 @@
                     <ul>
                       <li>
                         <p>
-                          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-                          dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                          This functionality is not currently enabled.
                         </p>
                       </li>
                     </ul>


### PR DESCRIPTION
Issue #108: Remove "Lorem Ipsum" text wherever possible.

Of note, the two places that it remained were either commented out, or linked to from the commented out code.

There's a potential cleanup here for the whole profiles section of the site which seems to be non operational, see https://github.com/SolutionGuidance/psm/commits/f5d70d7bb93