### PR TITLE
Fix #260: Add community assurance seed data

### DIFF
--- a/psm-app/db/seeds/agreement_documents.csv
+++ b/psm-app/db/seeds/agreement_documents.csv
@@ -2,3 +2,4 @@ agreement_document_id,type,title,version,body,created_by,created_at
 "1","01","Agreement (1)","0","This is the content of the agreement.","system","'NOW'"
 "2","02","Addendum (2)","0","This is the content of the addendum.","system","'NOW'"
 "3","01","Child And Teen Checkup Agreement (DHS-4646)","0","This is a required document.","system","'NOW'"
+"4","01","Applicant Assurance Statement - Community Mental Health Center (DHS-5748)","0","This is a required document.","system","'NOW'"

--- a/psm-app/db/seeds/provider_type_agreement_documents.csv
+++ b/psm-app/db/seeds/provider_type_agreement_documents.csv
@@ -1,3 +1,4 @@
 provider_type_code,agreement_document_id
 "18","1"
 "54","3"
+"57","4"


### PR DESCRIPTION
Issue #260: Community Mental Health Center requires assurance statement

You can test this by getting through the enrollment process for a Community Mental Health Center by checking the newly generated checkbox at the last step.