### PR TITLE
Remove constructed but unused object

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -563,11 +563,8 @@ public class EnrollmentController extends BaseController {
      */
     @RequestMapping("/agent/enrollment/approve")
     public String approve(@RequestParam("id") long id, ApprovalDTO dto) {
-        StatusDTO statusDTO = new StatusDTO();
-
         try {
             completeReview(id, dto, false, "");
-            statusDTO.setSuccess(true);
             ControllerHelper.flashInfo("Approval request has been sent, you will be notified once it is processed.");
         } catch (PortalServiceException ex) {
             ControllerHelper.flashError(USER_ERROR_MSG);


### PR DESCRIPTION
Problem found with Spotbugs:

> UC: Useless object created ([UC_USELESS_OBJECT](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#uc-useless-object-created-uc-useless-object))
> 
> Our analysis shows that this object is useless. It's created and modified, but its value never go outside of the method or produce any side-effect. Either there is a mistake and object was intended to be used or it can be removed.
> 
> This analysis rarely produces false-positives. Common false-positive cases include:
> 
> - This object used to implicitly throw some obscure exception.
> - This object used as a stub to generalize the code.
> - This object used to hold strong references to weak/soft-referenced objects.

Delete it.

Issue #915 Use static analysis to find bugs