### PR TITLE
Add Checkstyle check for modifier order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,18 +226,11 @@ For example, see commit efbf5413e, which made whitespace adjustments to
 and was followed immediately by a substantive change to the same file
 in commit 2fd2dd21e.
 
-### Imports
+### Code style
 
-Import ordering is done in the way that Intellij IDEA does.  It is, as
-follows:
+Please see our style guide for more language-specific conventions:
 
-* First all imports, then javax, then java
-* Each group should be sorted lexonagraphically
-* Static imports at bottom of list
-
-Small note that the IDEA default doesn't enforce spaces between all groups,
-so neither does the checkstyle for the PSM.  However, those are acceptable
-and encouraged for larger groups of imports.
+- [Java code style](docs/code-style-java.md)
 
 ### Licensing Your Contribution
 The PSM is published under the terms of version 2 of the

--- a/docs/code-style-java.md
+++ b/docs/code-style-java.md
@@ -30,3 +30,24 @@ follows:
 Small note that the IDEA default doesn't enforce spaces between all groups,
 so neither does the checkstyle for the PSM.  However, those are acceptable
 and encouraged for larger groups of imports.
+
+## Modifiers
+
+Class, field, and method modifiers should be written in the order suggested by
+the Java Language specification:
+
+1. public
+2. protected
+3. private
+4. abstract
+5. default
+6. static
+7. final
+8. transient
+9. volatile
+10. synchronized
+11. native
+12. strictfp
+
+This is enforced via the Checkstyle rule
+[ModifierOrder](http://checkstyle.sourceforge.net/config_modifier.html#ModifierOrder).

--- a/docs/code-style-java.md
+++ b/docs/code-style-java.md
@@ -1,0 +1,32 @@
+# PSM code style guidelines for Java
+
+We would like the code in the PSM to be consistent and easily readable. To that
+end, here are some of the code style guidelines we've adopted for our Java
+code.
+
+## Checkstyle
+
+As much as possible, we have encoded our style guide into the static analysis
+tool [Checkstyle](http://checkstyle.sourceforge.net/). It is included in our
+build system as a Gradle task named `checkstyleMain`; you can run it from
+within the `psm-app` subdirectory like so:
+
+```shell-session
+$ ./gradlew checkstyleMain
+```
+
+Checkstyle is run against all pull requests, and needs to pass for us to merge
+a pull request.
+
+## Imports
+
+Import ordering is done in the way that Intellij IDEA does.  It is, as
+follows:
+
+* First all imports, then javax, then java
+* Each group should be sorted lexonagraphically
+* Static imports at bottom of list
+
+Small note that the IDEA default doesn't enforce spaces between all groups,
+so neither does the checkstyle for the PSM.  However, those are acceptable
+and encouraged for larger groups of imports.

--- a/psm-app/checkstyle.xml
+++ b/psm-app/checkstyle.xml
@@ -47,6 +47,7 @@
       <property name="option" value="alone"/>
       <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
     </module>
+    <module name="ModifierOrder"/>
     <module name="RedundantModifier"/>
     <module name="AvoidStarImport"/>
     <module name="IllegalImport"/>


### PR DESCRIPTION
From the [documentation](http://checkstyle.sourceforge.net/config_modifier.html#ModifierOrder
):

> Checks that the order of modifiers conforms to the suggestions in the Java Language specification, sections 8.1.1, 8.3.1, 8.4.3 and 9.4. The correct order is:
> 
> 1. public
> 2. protected
> 3. private
> 4. abstract
> 5. default
> 6. static
> 7. final
> 8. transient
> 9. volatile
> 10. synchronized
> 11. native
> 12. strictfp

We are already following this suggestion throughout our codebase;
enforce that we continue to do so.

Issue #456 Use consistent code style