### PR TITLE
Fix #233: cannot enroll as podiatrist

### DIFF
--- a/psm-app/db/seeds/license_types.csv
+++ b/psm-app/db/seeds/license_types.csv
@@ -54,7 +54,7 @@ code,description
 "L6","Traditional Midwife"
 "L7","MnSCU Certification"
 "L8","Chiropractic Examiner"
-"L9","License To Practice Podiatric Medicine"
+"L9","Podiatrist License"
 "M0","Hearing Aid Dispenser"
 "M1","Professional Clinical Counselor"
 "M2","Occupational Therapy"


### PR DESCRIPTION
Update seed data to match LicenseNames.PODIATRIST_LICENSE so that rule "Copy of license as a podiatrist from the MN Board of Podiatric Medicine or current state of practice is required for Podiatrist" allows.

The other option would be to update the LicenseNames string, and I chose the seed data to change somewhat randomly.

Related to #166