### PR TITLE
Fix #33.  Add user account suspend/reinstate UI.

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -113,11 +113,10 @@ public class RegistrationServiceBean extends BaseService implements Registration
      * @param systemName the external system name to search the link for
      * @param username the username for the external system
      * @return the matching user, or null if not found
-     * @throws PortalServiceException for any errors encountered
      */
     @SuppressWarnings("rawtypes")
     @TransactionAttribute(TransactionAttributeType.SUPPORTS)
-    public CMSUser findByExternalUsername(SystemId systemName, String username) throws PortalServiceException {
+    public CMSUser findByExternalUsername(SystemId systemName, String username) {
         String str = "SELECT u FROM CMSUser u, ExternalAccountLink e WHERE e.systemId = :system "
             + "AND e.externalUserId = :username AND u.userId = e.userId AND u.username IS NULL";
 
@@ -136,11 +135,10 @@ public class RegistrationServiceBean extends BaseService implements Registration
      *
      * @param username the username to search for
      * @return the matching user, null if not found
-     * @throws PortalServiceException for any errors encountered
      */
     @SuppressWarnings("rawtypes")
     @TransactionAttribute(TransactionAttributeType.SUPPORTS)
-    public CMSUser findByUsername(String username) throws PortalServiceException {
+    public CMSUser findByUsername(String username) {
         Query q = getEm().createQuery("FROM CMSUser u WHERE u.username = :username");
         q.setParameter("username", username);
         List rs = q.getResultList();
@@ -195,12 +193,9 @@ public class RegistrationServiceBean extends BaseService implements Registration
      * @param username the external user id
      * @param registrant the user profile
      * @return the generated user id
-     * @throws PortalServiceException for any errors encountered, or if any field is considered invalid by the
-     *             underlying implementations
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public String registerExternalUser(SystemId systemId, String username, CMSUser registrant)
-        throws PortalServiceException {
+    public String registerExternalUser(SystemId systemId, String username, CMSUser registrant) {
 
         // create only in database (no LDAP account)
         String userId = createUser(null, registrant);
@@ -218,10 +213,9 @@ public class RegistrationServiceBean extends BaseService implements Registration
      *
      * @param principal the user performing the action
      * @param userId the user to be suspended
-     * @throws PortalServiceException for any errors encountered
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public void suspend(CMSUser principal, String userId) throws PortalServiceException {
+    public void suspend(CMSUser principal, String userId) {
         changeStatus(principal, userId, UserStatus.DISABLED);
     }
 
@@ -230,10 +224,9 @@ public class RegistrationServiceBean extends BaseService implements Registration
      *
      * @param principal the user performing the action
      * @param userId the user to be reinstated
-     * @throws PortalServiceException for any errors encountered
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public void reinstate(CMSUser principal, String userId) throws PortalServiceException {
+    public void reinstate(CMSUser principal, String userId) {
         changeStatus(principal, userId, UserStatus.ACTIVE);
     }
 
@@ -242,10 +235,9 @@ public class RegistrationServiceBean extends BaseService implements Registration
      *
      * @param userId the user id to be linked
      * @param link the account link details
-     * @throws PortalServiceException for any errors encountered
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public void addAccountLink(String userId, ExternalAccountLink link) throws PortalServiceException {
+    public void addAccountLink(String userId, ExternalAccountLink link) {
         ExternalAccountLink existing = findAccountLink(userId, link.getSystemId(), link.getExternalUserId());
         if (existing == null) {
             link.setId(0);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -813,6 +813,10 @@ public class RegistrationServiceBean extends BaseService implements Registration
      * @throws PortalServiceException for any errors encountered
      */
     public boolean authenticate(String username, String password) throws PortalServiceException {
+        CMSUser user = findByUsername(username);
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new PortalServiceException("User is disabled");
+        }
         return identityProvider.authenticate(username, password);
     }
 }

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/accountsTab.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/accountsTab.jsp
@@ -38,7 +38,12 @@
         </thead>
         <tbody>
             <c:forEach var="item" items="${results.items}">
-            <tr>
+            <tr
+              <c:choose>
+                <c:when test="${item.status == 'DISABLED'}">class="disabledUser"</c:when>
+                <c:when test="${item.status == 'ACTIVE'}">class="enabledUser"</c:when>
+              </c:choose>
+              >
                 <td class="alignCenter">
                 <input type="checkbox" title="User ${item.userId}" value="${item.userId}" name="providers"/>
                 </td>
@@ -47,6 +52,9 @@
                 <td>${item.firstName}</td>
                 <td>${item.email}</td>
                 <td class="alignCenter"><a href="<c:url value='/system/user/edit?role=${role}&userId=${item.userId}' />">Edit</a>
+                <span class="sep">|</span>
+                <a href="<c:url value='/system/user/reinstate?userId=${item.userId}' />" class="reinstateLink">Reinstate</a>
+                <a href="<c:url value='/system/user/suspend?userId=${item.userId}' />" class="suspendLink">Suspend</a>
                 <span class="sep">|</span><a href="javascript:;" class="deleteLink">Delete</a></td>
             </tr>
             </c:forEach>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4047,6 +4047,13 @@ input.passwordNormalInput{
   width:auto;
 }
 
+.enabledUser .reinstateLink {
+  display:none;
+}
+.disabledUser .suspendLink {
+  display:none;
+}
+
 
 /* END OF SYSTEM ADMIN STYLES --------------------------------------------------- */
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
@@ -317,6 +317,34 @@ public class SystemAdminUserController extends BaseSystemAdminController {
     }
 
     /**
+     * This action will disable the user with the given ID.
+     *
+     * @param userId - the user Id
+     * @return the model and view instance that contains the name of view to be rendered and data to be used for
+     *         rendering (not null)
+     */
+    @RequestMapping(value = "/suspend", method = RequestMethod.POST)
+    @ResponseBody
+    public void disable(@RequestParam("userId") String userId) {
+        CMSUser actor = ControllerHelper.getCurrentUser();
+        getRegistrationService().suspend(actor, userId);
+    }
+
+    /**
+     * This action will enable the user with the given ID.
+     *
+     * @param userId - the user Id
+     * @return the model and view instance that contains the name of view to be rendered and data to be used for
+     *         rendering (not null)
+     */
+    @RequestMapping(value = "/reinstate", method = RequestMethod.POST)
+    @ResponseBody
+    public void reinstate(@RequestParam("userId") String userId) {
+        CMSUser actor = ControllerHelper.getCurrentUser();
+        getRegistrationService().reinstate(actor, userId);
+    }
+
+    /**
      * Loads the user with the given id into a ModelAndView.
      *
      * @param viewName the name of the view

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.annotation.PostConstruct;
@@ -297,15 +298,14 @@ public class SystemAdminUserController extends BaseSystemAdminController {
      *
      * @param role - the role being managed
      * @param userIds - the entity IDs
-     * @return the model and view instance that contains the name of view to be rendered and data to be used for
-     *         rendering (not null)
      *
      * @throws IllegalArgumentException - if role is not one of the four configured roles
      * @throws PortalServiceException - If there are any errors in the action
      * @endpoint "/system/user/delete"
      */
-    @RequestMapping(value = "/delete")
-    public ModelAndView delete(@RequestParam("role") String role, @RequestParam("userIds") String[] userIds)
+    @RequestMapping(value = "/delete", method = RequestMethod.POST)
+    @ResponseBody
+    public void delete(@RequestParam("role") String role, @RequestParam("userIds") String[] userIds)
         throws PortalServiceException {
         checkRoleParameter(role);
         if (userIds == null) {
@@ -314,10 +314,6 @@ public class SystemAdminUserController extends BaseSystemAdminController {
 
         CMSUser actor = ControllerHelper.getCurrentUser();
         getRegistrationService().unregisterUsers(actor.getUserId(), userIds);
-        // we may need to add criteria if the client wants to preserve current filters
-        ModelAndView mv = loadUserManagement(role, null);
-
-        return mv;
     }
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
@@ -20,7 +20,6 @@ import gov.medicaid.controllers.validators.BaseValidator;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.entities.dto.ViewStatics;
 import gov.medicaid.services.PortalServiceConfigurationException;
-import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.RegistrationService;
 
 import org.springframework.validation.Errors;
@@ -158,16 +157,12 @@ public class UserValidator extends BaseValidator implements Validator {
             }
         }
 
-        try {
-            // no two users should have the same login
-            if (!errors.hasFieldErrors("username")) {
-                CMSUser duplicate = registrationService.findByUsername(user.getUsername());
-                if (duplicate != null && !duplicate.getUserId().equals(user.getUserId())) {
-                    errors.rejectValue("username", "duplicate.username", "The requested username is already in use.");
-                }
+        // no two users should have the same login
+        if (!errors.hasFieldErrors("username")) {
+            CMSUser duplicate = registrationService.findByUsername(user.getUsername());
+            if (duplicate != null && !duplicate.getUserId().equals(user.getUserId())) {
+                errors.rejectValue("username", "duplicate.username", "The requested username is already in use.");
             }
-        } catch (PortalServiceException e) {
-            errors.rejectValue("userId", "generic.error", "Unable to process request, please try again later.");
         }
     }
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
@@ -18,8 +18,6 @@ package gov.medicaid.controllers.validators;
 
 import gov.medicaid.controllers.forms.RegistrationForm;
 import gov.medicaid.entities.CMSUser;
-import gov.medicaid.services.PortalServiceException;
-import gov.medicaid.services.PortalServiceRuntimeException;
 import gov.medicaid.services.RegistrationService;
 
 import org.springframework.validation.Errors;
@@ -113,17 +111,12 @@ public class RegistrationFormValidator extends BaseValidator {
             }
         }
 
-        try {
-            // no two users should have the same login
-            if (!errors.hasFieldErrors("username")) {
-                CMSUser duplicate = registrationService.findByUsername(user.getUsername());
-                if (duplicate != null) {
-                    errors.rejectValue("username", "duplicate.username");
-                }
+        // no two users should have the same login
+        if (!errors.hasFieldErrors("username")) {
+            CMSUser duplicate = registrationService.findByUsername(user.getUsername());
+            if (duplicate != null) {
+                errors.rejectValue("username", "duplicate.username");
             }
-        } catch (PortalServiceException e) {
-            // nothing we can do if services are not working correctly.
-            throw new PortalServiceRuntimeException("Unable to complete request validation.", e);
         }
     }
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSRememberMeUserDetailsService.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSRememberMeUserDetailsService.java
@@ -20,10 +20,8 @@ import gov.medicaid.controllers.dto.CMSUserDetailsWrapper;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.entities.SystemId;
 import gov.medicaid.services.PortalServiceConfigurationException;
-import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.RegistrationService;
 
-import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -85,22 +83,18 @@ public class CMSRememberMeUserDetailsService implements UserDetailsService {
      * @return the user principal
      */
     public UserDetails loadUserByUsername(String userId) {
-        try {
-            CMSUser cmsUser = registrationService.findByUsername(userId);
-            if (cmsUser == null) {
-                return null;
-            }
-
-            // we do not remembering external users
-            if (cmsUser.getUsername() == null) {
-                return null;
-            }
-
-            User user = new User(cmsUser.getUsername(), "", true, true, true, true, EMPTY_AUTH);
-            return new CMSUserDetailsWrapper(user, cmsUser, SystemId.CMS_ONLINE);
-        } catch (PortalServiceException e) {
-            throw new DataRetrievalFailureException("Database error.", e);
+        CMSUser cmsUser = registrationService.findByUsername(userId);
+        if (cmsUser == null) {
+            return null;
         }
+
+        // we do not remembering external users
+        if (cmsUser.getUsername() == null) {
+            return null;
+        }
+
+        User user = new User(cmsUser.getUsername(), "", true, true, true, true, EMPTY_AUTH);
+        return new CMSUserDetailsWrapper(user, cmsUser, SystemId.CMS_ONLINE);
     }
 
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
@@ -23,11 +23,9 @@ import gov.medicaid.entities.RoleView;
 import gov.medicaid.entities.SystemId;
 import gov.medicaid.services.PartnerSystemService;
 import gov.medicaid.services.PortalServiceConfigurationException;
-import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.RegistrationService;
 import gov.medicaid.services.util.Util;
 
-import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -133,32 +131,27 @@ public class DefaultExternalAuthenticationProvider implements AuthenticationProv
      * @return the mapped details
      */
     private UserDetails loadProxyUser(String userNPI, String profileNPI) {
-        try {
-            CMSUser cmsUser = registrationService.findByExternalUsername(system, userNPI);
-            if (cmsUser == null) {
-                cmsUser = new CMSUser();
-                // set defaults
-                cmsUser.setLastName(userNPI);
-                registrationService.registerExternalUser(system, userNPI, cmsUser);
-            }
-
-            // set session based fields
-            if (userNPI.equals(profileNPI)) {
-                cmsUser.setExternalRoleView(RoleView.SELF);
-            } else {
-                cmsUser.setExternalRoleView(RoleView.EMPLOYER);
-            }
-            cmsUser.setProxyForNPI(profileNPI);
-            ExternalAccountLink link = registrationService.findAccountLink(
-                    cmsUser.getUserId(), system, userNPI);
-            cmsUser.setExternalAccountLink(link);
-
-            User springUserObject = new User(userNPI, "", true, true, true, true, EMPTY_AUTH);
-            return new CMSUserDetailsWrapper(springUserObject, cmsUser, system);
-        } catch (PortalServiceException e) {
-            throw new DataRetrievalFailureException("Database error.", e);
+        CMSUser cmsUser = registrationService.findByExternalUsername(system, userNPI);
+        if (cmsUser == null) {
+            cmsUser = new CMSUser();
+            // set defaults
+            cmsUser.setLastName(userNPI);
+            registrationService.registerExternalUser(system, userNPI, cmsUser);
         }
 
+        // set session based fields
+        if (userNPI.equals(profileNPI)) {
+            cmsUser.setExternalRoleView(RoleView.SELF);
+        } else {
+            cmsUser.setExternalRoleView(RoleView.EMPLOYER);
+        }
+        cmsUser.setProxyForNPI(profileNPI);
+        ExternalAccountLink link = registrationService.findAccountLink(
+                cmsUser.getUserId(), system, userNPI);
+        cmsUser.setExternalAccountLink(link);
+
+        User springUserObject = new User(userNPI, "", true, true, true, true, EMPTY_AUTH);
+        return new CMSUserDetailsWrapper(springUserObject, cmsUser, system);
     }
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainDatabaseAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainDatabaseAuthenticationProvider.java
@@ -22,7 +22,6 @@ import gov.medicaid.entities.SystemId;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.RegistrationService;
 
-import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -108,22 +107,18 @@ public class DomainDatabaseAuthenticationProvider implements AuthenticationProvi
      * @return the user principal
      */
     public UserDetails loadUserByUsername(String userId) {
-        try {
-            CMSUser cmsUser = registrationService.findByUsername(userId);
-            if (cmsUser == null) {
-                return null;
-            }
-
-            // we do not remembering external users
-            if (cmsUser.getUsername() == null) {
-                return null;
-            }
-
-            User user = new User(cmsUser.getUsername(), "", true, true, true, true, EMPTY_AUTH);
-            return new CMSUserDetailsWrapper(user, cmsUser, SystemId.CMS_ONLINE);
-        } catch (PortalServiceException e) {
-            throw new DataRetrievalFailureException("Database error.", e);
+        CMSUser cmsUser = registrationService.findByUsername(userId);
+        if (cmsUser == null) {
+            return null;
         }
+
+        // we do not remembering external users
+        if (cmsUser.getUsername() == null) {
+            return null;
+        }
+
+        User user = new User(cmsUser.getUsername(), "", true, true, true, true, EMPTY_AUTH);
+        return new CMSUserDetailsWrapper(user, cmsUser, SystemId.CMS_ONLINE);
     }
 
     /**

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -168,6 +168,19 @@ function setUserHelpClickHandler(
     });
 };
 
+function postJson(settings) {
+  var token = $("meta[name='_csrf']").attr("content");
+  var header = $("meta[name='_csrf_header']").attr("content");
+  $.extend(settings, {
+    type: "post",
+    dataType: "json",
+    beforeSend: function (xhr) {
+      xhr.setRequestHeader(header, token);
+    },
+  })
+  $.ajax(settings);
+}
+
 $(document).ready(function () {
 
   $('.searchPanel input[type="checkbox"]')

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1954,19 +1954,6 @@ function openAgencyLookup(primary) {
   openModal('#practiceLookupModal');
 }
 
-function postJson(settings) {
-  var token = $("meta[name='_csrf']").attr("content");
-  var header = $("meta[name='_csrf_header']").attr("content");
-  $.extend(settings, {
-    type: "post",
-    dataType: "json",
-    beforeSend: function (xhr) {
-      xhr.setRequestHeader(header, token);
-    },
-  })
-  $.ajax(settings);
-}
-
 function populatePracticeLookupResults() {
   var rs = practiceLookupResults;
   if (rs.total === 0) {

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -1155,6 +1155,20 @@ $(document).ready(function () {
         return false;
       });
 
+    $(".suspendLink, .reinstateLink").on('click', function () {
+      var link = $(this);
+      postJson({
+        url: link.attr("href"),
+        cache: false,
+        type: "POST",
+        dataType: "text",
+        success: function () {
+          link.closest("tr").toggleClass("disabledUser enabledUser");
+        }
+      });
+      return false;
+    });
+
     $('.searchBox').live('click', function () {
         var val = $.trim($('#searchBoxFirstName').val());
         $('#searchBoxLastName').val(val);

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -1084,12 +1084,12 @@ function deleteUserAccounts(userIds, toUserAccounts) {
     }
   }
 
-  $.ajax({
+  postJson({
       url: $('#deleteAccountsURL').val() + urlParams,
       cache: false,
-      type: "GET",
+      type: "POST",
       dataType: "text",
-      success: function (data) {
+      success: function () {
           if (toUserAccounts) {
             window.location = $('#userAccountsURL').val();
           } else {

--- a/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
@@ -36,18 +36,16 @@ public interface RegistrationService {
      * @param systemName the external system name to search the link for
      * @param username the username for the external system
      * @return the matching user, or null if not found
-     * @throws PortalServiceException for any errors encountered
      */
-    CMSUser findByExternalUsername(SystemId systemName, String username) throws PortalServiceException;
+    CMSUser findByExternalUsername(SystemId systemName, String username);
 
     /**
      * Retrieves the user with the given username.
      *
      * @param username the username to search for
      * @return the matching user, null if not found
-     * @throws PortalServiceException for any errors encountered
      */
-    CMSUser findByUsername(String username) throws PortalServiceException;
+    CMSUser findByUsername(String username);
 
     /**
      * Registers the given user.
@@ -69,41 +67,36 @@ public interface RegistrationService {
      * @param username the external user id
      * @param registrant the user profile
      * @return the generated user id
-     * @throws PortalServiceException for any errors encountered, or if any field is considered invalid by the
-     *             underlying implementations
      */
     String registerExternalUser(
             SystemId systemId,
             String username,
             CMSUser registrant
-    ) throws PortalServiceException;
+    );
 
     /**
      * Suspends the given user.
      *
      * @param principal the user performing the action
      * @param userId the user to be suspended
-     * @throws PortalServiceException for any errors encountered
      */
-    void suspend(CMSUser principal, String userId) throws PortalServiceException;
+    void suspend(CMSUser principal, String userId);
 
     /**
      * Reinstates the given user.
      *
      * @param principal the user performing the action
      * @param userId the user to be reinstated
-     * @throws PortalServiceException for any errors encountered
      */
-    void reinstate(CMSUser principal, String userId) throws PortalServiceException;
+    void reinstate(CMSUser principal, String userId);
 
     /**
      * Creates the account link. Ignores duplicates.
      *
      * @param userId the user id to be linked
      * @param link the account link details
-     * @throws PortalServiceException for any errors encountered
      */
-    void addAccountLink(String userId, ExternalAccountLink link) throws PortalServiceException;
+    void addAccountLink(String userId, ExternalAccountLink link);
 
     /**
      * Retrieves the account link.
@@ -112,10 +105,8 @@ public interface RegistrationService {
      * @param system the system linked to
      * @param externalAccountId the external user
      * @return the matching account link or null if not found
-     * @throws PortalServiceException for any errors encountered
      */
-    ExternalAccountLink findAccountLink(String userId, SystemId system, String externalAccountId)
-        throws PortalServiceException;
+    ExternalAccountLink findAccountLink(String userId, SystemId system, String externalAccountId);
 
     /**
      * Replaces the password of the given user.
@@ -142,9 +133,8 @@ public interface RegistrationService {
      *
      * @param userId the id to search for
      * @return the matching user, null if not found
-     * @throws PortalServiceException for any errors encountered
      */
-    CMSUser findByUserId(String userId) throws PortalServiceException;
+    CMSUser findByUserId(String userId);
 
     /**
      * Updates basic profile information for the given user.


### PR DESCRIPTION
Issue #33: Complete or remove the ability to suspend user accounts

This is the System UI, as well as login check, only.  There is probably a lot more around account management that we could do, but I believe the spirit of #33 was that we should at least do something with the field in the DB and the related dao functions.  So I think we should hold off on messaging, better error handling, etc until more requirements come, and log issues for those.

One large note is that I found no easy way to force a logout of someone who is suspended while already logged in.  That would involve a DB call on every single page view to check the cms_user table, and add that to the top level spring security interceptors, as the system currently works.  My view was that was overkill for this step of this feature.

Test via logging in as a system user.  Suspend an account.  Ensure you can no longer log in as that account.  Log back in as a system user, reinstate it.  Log back in as other account.