### PR TITLE
Fix public mutable list

### DIFF
--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
@@ -1,5 +1,6 @@
 package gov.medicaid.controllers.admin.report;
 
+import com.google.common.collect.ImmutableList;
 import gov.medicaid.controllers.admin.report.ReportControllerUtils.EnrollmentMonth;
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.EnrollmentSearchCriteria;
@@ -23,7 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,11 +34,11 @@ import java.util.stream.Collectors;
 public class RiskLevelsReportController extends gov.medicaid.controllers.BaseController {
     private ProviderEnrollmentService enrollmentService;
 
-    public static final List<String> RISK_LEVELS = Arrays.asList(new String[] {
+    private static final List<String> RISK_LEVELS = ImmutableList.of(
         ViewStatics.LOW_RISK,
         ViewStatics.MODERATE_RISK,
         ViewStatics.HIGH_RISK
-    });
+    );
 
     public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
         this.enrollmentService = enrollmentService;


### PR DESCRIPTION
SpotBugs reported:

> [Field is a mutable collection which should be package protected](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#ms-field-is-a-mutable-collection-which-should-be-package-protected-ms-mutable-collection-pkgprotect)
> 
> A mutable collection instance is assigned to a `final static` field, thus can be changed by malicious code or by accident from another package. The field could be made package protected to avoid this vulnerability. Alternatively you may wrap this field into `Collections.unmodifiableSet`/`List`/`Map`/etc. to avoid this vulnerability.

Since the field is never referenced outside the class, we can change its visibility to `private`; since the list is never modified, we can use Guava's immutable list to construct it. Do both to resolve this warning.

Issue #915 Use static analysis to find bugs