### PR TITLE
Clean up provider enrollment service

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExternalScreeningTimerBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExternalScreeningTimerBean.java
@@ -72,7 +72,7 @@ public class ExternalScreeningTimerBean extends BaseService {
         }
     }
 
-    private void runRescreenings() throws PortalServiceException {
+    private void runRescreenings() {
         for (UserRequest enrollment : getRescreenableEnrollments()) {
             logger.info(String.format(
                 "Running automatic re-screenings for enrollment " +
@@ -86,7 +86,7 @@ public class ExternalScreeningTimerBean extends BaseService {
         }
     }
 
-    private List<UserRequest> getRescreenableEnrollments() throws PortalServiceException {
+    private List<UserRequest> getRescreenableEnrollments() {
         ProviderSearchCriteria criteria = new ProviderSearchCriteria();
         criteria.setStatuses(Collections.singletonList(
             ViewStatics.APPROVED_STATUS

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
@@ -87,10 +87,9 @@ public class MockMNITSPartnerServiceBean extends BaseService implements
      *
      * 3. Confirm that 1 and 2 are identical, or, that #2 works for #1, else
      * show access error
-     * @throws PortalServiceException for any errors encountered
      */
     public boolean authenticate(String externalUserId, String password,
-            String profileNPI, String referrer) throws PortalServiceException {
+            String profileNPI, String referrer) {
 
         if (!internalSecurityDomain.equals(referrer)) {
             getLogger().warning("Rejecting external login due to invalid domain: " + referrer);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
@@ -158,9 +158,8 @@ public class OnboardingServiceBean extends BaseService implements OnboardingServ
      * @param link the external account link to verify credentials for
      * @param password the credentials
      * @return true if the credentials provided are valid
-     * @throws PortalServiceException for any errors encountered
      */
-    public boolean verifyCredentials(ExternalAccountLink link, String password) throws PortalServiceException {
+    public boolean verifyCredentials(ExternalAccountLink link, String password) {
         PartnerSystemService partner = partnerSystemServices.get(link.getSystemId());
         return partner.authenticate(link.getExternalUserId(), password, null, null);
     }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -2514,7 +2514,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     public Long[] renewalProfiles(
             CMSUser user,
             Set<Long> profileIds
-    ) throws PortalServiceException {
+    ) {
         List<Long> results = new ArrayList<Long>();
         for (Long profileId : profileIds) {
             try {

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -390,13 +390,12 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * @throws IllegalArgumentException if any argument is null, or the page
      *                                  size and page number settings are
      *                                  invalid
-     * @throws PortalServiceException   for any errors encountered
      */
     @SuppressWarnings("unchecked")
     @Override
     public SearchResult<Enrollment> searchEnrollments(
             EnrollmentSearchCriteria criteria
-    ) throws PortalServiceException {
+    ) {
         if (criteria == null) {
             throw new IllegalArgumentException("Criteria cannot be null.");
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -2731,7 +2731,6 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      *
      * @param profileNPI the NPI to be checked
      * @return true if a record matches
-     * @throws PortalServiceException for any errors encountered
      */
     @Override
     public boolean existsProfile(String profileNPI) {

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -810,11 +810,10 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      *
      * @param user the user performing the action
      * @return - the applicable providers
-     * @throws PortalServiceException for any errors encountered
      */
     @SuppressWarnings("unchecked")
     @Override
-    public List<ProfileHeader> findMyProfiles(CMSUser user) throws PortalServiceException {
+    public List<ProfileHeader> findMyProfiles(CMSUser user) {
         if (user == null || user.getRole() == null) {
             throw new IllegalArgumentException("User and the corresponding role cannot be null.");
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -680,14 +680,13 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * @param user     the user performing the search
      * @param criteria the criteria filter
      * @return the matching practice results
-     * @throws PortalServiceException for any errors encountered
      */
     @SuppressWarnings("unchecked")
     @Override
     public SearchResult<PracticeLookup> searchPractice(
             CMSUser user,
             PracticeSearchCriteria criteria
-    ) throws PortalServiceException {
+    ) {
         if (criteria == null) {
             throw new IllegalArgumentException("Criteria cannot be null.");
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1007,14 +1007,13 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * @param sourceSystem the source of the imported profile
      * @param profile      the profile to be created
      * @return the assigned internal id
-     * @throws PortalServiceException for any errors encountered
      */
     @Override
     public long importProfile(
             CMSUser user,
             SystemId sourceSystem,
             ProviderProfile profile
-    ) throws PortalServiceException {
+    ) {
         throw new NotImplementedException("Profile import is not yet supported.");
     }
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -448,13 +448,12 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * @throws IllegalArgumentException if any argument is null, or the page
      *                                  size and page number settings are
      *                                  invalid
-     * @throws PortalServiceException   for any errors encountered
      */
     @SuppressWarnings("unchecked")
     @Override
     public SearchResult<Enrollment> getDraftAtEomEnrollments(
             EnrollmentSearchCriteria criteria
-    ) throws PortalServiceException {
+    ) {
         if (criteria == null) {
             throw new IllegalArgumentException("Criteria cannot be null.");
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -304,9 +304,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             }
 
             BinaryContent content = getEm().find(BinaryContent.class, attachment.getContentId());
-            InputStream input = null;
-            try {
-                input = content.getContent().getBinaryStream();
+            try (InputStream input = content.getContent().getBinaryStream()) {
                 response.setContentType(attachment.getType());
                 response.setHeader(
                         "Content-Disposition",
@@ -315,10 +313,6 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
                 IOUtils.copy(input, response.getOutputStream());
             } catch (SQLException e) {
                 throw new IOException("Cannot read binary content from database.", e);
-            } finally {
-                if (input != null) {
-                    input.close();
-                }
             }
         }
     }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1363,11 +1363,10 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * Inserts the provider profile statement.
      *
      * @param details the provider profile
-     * @throws PortalServiceException for any errors encountered
      */
     private void insertStatement(
             ProviderProfile details
-    ) throws PortalServiceException {
+    ) {
         ProviderStatement statement = details.getStatement();
         if (statement == null) {
             return;
@@ -1745,12 +1744,11 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      *
      * @param user     the user performing the operation.
      * @param ticketId the ticket that will be cleared
-     * @throws PortalServiceException for any errors encountered
      */
     private void purgeTicketDetails(
             CMSUser user,
             long ticketId
-    ) throws PortalServiceException {
+    ) {
         ProviderProfile profile = getProviderDetailsByTicket(ticketId, true);
         if (profile != null) {
             purge(profile);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -2686,7 +2686,6 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * @param profileNPI     the employee to be checked
      * @return true if there is an affiliation between the two arguments that
      * gives the first access to the latter
-     * @throws PortalServiceException for any errors encountered
      */
     @SuppressWarnings("unchecked")
     @Override

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -2472,7 +2472,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     }
 
     @Override
-    public List<Note> findNotes(long ticketId) throws PortalServiceException {
+    public List<Note> findNotes(long ticketId) {
         List<Note> pendingNotes = new ArrayList<Note>();
         pendingNotes.addAll(findNotes(0, ticketId));
         ProviderProfile profile = getProviderDetailsByTicket(ticketId, false);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -657,13 +657,12 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      *
      * @param npi the National Provider Identifier to search by
      * @return the matching practice results
-     * @throws PortalServiceException for any errors encountered
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public List<ProviderLookup> lookupProvider(
             String npi
-    ) throws PortalServiceException {
+    ) {
         String fetchQuery =
                 "SELECT NEW gov.medicaid.entities.ProviderLookup(e.profileId, e.npi, e.name, e.providerType.description) "
                 + "FROM Entity e WHERE e.npi = :npi AND ticketId = 0 AND e.enrolled = 'Y'";

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -268,7 +268,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             Enrollment ticket
     ) throws PortalServiceException {
         // update the profile with the given changes
-        purgeTicketDetails(user, ticket.getTicketId());
+        purgeTicketDetails(ticket.getTicketId());
         ticket.setDetails(ticket.getDetails().clone());
         saveTicket(user, ticket, true);
         approveTicket(user, ticket.getTicketId());
@@ -518,7 +518,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         } else {
             // delete - insert
             ProviderProfile profile = ticket.getDetails();
-            purgeTicketDetails(user, ticket.getTicketId());
+            purgeTicketDetails(ticket.getTicketId());
             ticket.setDetails(profile);
         }
 
@@ -706,10 +706,10 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
                 + "WHERE e.enrolled = 'Y'";
 
         StringBuilder countQuery = new StringBuilder("SELECT count(*) " + fromClause);
-        appendCriteria(countQuery, user, criteria);
+        appendCriteria(countQuery, criteria);
 
         Query count = getEm().createQuery(countQuery.toString());
-        bindParameters(count, user, criteria);
+        bindParameters(count, criteria);
         results.setTotal(((Number) count.getSingleResult()).intValue());
 
         StringBuilder fetchQuery = new StringBuilder(
@@ -718,11 +718,11 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
                         + "ci.address.zipcode, ci.address.county, ci.phoneNumber, ci.faxNumber, "
                         + "e.backgroundStudyId, e.backgroundClearanceDate, e.agencyId) " + fromClause);
 
-        appendCriteria(fetchQuery, user, criteria);
+        appendCriteria(fetchQuery, criteria);
         appendSorting(fetchQuery, criteria);
 
         Query items = getEm().createQuery(fetchQuery.toString());
-        bindParameters(items, user, criteria);
+        bindParameters(items, criteria);
         if (criteria.getPageNumber() > 0) {
             int offset = (criteria.getPageNumber() - 1) * criteria.getPageSize();
             items.setFirstResult(offset);
@@ -1741,11 +1741,9 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     /**
      * Removes the ticket details.
      *
-     * @param user     the user performing the operation.
      * @param ticketId the ticket that will be cleared
      */
     private void purgeTicketDetails(
-            CMSUser user,
             long ticketId
     ) {
         ProviderProfile profile = getProviderDetailsByTicket(ticketId, true);
@@ -2205,12 +2203,10 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * Appends the provider search criteria to the current buffer.
      *
      * @param buffer   the query buffer
-     * @param user     the current user
      * @param criteria the search criteria
      */
     private void appendCriteria(
             StringBuilder buffer,
-            CMSUser user,
             PracticeSearchCriteria criteria
     ) {
         if (criteria.isAgency()) {
@@ -2242,12 +2238,10 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * Binds the provider search criteria to the query.
      *
      * @param query    the query to bind to
-     * @param user     the user performing the action
      * @param criteria the search criteria
      */
     private void bindParameters(
             Query query,
-            CMSUser user,
             PracticeSearchCriteria criteria
     ) {
         if (criteria.getProfileId() > 0) {

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -346,7 +346,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
 
         checkSortColumn(criteria, TICKET_COL_CNT);
 
-        SearchResult<UserRequest> results = new SearchResult<UserRequest>();
+        SearchResult<UserRequest> results = new SearchResult<>();
         results.setPageNumber(criteria.getPageNumber());
         results.setPageSize(criteria.getPageSize());
 
@@ -698,7 +698,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
 
         checkSortColumn(criteria, PRACTICE_COL_CNT);
 
-        SearchResult<PracticeLookup> results = new SearchResult<PracticeLookup>();
+        SearchResult<PracticeLookup> results = new SearchResult<>();
         results.setPageNumber(criteria.getPageNumber());
         results.setPageSize(criteria.getPageSize());
 
@@ -748,7 +748,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             return;
         }
 
-        Map<Long, PracticeLookup> map = new HashMap<Long, PracticeLookup>();
+        Map<Long, PracticeLookup> map = new HashMap<>();
         for (PracticeLookup practiceLookup : resultList) {
             map.put(practiceLookup.getProfileId(), practiceLookup);
         }
@@ -757,7 +757,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
                 "SELECT NEW gov.medicaid.entities.ContactData(dc.profileId, dc.person.name) "
                 + "FROM DesignatedContact dc WHERE dc.type = 'ENROLLMENT' AND dc.profileId IN (:profileIds)";
         Query q = getEm().createQuery(fetchQuery);
-        q.setParameter("profileIds", new ArrayList<Long>(map.keySet()));
+        q.setParameter("profileIds", new ArrayList<>(map.keySet()));
         List<ContactData> rs = q.getResultList();
         for (ContactData contactData : rs) {
             PracticeLookup match = map.get(contactData.getProfileId());
@@ -778,7 +778,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             return;
         }
 
-        Map<Long, ProviderLookup> map = new HashMap<Long, ProviderLookup>();
+        Map<Long, ProviderLookup> map = new HashMap<>();
         for (ProviderLookup practiceLookup : resultList) {
             map.put(practiceLookup.getProfileId(), practiceLookup);
         }
@@ -787,7 +787,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
                 "SELECT NEW gov.medicaid.entities.ContactData(dc.profileId, dc.person.name, dc.person.contactInformation.phoneNumber) "
                 + "FROM DesignatedContact dc WHERE dc.type = 'ENROLLMENT' AND dc.profileId IN (:profileIds)";
         Query q = getEm().createQuery(fetchQuery);
-        q.setParameter("profileIds", new ArrayList<Long>(map.keySet()));
+        q.setParameter("profileIds", new ArrayList<>(map.keySet()));
         List<ContactData> rs = q.getResultList();
         for (ContactData contactData : rs) {
             ProviderLookup match = map.get(contactData.getProfileId());
@@ -1440,7 +1440,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
     private Map<Long, Long> insertAttachments(
             ProviderProfile details
     ) throws PortalServiceException {
-        HashMap<Long, Long> mapping = new HashMap<Long, Long>();
+        HashMap<Long, Long> mapping = new HashMap<>();
 
         List<Document> attachments = details.getAttachments();
         if (attachments == null || attachments.isEmpty()) {
@@ -2277,7 +2277,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             long profileId,
             long ticketId
     ) throws PortalServiceException {
-        List<ProviderCategoryOfService> services = new ArrayList<ProviderCategoryOfService>();
+        List<ProviderCategoryOfService> services = new ArrayList<>();
         services.addAll(getPendingCategoryOfServices(user, ticketId));
         services.addAll(getProviderCategoryOfServices(user, profileId));
         for (ProviderCategoryOfService service : services) {
@@ -2294,7 +2294,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * @param ticketId  the ticket associated
      */
     private void promoteNotesToBase(long profileId, long ticketId) {
-        List<Note> pendingNotes = new ArrayList<Note>();
+        List<Note> pendingNotes = new ArrayList<>();
         pendingNotes.addAll(findNotes(0, ticketId));
         pendingNotes.addAll(findNotes(profileId, ticketId));
 
@@ -2466,7 +2466,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
 
     @Override
     public List<Note> findNotes(long ticketId) {
-        List<Note> pendingNotes = new ArrayList<Note>();
+        List<Note> pendingNotes = new ArrayList<>();
         pendingNotes.addAll(findNotes(0, ticketId));
         ProviderProfile profile = getProviderDetailsByTicket(ticketId, false);
         if (profile.getProfileId() > 0) {
@@ -2508,7 +2508,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             CMSUser user,
             Set<Long> profileIds
     ) {
-        List<Long> results = new ArrayList<Long>();
+        List<Long> results = new ArrayList<>();
         for (Long profileId : profileIds) {
             try {
                 Enrollment ticket = renewProfile(user, profileId);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1046,7 +1046,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         if (rs.isEmpty()) {
             return null;
         }
-        return (Entity) rs.get(0);
+        return rs.get(0);
     }
 
     /**
@@ -1095,7 +1095,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
             return null;
         }
 
-        ProviderProfile profile = (ProviderProfile) rs.get(0);
+        ProviderProfile profile = rs.get(0);
         if (fetchChildren) {
             fetchChildren(profile);
         }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1788,11 +1788,11 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         Query query = getEm().createQuery(
                 "FROM ProviderCategoryOfService p WHERE ticketId = :ticketId AND profileId = :profileId");
         if (ticketId > 0) { // COS tickets do not populate the original profile id even on UPDATE
-            query.setParameter("profileId", new Long(0));
+            query.setParameter("profileId", 0L);
             query.setParameter("ticketId", ticketId);
         } else {
             query.setParameter("ticketId", ticketId);
-            query.setParameter("profileId", new Long(0));
+            query.setParameter("profileId", 0L);
         }
         return query.getResultList();
     }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -327,14 +327,13 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
      * @throws IllegalArgumentException if any argument is null, or the page
      *                                  size and page number settings are
      *                                  invalid
-     * @throws PortalServiceException   for any errors encountered
      */
     @SuppressWarnings("unchecked")
     @Override
     public SearchResult<UserRequest> searchTickets(
             CMSUser user,
             ProviderSearchCriteria criteria
-    ) throws PortalServiceException {
+    ) {
         if (criteria == null) {
             throw new IllegalArgumentException("Criteria cannot be null.");
         }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/TaskResourceProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/TaskResourceProvider.java
@@ -51,7 +51,7 @@ public class TaskResourceProvider implements IResourceProvider {
             @OptionalParam(name = "status") StringOrListParam statuses,
             @OptionalParam(name = "providerType") String providerType,
             @OptionalParam(name = "name") String name
-    ) throws PortalServiceException {
+    ) {
         validateNpi(npi);
 
         ProviderSearchCriteria criteria = new ProviderSearchCriteria();

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -721,7 +721,6 @@ public class EnrollmentPageFlowController extends BaseController {
      *
      * @param criteria the lookup criteria
      * @return the lookup JSON
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/enrollment/lookup"
      * @verb POST
      */
@@ -729,7 +728,7 @@ public class EnrollmentPageFlowController extends BaseController {
     @ResponseBody
     public SearchResult<PracticeLookup> lookup(
             PracticeSearchCriteria criteria
-    ) throws PortalServiceException {
+    ) {
         CMSUser user = ControllerHelper.getCurrentUser();
         SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(user, criteria);
         List<PracticeLookup> items = results.getItems();

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -746,7 +746,6 @@ public class EnrollmentPageFlowController extends BaseController {
      *
      * @param npi the provider NPI
      * @return the lookup JSON
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/enrollment/lookupProvider"
      * @verb POST
      */
@@ -754,7 +753,7 @@ public class EnrollmentPageFlowController extends BaseController {
     @ResponseBody
     public List<ProviderLookup> lookupProvider(
             @RequestParam("npi") String npi
-    ) throws PortalServiceException {
+    ) {
         List<ProviderLookup> results = getEnrollmentService().lookupProvider(npi);
         if (results != null) {
             for (ProviderLookup item : results) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
@@ -154,12 +154,11 @@ public class MyProfileController extends BaseController {
      * Displays the my profile page.
      *
      * @return the my profile model and view
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/profile/"
      * @verb GET
      */
     @RequestMapping(value = "/", method = RequestMethod.GET)
-    public ModelAndView viewDashboard() throws PortalServiceException {
+    public ModelAndView viewDashboard() {
         CMSPrincipal principal = ControllerHelper.getPrincipal();
         List<ProfileHeader> profiles = enrollmentService.findMyProfiles(principal.getUser());
         ModelAndView mv = new ModelAndView("provider/profile/list");

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -255,9 +255,10 @@ public class ProviderDashboardController extends BaseController {
      * @verb GET
      */
     @RequestMapping(value = "/filter", method = RequestMethod.GET)
-    public ModelAndView filterTicketsByStatus(@RequestParam("status") String status, ProviderSearchCriteria criteria)
-        throws PortalServiceException {
-
+    public ModelAndView filterTicketsByStatus(
+        @RequestParam("status") String status,
+        ProviderSearchCriteria criteria
+    ) throws PortalServiceException {
         String view = "provider/dashboard/list_by_status";
         criteria.setStatuses(Arrays.asList(status));
         ModelAndView mv = searchTickets(criteria, view);
@@ -284,8 +285,10 @@ public class ProviderDashboardController extends BaseController {
      */
     @SuppressWarnings("unchecked")
     @RequestMapping(value = "/export", method = RequestMethod.GET)
-    public void exportTicketsByStatus(@RequestParam("status") String status, ProviderSearchCriteria criteria,
-        HttpServletResponse response) throws PortalServiceException, IOException {
+    public void exportTicketsByStatus(
+        @RequestParam("status") String status, ProviderSearchCriteria criteria,
+        HttpServletResponse response
+    ) throws PortalServiceException, IOException {
         criteria.setStatuses(Arrays.asList(status));
 
         // export all
@@ -324,7 +327,10 @@ public class ProviderDashboardController extends BaseController {
      * @return the results and the view provided
      * @throws PortalServiceException for any errors encountered
      */
-    private ModelAndView searchTickets(ProviderSearchCriteria criteria, String view) throws PortalServiceException {
+    private ModelAndView searchTickets(
+        ProviderSearchCriteria criteria,
+        String view
+    ) throws PortalServiceException {
         String enrollmentNumber = criteria.getEnrollmentNumber();
         // enrollment number must be a valid long since ids are of that type.
         if (Util.isNotBlank(enrollmentNumber)) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -97,12 +97,11 @@ public class ProviderDashboardController extends BaseController {
      * Opens the dashboard.
      *
      * @return the dashboard page and the needed models
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/dashboard/"
      * @verb GET
      */
     @RequestMapping(value = "/", method = RequestMethod.GET)
-    public ModelAndView viewDashboard() throws PortalServiceException {
+    public ModelAndView viewDashboard() {
         if (isOperations()) {
             return new ModelAndView("redirect:/landing");
         }
@@ -157,12 +156,11 @@ public class ProviderDashboardController extends BaseController {
      * Shows the default dashboard page.
      *
      * @return the dashboard page
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/dashboard/list"
      * @verb GET
      */
     @RequestMapping(value = "/list", method = RequestMethod.GET)
-    public ModelAndView viewTicketList() throws PortalServiceException {
+    public ModelAndView viewTicketList() {
         return filterTicketList(createDefaultFilter());
     }
 
@@ -170,12 +168,11 @@ public class ProviderDashboardController extends BaseController {
      * Shows the drafts page.
      *
      * @return the drafts page
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/dashboard/drafts"
      * @verb GET
      */
     @RequestMapping(value = "/drafts", method = RequestMethod.GET)
-    public ModelAndView viewDrafts() throws PortalServiceException {
+    public ModelAndView viewDrafts() {
         if (isOperations()) {
             return new ModelAndView("redirect:/agent/enrollment/list/draft?statuses=Draft&showFilterPanel=true");
         }
@@ -186,12 +183,11 @@ public class ProviderDashboardController extends BaseController {
      * Shows the pending page.
      *
      * @return the pending page
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/dashboard/pending"
      * @verb GET
      */
     @RequestMapping(value = "/pending", method = RequestMethod.GET)
-    public ModelAndView viewPending() throws PortalServiceException {
+    public ModelAndView viewPending() {
         if (isOperations()) {
             return new ModelAndView("redirect:/agent/enrollment/list/draft?statuses=Pending&showFilterPanel=true");
         }
@@ -202,12 +198,11 @@ public class ProviderDashboardController extends BaseController {
      * Shows the approved page.
      *
      * @return the approved page
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/dashboard/approved"
      * @verb GET
      */
     @RequestMapping(value = "/approved", method = RequestMethod.GET)
-    public ModelAndView viewApproved() throws PortalServiceException {
+    public ModelAndView viewApproved() {
         if (isOperations()) {
             return new ModelAndView("redirect:/agent/enrollment/list/draft?statuses=Approved&showFilterPanel=true");
         }
@@ -218,12 +213,11 @@ public class ProviderDashboardController extends BaseController {
      * Shows the rejected page.
      *
      * @return the rejected page
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/dashboard/rejected"
      * @verb GET
      */
     @RequestMapping(value = "/rejected", method = RequestMethod.GET)
-    public ModelAndView viewRejected() throws PortalServiceException {
+    public ModelAndView viewRejected() {
         if (isOperations()) {
             return new ModelAndView("redirect:/agent/enrollment/list/draft?statuses=Rejected&showFilterPanel=true");
         }
@@ -250,7 +244,6 @@ public class ProviderDashboardController extends BaseController {
      * @param status only status of this type will be returned
      * @param criteria the search criteria
      * @return the view to show the results by status
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/dashboard/filter"
      * @verb GET
      */
@@ -258,7 +251,7 @@ public class ProviderDashboardController extends BaseController {
     public ModelAndView filterTicketsByStatus(
         @RequestParam("status") String status,
         ProviderSearchCriteria criteria
-    ) throws PortalServiceException {
+    ) {
         String view = "provider/dashboard/list_by_status";
         criteria.setStatuses(Arrays.asList(status));
         ModelAndView mv = searchTickets(criteria, view);
@@ -310,12 +303,11 @@ public class ProviderDashboardController extends BaseController {
      *
      * @param criteria the filter
      * @return the dashboard page
-     * @throws PortalServiceException for any errors encountered
      * @endpoint "/provider/dashboard/list/filter"
      * @verb GET
      */
     @RequestMapping(value = "/list/filter", method = RequestMethod.GET)
-    public ModelAndView filterTicketList(ProviderSearchCriteria criteria) throws PortalServiceException {
+    public ModelAndView filterTicketList(ProviderSearchCriteria criteria) {
         return searchTickets(criteria, "provider/dashboard/list");
     }
 
@@ -325,12 +317,11 @@ public class ProviderDashboardController extends BaseController {
      * @param criteria the search criteria
      * @param view the view to render the results
      * @return the results and the view provided
-     * @throws PortalServiceException for any errors encountered
      */
     private ModelAndView searchTickets(
         ProviderSearchCriteria criteria,
         String view
-    ) throws PortalServiceException {
+    ) {
         String enrollmentNumber = criteria.getEnrollmentNumber();
         // enrollment number must be a valid long since ids are of that type.
         if (Util.isNotBlank(enrollmentNumber)) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -448,13 +448,12 @@ public class EnrollmentController extends BaseController {
      * @return the model and view instance that contains the name of view to be
      * rendered and data to be used for rendering (not null)
      * @throws IllegalArgumentException if npi is null/empty
-     * @throws PortalServiceException   If there are any errors in the action
      * @endpoint "/agent/enrollment/status"
      */
     @RequestMapping(value = "/agent/enrollment/status")
     public ModelAndView getByNumber(
             @RequestParam("npi") String npi
-    ) throws PortalServiceException {
+    ) {
 
         if (npi == null || npi.trim().length() == 0) {
             throw new IllegalArgumentException("A valid NPI must be provided.");

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
@@ -44,7 +44,7 @@ public class ApplicationsByReviewerReportController extends gov.medicaid.control
         @RequestParam(value = "startDate", required = false) String startDateSubmitted,
         @RequestParam(value = "startDate", required = false) Date inputStartDate,
         @RequestParam(value = "endDate", required = false) Date inputEndDate
-    ) throws PortalServiceException {
+    ) {
         ModelAndView mv = new ModelAndView("admin/reports/applications_by_reviewer");
 
         Date startDate = startDateSubmitted != null
@@ -105,7 +105,7 @@ public class ApplicationsByReviewerReportController extends gov.medicaid.control
     private List<Enrollment> getEnrollmentsFromDB(
         Date startDate,
         Date endDate
-    ) throws PortalServiceException {
+    ) {
         EnrollmentSearchCriteria criteria = new EnrollmentSearchCriteria();
         criteria.setCreateDateStart(startDate);
         criteria.setCreateDateEnd(endDate);

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/DraftApplicationsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/DraftApplicationsReportController.java
@@ -38,7 +38,7 @@ public class DraftApplicationsReportController extends gov.medicaid.controllers.
     }
 
     @RequestMapping(value = "/admin/reports/draft-applications", method = RequestMethod.GET)
-    public ModelAndView getDraftApplications() throws PortalServiceException {
+    public ModelAndView getDraftApplications() {
         ModelAndView mv = new ModelAndView("admin/reports/draft_applications");
         SearchResult<Enrollment> enrollments = getEnrollmentsFromDB();
         List<EnrollmentMonth> months = groupEnrollments(enrollments.getItems());
@@ -82,7 +82,7 @@ public class DraftApplicationsReportController extends gov.medicaid.controllers.
         }
     }
 
-    private SearchResult<Enrollment> getEnrollmentsFromDB() throws PortalServiceException {
+    private SearchResult<Enrollment> getEnrollmentsFromDB() {
         EnrollmentSearchCriteria criteria = new EnrollmentSearchCriteria();
         criteria.setAscending(true);
         criteria.setSortColumn("created_at");

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
@@ -118,7 +118,7 @@ public class ProviderTypesReportController extends gov.medicaid.controllers.Base
 
     private List<Enrollment> getEnrollmentsFromDB(
         List<String> providerTypeCodes
-    ) throws PortalServiceException {
+    ) {
         EnrollmentSearchCriteria criteria = new EnrollmentSearchCriteria();
         criteria.setProviderTypes(providerTypeCodes);
         return enrollmentService.searchEnrollments(criteria).getItems();

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
@@ -134,7 +134,7 @@ public class ProviderTypesReportController extends gov.medicaid.controllers.Base
             });
     }
 
-    private List<Month> buildMonths(List<EnrollmentMonth> ems) throws PortalServiceException {
+    private List<Month> buildMonths(List<EnrollmentMonth> ems) {
         List<Month> months = new ArrayList<>();
 
         for (EnrollmentMonth em : ems) {
@@ -148,8 +148,7 @@ public class ProviderTypesReportController extends gov.medicaid.controllers.Base
         Map<ProviderType, List<Enrollment>> typeEnrollments;
         LocalDate month;
 
-        public Month(EnrollmentMonth em, ProviderEnrollmentService enrollmentService)
-            throws PortalServiceException {
+        public Month(EnrollmentMonth em, ProviderEnrollmentService enrollmentService) {
             typeEnrollments = new HashMap<>();
             month = em.getMonth();
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportController.java
@@ -39,7 +39,7 @@ public class ReviewedDocumentsReportController extends gov.medicaid.controllers.
     }
 
     @RequestMapping(value = "/admin/reports/reviewed-documents", method = RequestMethod.GET)
-    public ModelAndView getReviewedDocuments() throws PortalServiceException {
+    public ModelAndView getReviewedDocuments() {
         ModelAndView mv = new ModelAndView("admin/reports/reviewed_documents");
 
         List<Enrollment> enrollments = getEnrollmentsFromDB();
@@ -77,7 +77,7 @@ public class ReviewedDocumentsReportController extends gov.medicaid.controllers.
         }
     }
 
-    private List<Enrollment> getEnrollmentsFromDB() throws PortalServiceException {
+    private List<Enrollment> getEnrollmentsFromDB() {
         EnrollmentSearchCriteria criteria = new EnrollmentSearchCriteria();
         criteria.setAscending(true);
         criteria.setSortColumn("created_at");

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
@@ -53,7 +53,7 @@ public class RiskLevelsReportController extends gov.medicaid.controllers.BaseCon
     }
 
     @RequestMapping(value = "/admin/reports/risk-levels", method = RequestMethod.GET)
-    public ModelAndView getRiskLevels() throws PortalServiceException {
+    public ModelAndView getRiskLevels() {
         ModelAndView mv = new ModelAndView("admin/reports/risk_levels");
 
         List<Enrollment> enrollments = getEnrollmentsFromDB();
@@ -104,7 +104,7 @@ public class RiskLevelsReportController extends gov.medicaid.controllers.BaseCon
         }
     }
 
-    private List<Enrollment> getEnrollmentsFromDB() throws PortalServiceException {
+    private List<Enrollment> getEnrollmentsFromDB() {
         EnrollmentSearchCriteria criteria = new EnrollmentSearchCriteria();
         criteria.setAscending(true);
         criteria.setSortColumn("created_at");

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/TimeToReviewReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/TimeToReviewReportController.java
@@ -41,7 +41,7 @@ public class TimeToReviewReportController extends gov.medicaid.controllers.BaseC
     }
 
     @RequestMapping(value = "/admin/reports/time-to-review", method = RequestMethod.GET)
-    public ModelAndView getTimeToReview() throws PortalServiceException {
+    public ModelAndView getTimeToReview() {
         ModelAndView mv = new ModelAndView("admin/reports/time_to_review");
         SearchResult<Enrollment> enrollments = getEnrollmentsFromDB();
         List<EnrollmentMonth> ems = groupEnrollments(enrollments.getItems());
@@ -84,7 +84,7 @@ public class TimeToReviewReportController extends gov.medicaid.controllers.BaseC
         }
     }
 
-    private SearchResult<Enrollment> getEnrollmentsFromDB() throws PortalServiceException {
+    private SearchResult<Enrollment> getEnrollmentsFromDB() {
         EnrollmentSearchCriteria criteria = new EnrollmentSearchCriteria();
         return enrollmentService.searchEnrollments(criteria);
     }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
@@ -24,7 +24,6 @@ import gov.medicaid.entities.SystemId;
 import gov.medicaid.services.PartnerSystemService;
 import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
-import gov.medicaid.services.PortalServiceRuntimeException;
 import gov.medicaid.services.RegistrationService;
 import gov.medicaid.services.util.Util;
 
@@ -117,12 +116,8 @@ public class DefaultExternalAuthenticationProvider implements AuthenticationProv
                 throw new BadCredentialsException("Referrer is required.");
             }
 
-            try {
-                if (!partnerService.authenticate(username, password, profileNPI, referrer)) {
-                    throw new BadCredentialsException("Invalid credentials.");
-                }
-            } catch (PortalServiceException e) {
-                throw new PortalServiceRuntimeException("Data lookup errors", e);
+            if (!partnerService.authenticate(username, password, profileNPI, referrer)) {
+                throw new BadCredentialsException("Invalid credentials.");
             }
 
             return createSuccessfulAuthentication(userToken, loadProxyUser(username, profileNPI));

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
@@ -35,7 +35,6 @@ import gov.medicaid.entities.RoleView;
 import gov.medicaid.entities.SearchResult;
 import gov.medicaid.entities.dto.FormError;
 import gov.medicaid.entities.dto.ViewStatics;
-import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.PortalServiceRuntimeException;
 import gov.medicaid.services.util.Util;
 
@@ -108,28 +107,24 @@ public abstract class AbstractPracticeFormBinder extends BaseFormBinder {
      * @param practice the practice to attach to
      */
     private void attachLinkedGroup(PracticeInformationType practice) {
-        try {
-            PracticeSearchCriteria criteria = new PracticeSearchCriteria();
-            criteria.setProfileId(Long.parseLong(practice.getObjectId()));
-            SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(getSystemUser(), criteria);
-            PracticeLookup linkedPractice = results.getItems().get(0);
+        PracticeSearchCriteria criteria = new PracticeSearchCriteria();
+        criteria.setProfileId(Long.parseLong(practice.getObjectId()));
+        SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(getSystemUser(), criteria);
+        PracticeLookup linkedPractice = results.getItems().get(0);
 
-            practice.setName(linkedPractice.getName());
-            practice.setGroupNPI(linkedPractice.getNpi());
-            AddressType address = XMLUtility.nsGetAddress(practice);
-            address.setAddressLine1(linkedPractice.getAddressLine1());
-            address.setAddressLine2(linkedPractice.getAddressLine2());
-            address.setCity(linkedPractice.getCity());
-            address.setState(linkedPractice.getState());
-            address.setZipCode(linkedPractice.getZip());
-            address.setCounty(linkedPractice.getCounty());
+        practice.setName(linkedPractice.getName());
+        practice.setGroupNPI(linkedPractice.getNpi());
+        AddressType address = XMLUtility.nsGetAddress(practice);
+        address.setAddressLine1(linkedPractice.getAddressLine1());
+        address.setAddressLine2(linkedPractice.getAddressLine2());
+        address.setCity(linkedPractice.getCity());
+        address.setState(linkedPractice.getState());
+        address.setZipCode(linkedPractice.getZip());
+        address.setCounty(linkedPractice.getCounty());
 
-            ContactInformationType contact = XMLUtility.nsGetContactInformation(practice);
-            contact.setPhoneNumber(linkedPractice.getPhoneNumber());
-            contact.setFaxNumber(linkedPractice.getFaxNumber());
-        } catch (PortalServiceException e) {
-            throw new PortalServiceRuntimeException("Cannot verify linked practice.", e);
-        }
+        ContactInformationType contact = XMLUtility.nsGetContactInformation(practice);
+        contact.setPhoneNumber(linkedPractice.getPhoneNumber());
+        contact.setFaxNumber(linkedPractice.getFaxNumber());
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
@@ -32,7 +32,6 @@ import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.SearchResult;
 import gov.medicaid.entities.dto.FormError;
 import gov.medicaid.entities.dto.ViewStatics;
-import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.PortalServiceRuntimeException;
 import gov.medicaid.services.util.Util;
 
@@ -333,19 +332,15 @@ public class AdditionalAgencyFormBinder extends BaseFormBinder {
      * @param location the practice location
      */
     private void attachLinkedGroup(GroupAffiliationType location) {
-        try {
-            PracticeSearchCriteria criteria = new PracticeSearchCriteria();
-            criteria.setProfileId(Long.parseLong(location.getObjectId()));
-            criteria.setAgency(true);
-            SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(getSystemUser(), criteria);
-            PracticeLookup linkedPractice = results.getItems().get(0);
+        PracticeSearchCriteria criteria = new PracticeSearchCriteria();
+        criteria.setProfileId(Long.parseLong(location.getObjectId()));
+        criteria.setAgency(true);
+        SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(getSystemUser(), criteria);
+        PracticeLookup linkedPractice = results.getItems().get(0);
 
-            location.setName(linkedPractice.getName());
-            location.setNPI(linkedPractice.getNpi());
-            location.setStudyId(linkedPractice.getBgsId());
-            location.setClearanceDate(BinderUtils.toCalendar(linkedPractice.getClearanceDate()));
-        } catch (PortalServiceException e) {
-            throw new PortalServiceRuntimeException("Cannot verify linked agency.", e);
-        }
+        location.setName(linkedPractice.getName());
+        location.setNPI(linkedPractice.getNpi());
+        location.setStudyId(linkedPractice.getBgsId());
+        location.setClearanceDate(BinderUtils.toCalendar(linkedPractice.getClearanceDate()));
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
@@ -36,7 +36,6 @@ import gov.medicaid.entities.RoleView;
 import gov.medicaid.entities.SearchResult;
 import gov.medicaid.entities.dto.FormError;
 import gov.medicaid.entities.dto.ViewStatics;
-import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.PortalServiceRuntimeException;
 import gov.medicaid.services.util.Util;
 
@@ -410,25 +409,20 @@ public class AdditionalPracticeFormBinder extends BaseFormBinder {
      * @param location the practice location
      */
     private void attachLinkedGroup(PracticeLocationType location) {
-        try {
-            PracticeSearchCriteria criteria = new PracticeSearchCriteria();
-            criteria.setProfileId(Long.parseLong(location.getObjectId()));
-            SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(getSystemUser(), criteria);
-            PracticeLookup linkedPractice = results.getItems().get(0);
+        PracticeSearchCriteria criteria = new PracticeSearchCriteria();
+        criteria.setProfileId(Long.parseLong(location.getObjectId()));
+        SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(getSystemUser(), criteria);
+        PracticeLookup linkedPractice = results.getItems().get(0);
 
-            location.setGroupName(linkedPractice.getName());
-            location.setGroupNPI(linkedPractice.getNpi());
-            location.setAddress(new AddressType());
+        location.setGroupName(linkedPractice.getName());
+        location.setGroupNPI(linkedPractice.getNpi());
+        location.setAddress(new AddressType());
 
-            AddressType address = location.getAddress();
-            address.setAddressLine2(linkedPractice.getAddressLine2());
-            address.setCity(linkedPractice.getCity());
-            address.setState(linkedPractice.getState());
-            address.setZipCode(linkedPractice.getZip());
-            address.setCounty(linkedPractice.getCounty());
-
-        } catch (PortalServiceException e) {
-            throw new PortalServiceRuntimeException("Cannot verify linked practice.", e);
-        }
+        AddressType address = location.getAddress();
+        address.setAddressLine2(linkedPractice.getAddressLine2());
+        address.setCity(linkedPractice.getCity());
+        address.setState(linkedPractice.getState());
+        address.setZipCode(linkedPractice.getZip());
+        address.setCounty(linkedPractice.getCounty());
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
@@ -35,7 +35,6 @@ import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.SearchResult;
 import gov.medicaid.entities.dto.FormError;
 import gov.medicaid.entities.dto.ViewStatics;
-import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.PortalServiceRuntimeException;
 import gov.medicaid.services.util.Util;
 
@@ -116,24 +115,20 @@ public class IndividualAgencyFormBinder extends BaseFormBinder {
      * @param agency the practice to attach to
      */
     private void attachLinkedGroup(AgencyInformationType agency) {
-        try {
-            PracticeSearchCriteria criteria = new PracticeSearchCriteria();
-            criteria.setProfileId(Long.parseLong(agency.getObjectId()));
-            criteria.setAgency(true);
+        PracticeSearchCriteria criteria = new PracticeSearchCriteria();
+        criteria.setProfileId(Long.parseLong(agency.getObjectId()));
+        criteria.setAgency(true);
 
-            SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(getSystemUser(), criteria);
-            PracticeLookup linkedPractice = results.getItems().get(0);
+        SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(getSystemUser(), criteria);
+        PracticeLookup linkedPractice = results.getItems().get(0);
 
-            agency.setName(linkedPractice.getName());
-            agency.setAgencyId(linkedPractice.getAgencyId());
-            agency.setNPI(linkedPractice.getNpi());
-            agency.setFaxNumber(linkedPractice.getFaxNumber());
-            agency.setContactName(linkedPractice.getContactName());
-            agency.setBackgroundStudyId(linkedPractice.getBgsId());
-            agency.setClearanceDate(BinderUtils.toCalendar(linkedPractice.getClearanceDate()));
-        } catch (PortalServiceException e) {
-            throw new PortalServiceRuntimeException("Cannot verify linked practice.", e);
-        }
+        agency.setName(linkedPractice.getName());
+        agency.setAgencyId(linkedPractice.getAgencyId());
+        agency.setNPI(linkedPractice.getNpi());
+        agency.setFaxNumber(linkedPractice.getFaxNumber());
+        agency.setContactName(linkedPractice.getContactName());
+        agency.setBackgroundStudyId(linkedPractice.getBgsId());
+        agency.setClearanceDate(BinderUtils.toCalendar(linkedPractice.getClearanceDate()));
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/OnboardingService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/OnboardingService.java
@@ -57,7 +57,6 @@ public interface OnboardingService {
      * @param link the external account link to verify credentials for
      * @param password the credentials
      * @return true if the credentials provided are valid
-     * @throws PortalServiceException for any errors encountered
      */
-    boolean verifyCredentials(ExternalAccountLink link, String password) throws PortalServiceException;
+    boolean verifyCredentials(ExternalAccountLink link, String password);
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/PartnerSystemService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PartnerSystemService.java
@@ -45,7 +45,6 @@ public interface PartnerSystemService {
      * @param referrer
      * @param profileNPI
      * @return true if the credentials are valid
-     * @throws PortalServiceException for any errors encountered
      */
-    boolean authenticate(String externalUserId, String password, String profileNPI, String referrer) throws PortalServiceException;
+    boolean authenticate(String externalUserId, String password, String profileNPI, String referrer);
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -414,11 +414,10 @@ public interface ProviderEnrollmentService {
      *
      * @param npi the npi to search for
      * @return the public lookup data
-     * @throws PortalServiceException for any errors encountered
      */
     List<ProviderLookup> lookupProvider(
             String npi
-    ) throws PortalServiceException;
+    );
 
     /**
      * Direct save (no logical checks) Used by business processes.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -537,12 +537,11 @@ public interface ProviderEnrollmentService {
      * @param profileNPI     the employee to be checked
      * @return true if there is an affiliation between the two arguments that
      * gives the first access to the latter
-     * @throws PortalServiceException for any errors encountered
      */
     boolean hasGroupAffiliation(
             String externalUserId,
             String profileNPI
-    ) throws PortalServiceException;
+    );
 
     /**
      * Returns true if there is a profile found in the database with the given

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -550,9 +550,8 @@ public interface ProviderEnrollmentService {
      *
      * @param profileNPI the NPI to be checked
      * @return true if a record matches
-     * @throws PortalServiceException for any errors encountered
      */
-    boolean existsProfile(String profileNPI) throws PortalServiceException;
+    boolean existsProfile(String profileNPI);
 
     /**
      * Callback from legacy system for setting the legacy ID.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -284,12 +284,11 @@ public interface ProviderEnrollmentService {
      * @param user     the user performing the search
      * @param criteria the criteria filter
      * @return the matching practice results
-     * @throws PortalServiceException for any errors encountered
      */
     SearchResult<PracticeLookup> searchPractice(
             CMSUser user,
             PracticeSearchCriteria criteria
-    ) throws PortalServiceException;
+    );
 
     /**
      * Creates a renewal ticket from the given profile id.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -405,9 +405,8 @@ public interface ProviderEnrollmentService {
      *
      * @param ticketId the ticket id
      * @return the notes for the ticket of for the referenced profile
-     * @throws PortalServiceException for any errors encountered
      */
-    List<Note> findNotes(long ticketId) throws PortalServiceException;
+    List<Note> findNotes(long ticketId);
 
     /**
      * Retrieves public data for enrolled providers by NPI.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -366,13 +366,12 @@ public interface ProviderEnrollmentService {
      * @param sourceSystem    the source of the imported profile
      * @param providerProfile the profile to be created
      * @return the internal profile id for the imported profile
-     * @throws PortalServiceException for any errors encountered
      */
     long importProfile(
             CMSUser user,
             SystemId sourceSystem,
             ProviderProfile providerProfile
-    ) throws PortalServiceException;
+    );
 
     /**
      * Retrieves the attachments with the given id.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -163,11 +163,10 @@ public interface ProviderEnrollmentService {
      * @throws IllegalArgumentException if any argument is null, or the page
      *                                  size and page number settings are
      *                                  invalid
-     * @throws PortalServiceException   for any errors encountered
      */
     SearchResult<Enrollment> searchEnrollments(
             EnrollmentSearchCriteria criteria
-    ) throws PortalServiceException;
+    );
 
     /**
      * This method gets all the enrollments that are draft status at end of

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -189,11 +189,10 @@ public interface ProviderEnrollmentService {
      *
      * @param user the user performing the action
      * @return the applicable providers
-     * @throws PortalServiceException for any errors encountered
      */
     List<ProfileHeader> findMyProfiles(
             CMSUser user
-    ) throws PortalServiceException;
+    );
 
     /**
      * Saves the given ticket as draft.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -178,11 +178,10 @@ public interface ProviderEnrollmentService {
      * @throws IllegalArgumentException if any argument is null, or the page
      *                                  size and page number settings are
      *                                  invalid
-     * @throws PortalServiceException   for any errors encountered
      */
     SearchResult<Enrollment> getDraftAtEomEnrollments(
             EnrollmentSearchCriteria criteria
-    ) throws PortalServiceException;
+    );
 
     /**
      * This method gets all the providers owned by the given user. If none

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -570,12 +570,11 @@ public interface ProviderEnrollmentService {
      * @param profileId the profile id of the provider
      * @param ticketId  the request ticket id
      * @return the related entity to the profile
-     * @throws PortalServiceException for any errors encountered
      */
     Entity findEntityByProviderKey(
             Long profileId,
             Long ticketId
-    ) throws PortalServiceException;
+    );
 
     /**
      * Retrieves the related attachments for the given profile key.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -439,7 +439,7 @@ public interface ProviderEnrollmentService {
     Long[] renewalProfiles(
             CMSUser currentUser,
             Set<Long> profileIds
-    ) throws PortalServiceException;
+    );
 
     /**
      * Gets the COS associated with a profile.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -148,12 +148,11 @@ public interface ProviderEnrollmentService {
      * @throws IllegalArgumentException if any argument is null, or the page
      *                                  size and page number settings are
      *                                  invalid
-     * @throws PortalServiceException   for any errors encountered
      */
     SearchResult<UserRequest> searchTickets(
             CMSUser user,
             ProviderSearchCriteria criteria
-    ) throws PortalServiceException;
+    );
 
     /**
      * This method gets all the enrollments that meet the search criteria. If none


### PR DESCRIPTION
As I was starting to look at #125, I noticed that there were a number of problems with the `ProviderEnrollmentService` interface and its implementation, `ProviderEnrollmentServiceBean`. I wanted to clean it up before digging deeper, in the hope that having a cleaner file with fewer warnings would be easier 

The class of problem that leads to the biggest changes is unnecessarily declared checked exception declarations. When a method declares that it throws a checked exception, callers must either handle the checked exception or declare that they might throw it, as well. This ripple is one of the reasons why checked exceptions have fallen out of favor; here and now, in our case, there is no upside and considerable downside to declaring a checked exception and then never throwing it.

I've split removing these unnecessary declarations into one commit per method, so that the changes to the calling methods are more clearly tied together. The two main follow-on changes are removing further `throws` statements from callers, or removing `try-catch` blocks.

Most of these problems I found with IntelliJ's inspection tool; some were also from SpotBugs.

I tested this by building it; if any of these changes were incorrect (such as throwing a checked exception from a method that does not declare it in its `throws` clause), that should be caught at compile time.

Issue #915 Use static analysis to find bugs