### PR TITLE
Put participation information in one place

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,36 @@
-# PSM Contribution Guidelines
+# PSM Participation and Contribution Guidelines
 
-This document contains information of use to developers looking to
-improve the PSM's codebase.  See [README.md](README.md) for an
-introduction to this project, and if you're thinking of contributing
-you might also want to look at [DESIGN.md](DESIGN.md). All discussions
-about PSM work fall under our [code of
-conduct](docs/CODE_OF_CONDUCT.md).
+This document explains how to engage with the PSM development team,
+either just to discuss something or to contribute to development
+yourself.  See [README.md](README.md) for an introduction to this
+project, and if you're thinking of contributing you might also want to
+look at [DESIGN.md](DESIGN.md). All discussions about PSM work fall
+under our [code of conduct](docs/CODE_OF_CONDUCT.md).
+
+## Communicating with the PSM Project
+
+We welcome questions, suggestions, and code contributions.  You can:
+
+* Post in the `psm-dev` discussion group at
+  https://groups.google.com/forum/#!forum/psm-dev.  The forum archives
+  are public, and anyone can post.  The posting guidelines are fairly
+  loose -- as long as your question is about the PSM, it's on-topic.
+
+* File a new issue ticket at https://github.com/SolutionGuidance/psm/issues.
+
+* Submit a [pull
+  request](https://help.github.com/articles/about-pull-requests/) to
+  the [repository](https://github.com/SolutionGuidance/psm/).
+  (Guidelines for code contributions are given later in this document.)
+
+* Chat with us in real time in our [Zulip chat
+  room](https://chat.opentechstrategies.com/#narrow/stream/Provider.20Screening).
+  You'll need to set up an account (which is free) to join the
+  conversation.
+
+Note that submitting issues or pull requests requires a
+[GitHub](https://github.com/) account, which anyone can create (there
+is no charge).
 
 ## Submitting and Reviewing Code
 

--- a/README.md
+++ b/README.md
@@ -168,36 +168,5 @@ See also the section "Participating in the PSM Project" below.
 SECTION 5: Participating in the PSM Project
 ---------------------------------------------------------------------
 
-We welcome questions and contributions.  You can:
-
-* Post in the `psm-dev` discussion group at
-  https://groups.google.com/forum/#!forum/psm-dev.  The forum archives
-  are public, and anyone can post.  The posting guidelines are fairly
-  loose -- as long as your question is about the PSM, it's on-topic.
-
-* File a new issue ticket at https://github.com/SolutionGuidance/psm/issues.
-
-* Submit a [pull
-  request](https://help.github.com/articles/about-pull-requests/) to
-  the [repository](https://github.com/SolutionGuidance/psm/). Here's
-  [our guide for code contributors](CONTRIBUTING.md).
-
-* Chat with us in real time in our [Zulip chat
-  room](https://chat.opentechstrategies.com/#narrow/stream/Provider.20Screening).
-  You'll need to set up an account (which is free) to join the
-  conversation.
-
-* We hold team meetings by conference call sometimes.  The agendas and
-  notes from these meetings can be found in
-  [team-notes/meetings/](team-notes/meetings/).  The current core
-  developers are all based in the U.S., and these meetings are
-  arranged around U.S. time zones.  Eventually, when the PSM project
-  has regular participants beyond the current core team, we may change
-  how we schedule real-time meetings.  For now, however, we schedule
-  meetings on an _ad hoc_ basis and just put the agendas and notes
-  here, so that they are visible along with all the other project
-  resources.
-
-Note that submitting issues or pull requests requires a
-[GitHub](https://github.com/) account, which anyone can create (there
-is no charge).
+Please see [CONTRIBUTING.md](CONTRIBUTING.md), in particular the
+section "Communicating with the PSM Project" at the top.


### PR DESCRIPTION
Move the section on participation from README.md to CONTRIBUTING.md,
so that all information about how to engage with the project is in one
place.  The proximate motivation for this change is that the CAV ETL
project is about to refer to this documentation, but it's a desirable
change in its own right anyway.

Note that in doing the move, I deliberately dropped an obsolete blurb
about team meeting notes.