### PR TITLE
Remove the domain menu from the login page

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -88,47 +88,9 @@
                 <h:handlebars template="includes/logo" context="${pageContext}"/>
               </div>
               <!-- /.mainNav -->
-              <form id="loginForm" action="<c:url value='/login'/>" method="post">
-                <sec:csrfInput />
-                <div class="loginPanel">
-                  <h:handlebars template="includes/flash" context="${pageContext}"/>
 
-                  <c:if test="${not empty SPRING_SECURITY_LAST_EXCEPTION.message}">
-                    <div class="errorInfo" style="display: block;">
-                      <h3>Invalid username/password.</h3>
-                      <div class="tl"></div>
-                      <div class="tr"></div>
-                      <div class="bl"></div>
-                      <div class="br"></div>
-                    </div>
-                    <% session.removeAttribute(WebAttributes.AUTHENTICATION_EXCEPTION); %>
-                  </c:if>
+              <%@ include file="/WEB-INF/pages/login_form.jsp" %>
 
-                  <div class="row">
-                    <label for="username" class="label">Username:</label>
-                    <input id="username" type="text" name="username" class="text" value="${LAST_USERNAME}" maxlength="50"/>
-                  </div>
-                  <div class="row">
-                    <label for="password" class="label">Password:</label>
-                    <input id="password" type="password" name="password"/>
-                  </div>
-                  <div class="row">
-                    <label class="label">&nbsp;</label>
-                    <input id="remember" type="checkbox" name="keepUserSignedIn"/>
-                    <label for="remember">Remember Me</label>
-                    <a class="forgotPasswordLink" href="<c:url value="/forgotpassword" />">Forgot Password?</a>
-                  </div>
-                  <div class="buttons">
-                    <button id="btnLogin" class="purpleBtn" type="submit">Login</button>
-                    <a class="registerNewAccountLink" href="<c:url value="/accounts/new" />">Register New Account</a>
-                  </div>
-
-                  <div class="tl"></div>
-                  <div class="tr"></div>
-                  <div class="bl"></div>
-                  <div class="br"></div>
-                </div>
-              </form>
             </div>
           </div>
           <!-- /#mainContent -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -113,13 +113,6 @@
                     <input id="password" type="password" name="password"/>
                   </div>
                   <div class="row">
-                    <label for="domain" class="label">Domain:</label>
-                    <select id="domain" name="domain" onchange="disableElement('remember', this.value != 'CMS_ONLINE')">
-                      <option value="CMS_ONLINE" selected="selected">Online Portal</option>
-                      <option value="MN_ITS">MN-ITS</option>
-                    </select>
-                  </div>
-                  <div class="row">
                     <label class="label">&nbsp;</label>
                     <input id="remember" type="checkbox" name="keepUserSignedIn"/>
                     <label for="remember">Remember Me</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -20,53 +20,9 @@
             <h:handlebars template="includes/logo" context="${pageContext}"/>
           </div>
           <!-- /.mainNav -->
-          <form id="loginForm" action="<c:url value='/login'/>" method="post">
-            <sec:csrfInput />
-            <div class="loginPanel">
-              <h:handlebars template="includes/flash" context="${pageContext}"/>
 
-              <c:if test="${not empty SPRING_SECURITY_LAST_EXCEPTION.message}">
-                <div class="errorInfo" style="display: block;">
-                  <h3>${SPRING_SECURITY_LAST_EXCEPTION.message}</h3>
-                  <div class="tl"></div>
-                  <div class="tr"></div>
-                  <div class="bl"></div>
-                  <div class="br"></div>
-                </div>
-                <% session.removeAttribute(WebAttributes.AUTHENTICATION_EXCEPTION); %>
-              </c:if>
+          <%@ include file="/WEB-INF/pages/login_form.jsp" %>
 
-              <div class="row">
-                <label for="username" class="label">Username</label>
-                <input id="username"
-                       name="username"
-                       type="text"
-                       class="text"
-                       value="${LAST_USERNAME}"
-                       maxlength="50"
-                       autofocus />
-              </div>
-              <div class="row">
-                <label for="password" class="label">Password</label>
-                <input id="password" type="password" name="password" />
-              </div>
-              <div class="row">
-                <label class="label">&nbsp;</label>
-                <input id="remember" type="checkbox" name="keepUserSignedIn"/>
-                <label for="remember">Remember Me</label>
-                <a class="forgotPasswordLink" href="<c:url value="/forgotpassword" />">Forgot Password?</a>
-              </div>
-              <div class="buttons">
-                <button id="btnLogin" class="purpleBtn" type="submit">Login</button>
-                <a class="registerNewAccountLink" href="<c:url value="/accounts/new" />">Register New Account</a>
-              </div>
-
-              <div class="tl"></div>
-              <div class="tr"></div>
-              <div class="bl"></div>
-              <div class="br"></div>
-            </div>
-          </form>
         </div>
       </div>
       <!-- /#mainContent -->
@@ -76,5 +32,3 @@
     <!-- /#wrapper -->
   </body>
 </html>
-
-<!-- login form -->

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -51,13 +51,6 @@
                 <input id="password" type="password" name="password" />
               </div>
               <div class="row">
