### PR TITLE
 Decode basic auth strings as UTF-8

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/BasicSecurityInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/BasicSecurityInterceptor.java
@@ -72,24 +72,21 @@ public class BasicSecurityInterceptor extends InterceptorAdapter {
 
     @VisibleForTesting
     String getUsernameFromBasicAuthHeader(String authHeader) throws AuthenticationException {
-        if (authHeader == null || authHeader.startsWith("Basic ") == false) {
-            throw generateAuthenticationException("Invalid or missing authorization header");
-        }
-        String base64 = authHeader.substring("Basic ".length());
-        String base64decoded = new String(Base64.decodeBase64(base64));
-        String[] parts = base64decoded.split(":", 2);
-        return parts[0];
+        return decodeBasicAuthHeader(authHeader)[0];
     }
 
     @VisibleForTesting
     String getPasswordFromBasicAuthHeader(String authHeader) throws AuthenticationException {
+        return decodeBasicAuthHeader(authHeader)[1];
+    }
+
+    private String[] decodeBasicAuthHeader(String authHeader) throws AuthenticationException {
         if (authHeader == null || authHeader.startsWith("Basic ") == false) {
             throw generateAuthenticationException("Invalid or missing authorization header");
         }
         String base64 = authHeader.substring("Basic ".length());
         String base64decoded = new String(Base64.decodeBase64(base64));
-        String[] parts = base64decoded.split(":", 2);
-        return parts[1];
+        return base64decoded.split(":", 2);
     }
 
     private AuthenticationException generateAuthenticationException(String message) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/BasicSecurityInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/BasicSecurityInterceptor.java
@@ -3,6 +3,7 @@ package gov.medicaid.api.interceptors;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import ca.uhn.fhir.rest.server.interceptor.InterceptorAdapter;
+import com.google.common.annotations.VisibleForTesting;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.services.RegistrationService;
 import org.apache.commons.codec.binary.Base64;
@@ -69,7 +70,8 @@ public class BasicSecurityInterceptor extends InterceptorAdapter {
         return true;
     }
 
-    private String getUsernameFromBasicAuthHeader(String authHeader) throws AuthenticationException {
+    @VisibleForTesting
+    String getUsernameFromBasicAuthHeader(String authHeader) throws AuthenticationException {
         if (authHeader == null || authHeader.startsWith("Basic ") == false) {
             throw generateAuthenticationException("Invalid or missing authorization header");
         }
@@ -79,7 +81,8 @@ public class BasicSecurityInterceptor extends InterceptorAdapter {
         return parts[0];
     }
 
-    private String getPasswordFromBasicAuthHeader(String authHeader) throws AuthenticationException {
+    @VisibleForTesting
+    String getPasswordFromBasicAuthHeader(String authHeader) throws AuthenticationException {
         if (authHeader == null || authHeader.startsWith("Basic ") == false) {
             throw generateAuthenticationException("Invalid or missing authorization header");
         }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/interceptors/BasicSecurityInterceptorTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/interceptors/BasicSecurityInterceptorTest.groovy
@@ -5,6 +5,8 @@ import org.apache.commons.codec.binary.Base64
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.nio.charset.Charset
+
 class BasicSecurityInterceptorTest extends Specification {
     BasicSecurityInterceptor interceptor
 
@@ -64,6 +66,7 @@ class BasicSecurityInterceptorTest extends Specification {
         "username" | "password"
         "username" | "pass:word"
         "username" | "pass::word"
+        "✓"        | "✓"
     }
 
     private static String createBasicAuthHeader(
@@ -71,7 +74,9 @@ class BasicSecurityInterceptorTest extends Specification {
         String password
     ) {
         return "Basic " + Base64.encodeBase64String(
-            String.format("%s:%s", username, password).getBytes()
+            String.format("%s:%s", username, password).getBytes(
+                Charset.forName("UTF-8")
+            )
         )
     }
 }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/interceptors/BasicSecurityInterceptorTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/interceptors/BasicSecurityInterceptorTest.groovy
@@ -1,0 +1,77 @@
+package gov.medicaid.api.interceptors
+
+import ca.uhn.fhir.rest.server.exceptions.AuthenticationException
+import org.apache.commons.codec.binary.Base64
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BasicSecurityInterceptorTest extends Specification {
+    BasicSecurityInterceptor interceptor
+
+    def setup() {
+        interceptor = new BasicSecurityInterceptor(null)
+    }
+
+    @Unroll
+    def "username lookup throws on #bad header"(String bad, String header) {
+        when:
+        interceptor.getUsernameFromBasicAuthHeader(header)
+
+        then:
+        thrown(AuthenticationException)
+
+        where:
+        bad         | header
+        "null"      | null
+        "empty"     | ""
+        "non-basic" | "Advanced"
+    }
+
+    @Unroll
+    def "password lookup throws on #bad header"(String bad, String header) {
+        when:
+        interceptor.getPasswordFromBasicAuthHeader(header)
+
+        then:
+        thrown(AuthenticationException)
+
+        where:
+        bad         | header
+        "null"      | null
+        "empty"     | ""
+        "non-basic" | "Advanced"
+    }
+
+    @Unroll
+    def "valid header for (#username, #password) correctly decodes"(
+        String username,
+        String password
+    ) {
+        when:
+        def decodedUsername = interceptor.getUsernameFromBasicAuthHeader(
+            createBasicAuthHeader(username, password)
+        )
+        def decodedPassword = interceptor.getPasswordFromBasicAuthHeader(
+            createBasicAuthHeader(username, password)
+        )
+
+        then:
+        decodedUsername == username
+        decodedPassword == password
+
+        where:
+        username   | password
+        "username" | "password"
+        "username" | "pass:word"
+        "username" | "pass::word"
+    }
+
+    private static String createBasicAuthHeader(
+        String username,
+        String password
+    ) {
+        return "Basic " + Base64.encodeBase64String(
+            String.format("%s:%s", username, password).getBytes()
+        )
+    }
+}


### PR DESCRIPTION
SpotBugs noted that when we decoded the HTTP basic authentication header, we were doing so with the default encoding:

> [Reliance on default encoding](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#dm-reliance-on-default-encoding-dm-default-encoding)
> 
> Found a call to a method which will perform a `byte` to `String` (or `String` to `byte`) conversion, and will assume that the default platform encoding is suitable. This will cause the application behaviour to vary between platforms. Use an alternative API and specify a charset name or Charset object explicitly.

According to RFC 7617, the client must encode in a character set that is
either compatible with ASCII (as UTF-8 is), or in UTF-8. (Per [this StackOverflow answer](https://stackoverflow.com/a/7243567/25637).)

Specify in our challenge header that we accept UTF-8, and decode the username and password as UTF-8 strings.

Add unit tests along the way, and do some refactoring in support of making this change.

I tested this by running the new unit tests, as well as by deploying and logging in through the API.

Issue #915 Use static analysis to find bugs