### PR TITLE
Fix #161.  Stop displaying contact info when marked use provider info.

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_personal_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_personal_info.jsp
@@ -4,17 +4,24 @@
         <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/person_info.jsp" %>
     </div>
     <!-- /.topPanel -->
-    <div class="tableHeader">
-        <span>Contact Info</span>
-    </div>
-    <!-- /.tableHeader -->
-    <div class="bottomPanel">
-        <div class="leftCol">
-            <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp" %>
-        </div>
-        <div class="bl"></div>
-        <div class="br"></div>
-    </div>
-    <!-- /.bottomPanel -->
+    <c:choose>
+        <c:when test="${'Y' != requestScope['_02_useProviderAsContact']}">
+            <div class="tableHeader">
+                <span>Contact Info</span>
+            </div>
+            <!-- /.tableHeader -->
+            <div class="bottomPanel">
+                <div class="leftCol">
+                    <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp" %>
+                </div>
+                <div class="bl"></div>
+                <div class="br"></div>
+            </div>
+            <!-- /.bottomPanel -->
+        </c:when>
+        <c:otherwise>
+            <div class="bottomPanel"></div>
+        </c:otherwise>
+    </c:choose>
 </div>
 <!-- /#tabPersonal -->

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
@@ -405,14 +405,16 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
         PDFHelper.addLabelValueCell(personalInfo, "Individual Practitioner's Email", PDFHelper.value(model, ns, "email"));
         document.add(personalInfo);
 
-        PdfPTable contactInfo = new PdfPTable(2); // 2 columns of key value pairs
-        PDFHelper.setTableAsFullPage(contactInfo);
+        if (!"Y".equals(enrollment.getContactSameAsApplicant())) {
+            PdfPTable contactInfo = new PdfPTable(2); // 2 columns of key value pairs
+            PDFHelper.setTableAsFullPage(contactInfo);
 
-        contactInfo.addCell(PDFHelper.createHeaderCell("Contact Information", 2));
-        PDFHelper.addLabelValueCell(contactInfo, "Contact Name", PDFHelper.value(model, ns, "contactName"));
-        PDFHelper.addLabelValueCell(contactInfo, "Contact Email Address", PDFHelper.value(model, ns, "contactEmail"));
-        PDFHelper.addLabelValueCell(contactInfo, "Contact Phone Number", PDFHelper.getPhone(model, ns, "contactPhone"));
+            contactInfo.addCell(PDFHelper.createHeaderCell("Contact Information", 2));
+            PDFHelper.addLabelValueCell(contactInfo, "Contact Name", PDFHelper.value(model, ns, "contactName"));
+            PDFHelper.addLabelValueCell(contactInfo, "Contact Email Address", PDFHelper.value(model, ns, "contactEmail"));
+            PDFHelper.addLabelValueCell(contactInfo, "Contact Phone Number", PDFHelper.getPhone(model, ns, "contactPhone"));
 
-        document.add(contactInfo);
+            document.add(contactInfo);
+        }
     }
 }


### PR DESCRIPTION
Issue #161: View Enrollment Details confirmation screen: contact name & email address are blank'

You can test by having two enrollments, one where the "contact information same as provider" is clicked, and one where it isn't.  Check the view and pdf versions of those two enrollments.  The one where it's checked should have an empty contact information section.