-                <label for="domain" class="label">Domain</label>
-                <select id="domain" name="domain" onchange="disableElement('remember', this.value != 'CMS_ONLINE')">
-                  <option value="CMS_ONLINE" selected="selected">Online Portal</option>
-                  <option value="MN_ITS">MN-ITS</option>
-                </select>
-              </div>
-              <div class="row">
                 <label class="label">&nbsp;</label>
                 <input id="remember" type="checkbox" name="keepUserSignedIn"/>
                 <label for="remember">Remember Me</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login_form.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login_form.jsp
@@ -1,0 +1,52 @@
+<%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
+<form id="loginForm" action="<c:url value='/login'/>" method="post">
+  <sec:csrfInput />
+  <div class="loginPanel">
+    <h:handlebars template="includes/flash" context="${pageContext}"/>
+
+    <c:if test="${not empty SPRING_SECURITY_LAST_EXCEPTION.message}">
+      <div class="errorInfo" style="display: block;">
+        <h3>
+          Invalid username and/or password.
+          <br>
+          ${SPRING_SECURITY_LAST_EXCEPTION.message}
+        </h3>
+        <div class="tl"></div>
+        <div class="tr"></div>
+        <div class="bl"></div>
+        <div class="br"></div>
+      </div>
+      <% session.removeAttribute(WebAttributes.AUTHENTICATION_EXCEPTION); %>
+    </c:if>
+
+    <div class="row">
+      <label for="username" class="label">Username</label>
+      <input id="username"
+             name="username"
+             type="text"
+             class="text"
+             value="${LAST_USERNAME}"
+             maxlength="50"
+             autofocus />
+    </div>
+    <div class="row">
+      <label for="password" class="label">Password</label>
+      <input id="password" type="password" name="password" />
+    </div>
+    <div class="row">
+      <label class="label">&nbsp;</label>
+      <input id="remember" type="checkbox" name="keepUserSignedIn"/>
+      <label for="remember">Remember Me</label>
+      <a class="forgotPasswordLink" href="<c:url value="/forgotpassword" />">Forgot Password?</a>
+    </div>
+    <div class="buttons">
+      <button id="btnLogin" class="purpleBtn" type="submit">Login</button>
+      <a class="registerNewAccountLink" href="<c:url value="/accounts/new" />">Register New Account</a>
+    </div>
+
+    <div class="tl"></div>
+    <div class="tr"></div>
+    <div class="bl"></div>
+    <div class="br"></div>
+  </div>
+</form>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
@@ -47,7 +47,10 @@ public class CustomAuthenticationProcessingFilter extends UsernamePasswordAuthen
 
         String username = obtainUsername(request);
         String password = obtainPassword(request);
-        String domain = request.getParameter("domain");
+
+        // We currently only support one domain.  When more are supported the
+        // domain can be passed as a parameter on the request. See issue #911.
+        String domain = "CMS_ONLINE";
 
         if (username == null) {
             username = "";
@@ -59,17 +62,11 @@ public class CustomAuthenticationProcessingFilter extends UsernamePasswordAuthen
 
         username = username.trim();
 
-        DomainAuthenticationToken authRequest;
-        if (domain == null || "MN_ITS".equalsIgnoreCase(domain)) {
-            domain = "MN_ITS";
-            String token = request.getParameter("token");
-            String userNPI = request.getParameter("userNPI");
-            String profileNPI = request.getParameter("profileNPI");
-            String referrer = request.getParameter("referrer");
-            authRequest = new DomainAuthenticationToken(userNPI, profileNPI, token, referrer, domain);
-        } else {
-            authRequest = new DomainAuthenticationToken(username, password, domain);
-        }
+        DomainAuthenticationToken authRequest = new DomainAuthenticationToken(
+                username,
+                password,
+                domain
+        );
 
         // Place the last username attempted into HttpSession for views
         HttpSession session = request.getSession(false);

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -2112,14 +2112,6 @@ function changePageNumber(page) {
   $('#paginationForm').submit();
 }
 
-function disableElement(el, cond) {
-  if (cond) {
-    $('#' + el).prop('disabled', true);
-  } else {
-    $('#' + el).prop('disabled', false);
-  }
-}
-
 var isPrimaryPracticeLookup = false;
 var isPrivatePracticeForm = false;
 var practiceLookupResults = {};


### PR DESCRIPTION
See issue #911.  As noted there, there's a lot of code related to supporting multiple domains that could be removed, but I did not want to go very far down that path in this PR, since the issue is focused on simplifying the UI.  We could create a separate issue for the rest.

Also consolidate two all-but-identical login forms into one JSP.  (The only somewhat-substantive difference between them was the error message for bad login attempts.)

Tested by logging in as a provider and as an admin, and by entering invalid login credentials. 

![screenshot-2018-6-29 login](https://user-images.githubusercontent.com/1091693/42117198-50258256-7bc9-11e8-9c83-19d399fb404b.png)

(Note: the icons to the right in the input fields are from my password manager browser add-on.)

Issue #911: Login page asks confusingly about "Domain"