### PR TITLE
Add SpotBugs to our build

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -13,6 +13,7 @@ buildscript {
             exclude group: 'com.google.inject', module:'guice'
         }
         classpath 'org.postgresql:postgresql:42.2.2'
+        classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.2'
     }
 }
 
@@ -90,6 +91,7 @@ allprojects {
 ].each { name ->
     project(":$name") {
         apply plugin: 'groovy'
+        apply plugin: 'com.github.spotbugs'
 
         configurations {
             testCompile.extendsFrom compileOnly


### PR DESCRIPTION
Add the static analysis tool SpotBugs to our Java subprojects, so that we can use it to find errors in our code.

From the [website](https://spotbugs.github.io/):

> SpotBugs is a program which uses static analysis to look for bugs in Java code.
> 
> SpotBugs is the spiritual successor of FindBugs, carrying on from the point where it left off with support of its community.

It adds `spotbugs{SourceSetName}` tasks in gradle via the [gradle plugin](https://plugins.gradle.org/plugin/com.github.spotbugs). In practice, since we use Groovy for our tests and don't have any other source sets, that means you can invoke it like so:

```ShellSession
$ ./gradlew spotbugsMain
```

It creates XML reports in `psm-app/<subproject>/build/reports/spotbugs/main.xml`.

Currently, there are many problems in our code that SpotBugs can detect, so these checks don't pass; I add it now as an aspirational tool that we can use to find small things to fix in between larger features.

See also the list of bugs it can [detect](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html).

Issue #915 Use static analysis to find bugs