### PR TITLE
Manage screening_schedules table with Liquibase

### DIFF
--- a/psm-app/db/changelog/db-changelog-1.0.xml
+++ b/psm-app/db/changelog/db-changelog-1.0.xml
@@ -891,4 +891,19 @@
     </rollback>
   </changeSet>
 
+  <changeSet author="" id="issue254-create-table-screening-schedules">
+    <createTable tableName="screening_schedules">
+      <column name="screening_schedule_id" type="bigint">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="upcoming_screening_date" type="date"/>
+      <column name="interval_type" type="text"/>
+      <column name="interval_value" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <rollback>
+      <dropTable tableName="screening_schedules"/>
+    </rollback>
+  </changeSet>
 </databaseChangeLog>

--- a/psm-app/db/changelog/db-changelog-seed.xml
+++ b/psm-app/db/changelog/db-changelog-seed.xml
@@ -149,4 +149,9 @@
       tableName="agreement_documents" />
   </changeSet>
 
+  <changeSet author="" id="issue254-seed-screening-schedules" runOnChange="true">
+    <loadUpdateData file="db/seeds/screening_schedules.csv"
+                    primaryKey="screening_schedule_id"
+                    tableName="screening_schedules" />
+  </changeSet>
 </databaseChangeLog>

--- a/psm-app/db/seed.sql
+++ b/psm-app/db/seed.sql
@@ -20,8 +20,7 @@ DROP TABLE IF EXISTS
   provider_services,
   provider_type_agreement_documents,
   provider_type_license_types,
-  provider_type_settings,
-  screening_schedules
+  provider_type_settings
 CASCADE;
 
 CREATE TABLE contacts(
@@ -350,21 +349,6 @@ CREATE TABLE accepted_agreements(
   agreement_document_id BIGINT
     REFERENCES  agreement_documents(agreement_document_id)
  ) ;
-
-CREATE TABLE screening_schedules(
-  screening_schedule_id BIGINT PRIMARY KEY,
-  upcoming_screening_date DATE,
-  interval_type TEXT,
-  interval_value BIGINT NOT NULL
-);
-
-INSERT INTO screening_schedules(
-  screening_schedule_id,
-  upcoming_screening_date,
-  interval_type,
-  interval_value
-) VALUES
-  (1, null, null, 0);
 
 CREATE TABLE licenses(
   license_id BIGINT PRIMARY KEY,

--- a/psm-app/db/seeds/screening_schedules.csv
+++ b/psm-app/db/seeds/screening_schedules.csv
@@ -1,0 +1,2 @@
+screening_schedule_id,upcoming_screening_date,interval_type,interval_value
+1,null,null,0


### PR DESCRIPTION
Move the table backing screening schedules from seed.sql into Liquibase, and move the single row initialization from seed.sql into a CSV that Liquibase re-runs every time it is changed.

Prepare for restructuring the table (and the entity it backs) for #740.

Issue #254 Allow database schema changes without losing data
Issue #740 Re-screen approved providers monthly