### PR TITLE
Fix and simplify configuration initialization

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -73,8 +73,8 @@ public class CMSConfigurator {
                 "Could not find application configuration, make sure it is in the classpath.");
         }
 
-        if (globalSettings == null) {
-            synchronized (CMSConfigurator.class) {
+        synchronized (CMSConfigurator.class) {
+            if (globalSettings == null) {
                 globalSettings = new Properties();
                 try {
                     globalSettings.load(stream);
@@ -90,13 +90,13 @@ public class CMSConfigurator {
                         }
                     }
                 }
-            }
-        } else {
-            if (stream != null) {
-                try {
-                    stream.close();
-                } catch (IOException e) {
-                    throw new PortalServiceConfigurationException("Unable to close configuration.");
+            } else {
+                if (stream != null) {
+                    try {
+                        stream.close();
+                    } catch (IOException e) {
+                        throw new PortalServiceConfigurationException("Unable to close configuration.");
+                    }
                 }
             }
         }

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -67,36 +67,21 @@ public class CMSConfigurator {
      * Reads the configuration and stores it.
      */
     public CMSConfigurator() {
-        InputStream stream = getClass().getResourceAsStream(DEFAULT_CMS_CONFIG_FILE);
-        if (stream == null) {
-            throw new PortalServiceConfigurationException(
-                "Could not find application configuration, make sure it is in the classpath.");
-        }
-
         synchronized (CMSConfigurator.class) {
             if (globalSettings == null) {
-                globalSettings = new Properties();
-                try {
+                try (InputStream stream = getClass().getResourceAsStream(DEFAULT_CMS_CONFIG_FILE)) {
+                    if (stream == null) {
+                        throw new PortalServiceConfigurationException(
+                            "Could not find application configuration, make sure it is in the classpath.");
+                    }
+
+                    globalSettings = new Properties();
                     globalSettings.load(stream);
                 } catch (IOException e) {
                     throw new PortalServiceConfigurationException(
-                        "Could not read application configuration, make sure it is in the classpath.");
-                } finally {
-                    if (stream != null) {
-                        try {
-                            stream.close();
-                        } catch (IOException e) {
-                            throw new PortalServiceConfigurationException("Unable to close configuration.");
-                        }
-                    }
-                }
-            } else {
-                if (stream != null) {
-                    try {
-                        stream.close();
-                    } catch (IOException e) {
-                        throw new PortalServiceConfigurationException("Unable to close configuration.");
-                    }
+                        "Error reading application configuration.",
+                        e
+                    );
                 }
             }
         }


### PR DESCRIPTION
The `CMSConfigurator` class reads the contents of the file `cms.properties` into a static variable on initialization, but it was not doing so in a thread-safe way. Rewrite it so that we don't re-read the file multiple times during a race condition, and then refactor it to use try-with-resources so as to simplify a lot of duplicate code.

Issue #915 Use static analysis to find bugs