### PR TITLE
Make 'tabNotes' id conditional on the notes tab being active

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
@@ -44,7 +44,7 @@
             <%@ include file="/WEB-INF/pages/admin/includes/enrollment_tab_section.jsp" %>
             <%@ include file="/WEB-INF/pages/admin/includes/enrollment_search_form.jsp" %>
             <!-- /.tabHead -->
-            <div class="tabContent" id="tabNotes">
+            <div class="tabContent" id="${tabName == 'notes' ? 'tabNotes' : ''}">
               <div class="pagination">
                 <%@ include file="/WEB-INF/pages/admin/includes/page_left_navigation.jsp" %>
                 <%@ include file="/WEB-INF/pages/admin/includes/enrollment_buttons.jsp" %>


### PR DESCRIPTION
This is a follow-up on PR #888.  Specifically see [this comment](https://github.com/SolutionGuidance/psm/pull/888#discussion_r199955993).  This is a quick fix for now until we redo the notes tab with #766.  (In hindsight this could have just been done as part of #888 .)

Tested by logging in as an service admin, navigating to 'Enrollments', and confirming that the id only appears in the HTML when the notes tab is active.