### PR TITLE
Fix null pointer exception in risk levels report

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -135,6 +136,7 @@ public class RiskLevelsReportController extends gov.medicaid.controllers.BaseCon
                 .map(Enrollment::getTicketId)
                 .map(id -> enrollmentService2.getProviderDetailsByTicket(id, false))
                 .map(ProviderProfile::getRiskLevel)
+                .filter(Objects::nonNull)
                 .map(RiskLevel::getDescription)
                 .collect(Collectors.groupingBy(
                     Function.identity(),

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
@@ -3,6 +3,8 @@ package gov.medicaid.controllers.admin.report;
 import gov.medicaid.controllers.admin.report.ReportControllerUtils.EnrollmentMonth;
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.EnrollmentSearchCriteria;
+import gov.medicaid.entities.ProviderProfile;
+import gov.medicaid.entities.RiskLevel;
 import gov.medicaid.entities.dto.ViewStatics;
 import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
@@ -22,9 +24,9 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Controller
@@ -119,22 +121,29 @@ public class RiskLevelsReportController extends gov.medicaid.controllers.BaseCon
     }
 
     public static class RiskLevelsMonth {
-        private Map<String, Integer> numByRiskLevel;
+        private Map<String, Long> numByRiskLevel;
         private LocalDate month;
 
         public RiskLevelsMonth(EnrollmentMonth em, ProviderEnrollmentService enrollmentService2) {
-            numByRiskLevel = new HashMap<>();
-            RISK_LEVELS.stream().forEach(l -> numByRiskLevel.put(l, 0));
+            numByRiskLevel = RISK_LEVELS.stream().collect(Collectors.toMap(
+                Function.identity(),
+                x -> 0L
+            ));
             month = em.getMonth();
 
-            em.getEnrollments().stream().forEach(e -> {
-                numByRiskLevel.computeIfPresent(
-                    enrollmentService2.getProviderDetailsByTicket(e.getTicketId(), false)
-                        .getRiskLevel().getDescription(),
-                    (k, v) -> v + 1); });
+            numByRiskLevel.putAll(em.getEnrollments().stream()
+                .map(Enrollment::getTicketId)
+                .map(id -> enrollmentService2.getProviderDetailsByTicket(id, false))
+                .map(ProviderProfile::getRiskLevel)
+                .map(RiskLevel::getDescription)
+                .collect(Collectors.groupingBy(
+                    Function.identity(),
+                    Collectors.counting()
+                ))
+            );
         }
 
-        public int getNum(String riskLevel) {
+        public long getNum(String riskLevel) {
             return numByRiskLevel.get(riskLevel);
         }
 

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/RiskLevelsReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/RiskLevelsReportControllerTest.groovy
@@ -141,4 +141,25 @@ class RiskLevelsReportControllerTest extends Specification {
         mv["months"][2].month == noonMiddleThisMonth.minusMonths(2).withDayOfMonth(1).toLocalDate()
         mv["months"][2].getNum(ViewStatics.MODERATE_RISK) == 1
     }
+
+    def "enrollment without risk level does not cause exceptions"() {
+        given:
+        def results = new SearchResult<Enrollment>()
+        results.setItems([
+            makeEnrollment(1, noonMiddleThisMonth),
+        ])
+        1 * enrollmentService.searchEnrollments(_) >> results
+        enrollmentService.getProviderDetailsByTicket(1, false) >>
+            new ProviderProfile()
+
+        when:
+        def mv = controller.getRiskLevels().model
+
+        then:
+        mv["months"].size == 1
+        mv["months"][0].month == noonMiddleThisMonth.withDayOfMonth(1).toLocalDate()
+        mv["months"][0].getNum(ViewStatics.LOW_RISK) == 0
+        mv["months"][0].getNum(ViewStatics.MODERATE_RISK) == 0
+        mv["months"][0].getNum(ViewStatics.HIGH_RISK) == 0
+    }
 }


### PR DESCRIPTION
Not all enrollments have risk levels. This is a somewhat erroneous state that the application can get into; risk levels are supposed to be assigned shortly after an enrollment is submitted, but if an error happens and a risk level is not assigned, this report should still work.

Fix this in two steps: first, refactor the way the number of enrollments with each risk level is counted (maintaining the behavior), and then filter out enrollments without risk levels assigned.

Thank you to @frankduncan for writing tests! That made me more confident in the refactoring.

Issue #786 Add report based on CMS' provider risk level