### PR TITLE
Fix #74. Change MN Tax ID Label

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
@@ -59,7 +59,7 @@
     <span id="fein">${requestScope['_05_fein']}</span>
 </div>
 <div class="row">
-    <label>MN Tax ID</label>
+    <label>State Tax ID</label>
     <span id="stateTaxId">${requestScope['_05_stateTaxId']}</span>
 </div>
 <div class="row">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
@@ -103,7 +103,7 @@
                     <div class="row">
                         <c:set var="formName" value="_15_stateTaxId"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}">MN Tax ID</label>
+                        <label for="{formIdPrefix}_${formName}">State Tax ID</label>
                         <input id="{formIdPrefix}_${formName}" type="text" class="normalInput taxIdMasked" id="stateTaxId" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
@@ -240,7 +240,7 @@
                     <div class="row">
                         <c:set var="formName" value="_15_stateTaxId"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="{formIdPrefix}_${formName}">MN Tax ID</label>
+                        <label for="{formIdPrefix}_${formName}">State Tax ID</label>
                         <input id="{formIdPrefix}_${formName}" type="text" class="normalInput taxIdMasked" id="stateTaxId" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
@@ -364,7 +364,7 @@
                     <div class="row">
                         <c:set var="formName" value="_15_stateTaxId"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <label for="stateTaxId">MN Tax ID</label>
+                        <label for="stateTaxId">State Tax ID</label>
                         <input type="text" class="normalInput taxIdMasked" id="stateTaxId" name="${formName}" value="${formValue}" maxlength="10"/>
                     </div>
 
@@ -625,7 +625,7 @@
                 <div class="row">
                     <c:set var="formName" value="_15_stateTaxId"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <label for="stateTaxId">MN Tax ID</label>
+                    <label for="stateTaxId">State Tax ID</label>
                     <input type="text" class="normalInput taxIdMasked" id="stateTaxId" name="${formName}" value="${formValue}" maxlength="10"/>
                 </div>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
@@ -51,7 +51,7 @@
                 <span>${requestScope['_15_legalName']}</span>
             </div>
             <div class="row">
-                <label>MN TAX ID </label>
+                <label>State Tax ID</label>
                 <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_stateTaxId']}</span>
             </div>
@@ -123,7 +123,7 @@
                 <span>${requestScope['_15_legalName']}</span>
             </div>
             <div class="row">
-                <label>MN TAX ID </label>
+                <label>State Tax ID</label>
                 <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_stateTaxId']}</span>
             </div>
@@ -178,7 +178,7 @@
                   <span>${requestScope['_15_fein']}</span>
                 </div>
                 <div class="row">
-                    <label>MN Tax Id</label>
+                    <label>State Tax Id</label>
                     <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_stateTaxId']}</span>
                 </div>
@@ -322,7 +322,7 @@
                     </span>
                 </div>
                 <div class="row">
-                    <label>MN TAX ID </label>
+                    <label>State Tax ID</label>
                     <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_stateTaxId']}</span>
                 </div>


### PR DESCRIPTION
The plumbing behind this was all generic anyway, with things like the organizations database table having a state_tax_id as the column name, so label change only.