### PR TITLE
Fix #259 - Reword rule name to be more descriptive.

### DIFF
--- a/psm-app/cms-business-process/src/main/resources/cms.validation.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.validation.drl
@@ -3473,7 +3473,7 @@ dialect 'mvel'
 
 end
 
-rule 'CMHC Members Must Be A Certified Mental Health Professional Or A Licensed Psychiatrist'
+rule 'CMHC Members Must Be A Certified Mental Health Rehab Professional'
 dialect 'mvel'
 /*
  * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
@@ -3486,14 +3486,13 @@ dialect 'mvel'
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value())
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
-        GroupMemberType($specialties: specialties, providerType != ProviderType.CERTIFIED_MENTAL_HEALTH_REHAB_PROF_CPRP.value(), highestDegreeEarned != "DOCTORATE") from $memberList
-        not SpecialtiesType(specialtyName contains "Psychiatry") from $specialties
+        GroupMemberType(providerType != ProviderType.CERTIFIED_MENTAL_HEALTH_REHAB_PROF_CPRP.value()) from $memberList
         $report: ErrorReporter()
     then
         $report.addError(
             "/ProviderInformation/MemberInformation",
             "00001",
-            "Members must be certified mental health professionals or licensed psychiatrists."
+            "Members must be certified mental health rehab professionals."
         );
 
 end


### PR DESCRIPTION
Issue #259: Community Mental Health Center refers to missing provider type

Punting on adding the provider type until better requirements come in about what provider types make sense.  However, in the meantime, the wording of the rule output should match the functionality.

I also looked into the dropdown only having pertinent options, and while that information is stored in the database for license/provider types (in the provider_type_settings), I didn't see a similar table for provider type -> member provider type to easily cull the list to match the rules.