### PR TITLE
Add a Demo page to projectpsm.org, linking to demo installation

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,63 @@
+---
+layout: default
+title: Demo
+permalink: /demo/
+---
+<h1>Demo</h1>
+<p>
+  There is a 
+  <a href="https://demo.psm.solutionguidance.com">demo installation of the Provider Screening Module</a>
+  that closely follows the current state of development.
+  Use the following usernames and passwords to log in as one of the three user roles.
+</p>
+
+<h2>Provider Role</h2>
+
+<p>
+  A medical provider such as a doctor or hospital.
+</p>
+
+<p>
+  Username: p1
+</p>
+
+<p>
+  Password: p1
+</p>
+
+<h2>Service Admin Role</h2>
+
+<p>
+  An administrator who reviews, approves, and denies enrollment applications from providers.
+</p>
+
+<p>
+  Username: admin
+</p>
+
+<p>
+  Password: admin
+</p>
+
+<h2>System Admin Role</h2>
+
+<p>
+  A system administrator who does technical management tasks.
+</p>
+
+<p>
+  Username: system
+</p>
+
+<p>
+  Password: system
+</p>
+
+<h2>Questions?</h2>
+
+<p>
+  If you have questions about the demo installation of the PSM, please get in
+  <a href="/contact/">contact</a>.
+</p>
+
+{% include get_started.html %}


### PR DESCRIPTION
I didn't see an obvious place to link to the demo site, and since instructions for how to log in are needed, I added a new 'Demo' page.  Tested by building the projectpsm.org site locally (requires setting up a Ruby dev environment to run Jekyll) and checking that the links worked and everything appeared as expected.

Screenshot:

![screenshot_2018-07-10 demo](https://user-images.githubusercontent.com/1091693/42534551-f9a966fa-845a-11e8-8cc4-cda5c48b9c08.png)


Issue #913 ProjectPSM.org should link to demo site(s)