### PR TITLE
Ignore JAXB-generated code in SpotBugs

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -106,6 +106,10 @@ allprojects {
             testCompile 'org.codehaus.groovy:groovy-all:2.4.13'
             testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
         }
+
+        spotbugs {
+           excludeFilter = file("$projectDir/spotbugs-exclude.xml")
+        }
     }
 }
 

--- a/psm-app/cms-business-model/spotbugs-exclude.xml
+++ b/psm-app/cms-business-model/spotbugs-exclude.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+  https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+</FindBugsFilter>

--- a/psm-app/cms-business-model/spotbugs-exclude.xml
+++ b/psm-app/cms-business-model/spotbugs-exclude.xml
@@ -4,4 +4,8 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
   https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+  <Match>
+    <!-- JAXB-generated code -->
+    <Package name="gov.medicaid.domain.model"/>
+  </Match>
 </FindBugsFilter>

--- a/psm-app/cms-business-process/spotbugs-exclude.xml
+++ b/psm-app/cms-business-process/spotbugs-exclude.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+  https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+</FindBugsFilter>

--- a/psm-app/cms-portal-services/spotbugs-exclude.xml
+++ b/psm-app/cms-portal-services/spotbugs-exclude.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+  https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+</FindBugsFilter>

--- a/psm-app/cms-web/spotbugs-exclude.xml
+++ b/psm-app/cms-web/spotbugs-exclude.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+  https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+</FindBugsFilter>

--- a/psm-app/services/spotbugs-exclude.xml
+++ b/psm-app/services/spotbugs-exclude.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+  https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+</FindBugsFilter>


### PR DESCRIPTION
SpotBugs had a lot to say about the code generated by JAXB, but given #596 and the fact that that code is generated, I think we can safely ignore what it has to say on that subject.

Create empty exclusion filter files in each subproject, and then tell SpotBugs to ignore the JAXB-generated Java code by its package. There are no non-generated classes in that package, so it should be safe to ignore it.

Issue #915 Use static analysis to find bugs