### PR TITLE
Use Spring to find and initialize report controllers

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -169,9 +169,8 @@
         class="gov.medicaid.controllers.admin.ReportController">
   </bean>
 
-  <bean id="ApplicationsByReviewerReportController" class="gov.medicaid.controllers.admin.report.ApplicationsByReviewerReportController">
-    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-  </bean>
+  <bean id="ApplicationsByReviewerReportController"
+        class="gov.medicaid.controllers.admin.report.ApplicationsByReviewerReportController"/>
 
   <bean id="DraftApplicationsReportController" class="gov.medicaid.controllers.admin.report.DraftApplicationsReportController">
     <property name="enrollmentService" ref="ProviderEnrollmentService"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -172,9 +172,8 @@
   <bean id="ApplicationsByReviewerReportController"
         class="gov.medicaid.controllers.admin.report.ApplicationsByReviewerReportController"/>
 
-  <bean id="DraftApplicationsReportController" class="gov.medicaid.controllers.admin.report.DraftApplicationsReportController">
-    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-  </bean>
+  <bean id="DraftApplicationsReportController"
+        class="gov.medicaid.controllers.admin.report.DraftApplicationsReportController"/>
 
   <bean id="TimeToReviewReportController" class="gov.medicaid.controllers.admin.report.TimeToReviewReportController">
     <property name="enrollmentService" ref="ProviderEnrollmentService"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -184,9 +184,8 @@
   <bean id="ReviewedDocumentsReportController"
         class="gov.medicaid.controllers.admin.report.ReviewedDocumentsReportController"/>
 
-  <bean id="RiskLevelsReportController" class="gov.medicaid.controllers.admin.report.RiskLevelsReportController">
-    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-  </bean>
+  <bean id="RiskLevelsReportController"
+        class="gov.medicaid.controllers.admin.report.RiskLevelsReportController"/>
 
   <bean id="RegistrationFormValidator" class="gov.medicaid.controllers.validators.RegistrationFormValidator">
     <property name="registrationService" ref="RegistrationService"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -169,23 +169,8 @@
         class="gov.medicaid.controllers.admin.ReportController">
   </bean>
 
-  <bean id="ApplicationsByReviewerReportController"
-        class="gov.medicaid.controllers.admin.report.ApplicationsByReviewerReportController"/>
-
-  <bean id="DraftApplicationsReportController"
-        class="gov.medicaid.controllers.admin.report.DraftApplicationsReportController"/>
-
-  <bean id="TimeToReviewReportController"
-        class="gov.medicaid.controllers.admin.report.TimeToReviewReportController"/>
-
-  <bean id="ProviderTypesReportController"
-        class="gov.medicaid.controllers.admin.report.ProviderTypesReportController"/>
-
-  <bean id="ReviewedDocumentsReportController"
-        class="gov.medicaid.controllers.admin.report.ReviewedDocumentsReportController"/>
-
-  <bean id="RiskLevelsReportController"
-        class="gov.medicaid.controllers.admin.report.RiskLevelsReportController"/>
+  <context:component-scan
+      base-package="gov.medicaid.controllers.admin.report" />
 
   <bean id="RegistrationFormValidator" class="gov.medicaid.controllers.validators.RegistrationFormValidator">
     <property name="registrationService" ref="RegistrationService"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -175,9 +175,8 @@
   <bean id="DraftApplicationsReportController"
         class="gov.medicaid.controllers.admin.report.DraftApplicationsReportController"/>
 
-  <bean id="TimeToReviewReportController" class="gov.medicaid.controllers.admin.report.TimeToReviewReportController">
-    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-  </bean>
+  <bean id="TimeToReviewReportController"
+        class="gov.medicaid.controllers.admin.report.TimeToReviewReportController"/>
 
   <bean id="ProviderTypesReportController" class="gov.medicaid.controllers.admin.report.ProviderTypesReportController">
     <property name="enrollmentService" ref="ProviderEnrollmentService"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -178,10 +178,8 @@
   <bean id="TimeToReviewReportController"
         class="gov.medicaid.controllers.admin.report.TimeToReviewReportController"/>
 
-  <bean id="ProviderTypesReportController" class="gov.medicaid.controllers.admin.report.ProviderTypesReportController">
-    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-    <property name="providerTypeService" ref="ProviderTypeService"/>
-  </bean>
+  <bean id="ProviderTypesReportController"
+        class="gov.medicaid.controllers.admin.report.ProviderTypesReportController"/>
 
   <bean id="ReviewedDocumentsReportController" class="gov.medicaid.controllers.admin.report.ReviewedDocumentsReportController">
     <property name="enrollmentService" ref="ProviderEnrollmentService"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -181,9 +181,8 @@
   <bean id="ProviderTypesReportController"
         class="gov.medicaid.controllers.admin.report.ProviderTypesReportController"/>
 
-  <bean id="ReviewedDocumentsReportController" class="gov.medicaid.controllers.admin.report.ReviewedDocumentsReportController">
-    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-  </bean>
+  <bean id="ReviewedDocumentsReportController"
+        class="gov.medicaid.controllers.admin.report.ReviewedDocumentsReportController"/>
 
   <bean id="RiskLevelsReportController" class="gov.medicaid.controllers.admin.report.RiskLevelsReportController">
     <property name="enrollmentService" ref="ProviderEnrollmentService"/>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
@@ -2,7 +2,6 @@ package gov.medicaid.controllers.admin.report;
 
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.EnrollmentSearchCriteria;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
@@ -25,18 +23,10 @@ import java.util.List;
 
 @Controller
 public class ApplicationsByReviewerReportController extends gov.medicaid.controllers.BaseController {
-    private ProviderEnrollmentService enrollmentService;
+    private final ProviderEnrollmentService enrollmentService;
 
-    public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
+    public ApplicationsByReviewerReportController(ProviderEnrollmentService enrollmentService) {
         this.enrollmentService = enrollmentService;
-    }
-
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (enrollmentService == null) {
-            throw new PortalServiceConfigurationException("enrollmentService is not configured correctly.");
-        }
     }
 
     @RequestMapping(value = "/admin/reports/applications-by-reviewer", method = RequestMethod.GET)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/DraftApplicationsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/DraftApplicationsReportController.java
@@ -4,7 +4,6 @@ import gov.medicaid.controllers.admin.report.ReportControllerUtils.EnrollmentMon
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.EnrollmentSearchCriteria;
 import gov.medicaid.entities.SearchResult;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
@@ -23,18 +21,10 @@ import java.util.List;
 
 @Controller
 public class DraftApplicationsReportController extends gov.medicaid.controllers.BaseController {
-    private ProviderEnrollmentService enrollmentService;
+    private final ProviderEnrollmentService enrollmentService;
 
-    public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
+    public DraftApplicationsReportController(ProviderEnrollmentService enrollmentService) {
         this.enrollmentService = enrollmentService;
-    }
-
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (enrollmentService == null) {
-            throw new PortalServiceConfigurationException("enrollmentService is not configured correctly.");
-        }
     }
 
     @RequestMapping(value = "/admin/reports/draft-applications", method = RequestMethod.GET)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
@@ -5,7 +5,6 @@ import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.EnrollmentSearchCriteria;
 import gov.medicaid.entities.ProviderType;
 import gov.medicaid.entities.ProviderTypeSearchCriteria;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 import gov.medicaid.services.ProviderTypeService;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
@@ -31,26 +29,15 @@ import java.util.stream.Collectors;
 
 @Controller
 public class ProviderTypesReportController extends gov.medicaid.controllers.BaseController {
-    private ProviderEnrollmentService enrollmentService;
-    private ProviderTypeService providerTypeService;
+    private final ProviderEnrollmentService enrollmentService;
+    private final ProviderTypeService providerTypeService;
 
-    public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
+    public ProviderTypesReportController(
+        ProviderEnrollmentService enrollmentService,
+        ProviderTypeService providerTypeService
+    ) {
         this.enrollmentService = enrollmentService;
-    }
-
-    public void setProviderTypeService(ProviderTypeService providerTypeService) {
         this.providerTypeService = providerTypeService;
-    }
-
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (enrollmentService == null) {
-            throw new PortalServiceConfigurationException("enrollmentService is not configured correctly.");
-        }
-        if (providerTypeService == null) {
-            throw new PortalServiceConfigurationException("providerTypeService is not configured correctly.");
-        }
     }
 
     @RequestMapping(value = "/admin/reports/provider-types", method = RequestMethod.GET)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportController.java
@@ -3,7 +3,6 @@ package gov.medicaid.controllers.admin.report;
 import gov.medicaid.controllers.admin.report.ReportControllerUtils.EnrollmentMonth;
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.EnrollmentSearchCriteria;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
@@ -24,18 +22,10 @@ import java.util.stream.Collectors;
 
 @Controller
 public class ReviewedDocumentsReportController extends gov.medicaid.controllers.BaseController {
-    private ProviderEnrollmentService enrollmentService;
+    private final ProviderEnrollmentService enrollmentService;
 
-    public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
+    public ReviewedDocumentsReportController(ProviderEnrollmentService enrollmentService) {
         this.enrollmentService = enrollmentService;
-    }
-
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (enrollmentService == null) {
-            throw new PortalServiceConfigurationException("enrollmentService is not configured correctly.");
-        }
     }
 
     @RequestMapping(value = "/admin/reports/reviewed-documents", method = RequestMethod.GET)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
@@ -7,7 +7,6 @@ import gov.medicaid.entities.EnrollmentSearchCriteria;
 import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.RiskLevel;
 import gov.medicaid.entities.dto.ViewStatics;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
@@ -32,24 +30,16 @@ import java.util.stream.Collectors;
 
 @Controller
 public class RiskLevelsReportController extends gov.medicaid.controllers.BaseController {
-    private ProviderEnrollmentService enrollmentService;
-
     private static final List<String> RISK_LEVELS = ImmutableList.of(
         ViewStatics.LOW_RISK,
         ViewStatics.MODERATE_RISK,
         ViewStatics.HIGH_RISK
     );
 
-    public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
-        this.enrollmentService = enrollmentService;
-    }
+    private final ProviderEnrollmentService enrollmentService;
 
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (enrollmentService == null) {
-            throw new PortalServiceConfigurationException("enrollmentService is not configured correctly.");
-        }
+    public RiskLevelsReportController(ProviderEnrollmentService enrollmentService) {
+        this.enrollmentService = enrollmentService;
     }
 
     @RequestMapping(value = "/admin/reports/risk-levels", method = RequestMethod.GET)

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/TimeToReviewReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/TimeToReviewReportController.java
@@ -4,7 +4,6 @@ import gov.medicaid.controllers.admin.report.ReportControllerUtils.EnrollmentMon
 import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.EnrollmentSearchCriteria;
 import gov.medicaid.entities.SearchResult;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
@@ -26,18 +24,10 @@ import java.util.stream.Collectors;
 
 @Controller
 public class TimeToReviewReportController extends gov.medicaid.controllers.BaseController {
-    private ProviderEnrollmentService enrollmentService;
+    private final ProviderEnrollmentService enrollmentService;
 
-    public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
+    public TimeToReviewReportController(ProviderEnrollmentService enrollmentService) {
         this.enrollmentService = enrollmentService;
-    }
-
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (enrollmentService == null) {
-            throw new PortalServiceConfigurationException("enrollmentService is not configured correctly.");
-        }
     }
 
     @RequestMapping(value = "/admin/reports/time-to-review", method = RequestMethod.GET)

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
@@ -54,10 +54,8 @@ class ApplicationsByReviewerReportControllerTest extends Specification {
     }
 
     void setup() {
-        controller = new ApplicationsByReviewerReportController()
         service = Mock(ProviderEnrollmentService)
-
-        controller.setEnrollmentService(service)
+        controller = new ApplicationsByReviewerReportController(service)
 
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/DraftApplicationsReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/DraftApplicationsReportControllerTest.groovy
@@ -28,10 +28,8 @@ class DraftApplicationsReportControllerTest extends Specification {
     }
 
     void setup() {
-        controller = new DraftApplicationsReportController()
         service = Mock(ProviderEnrollmentService)
-
-        controller.setEnrollmentService(service)
+        controller = new DraftApplicationsReportController(service)
 
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ProviderTypesReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ProviderTypesReportControllerTest.groovy
@@ -27,9 +27,9 @@ class ProviderTypesReportControllerTest extends Specification {
     }
 
     void setup() {
-        controller = new ProviderTypesReportController()
         enrollmentService = Mock(ProviderEnrollmentService)
         providerTypeService = Mock(ProviderTypeService)
+        controller = new ProviderTypesReportController(enrollmentService, providerTypeService)
 
         providerTypeService.search(_) >>
                 new SearchResult<ProviderType>(
@@ -42,9 +42,6 @@ class ProviderTypesReportControllerTest extends Specification {
                     ]
                 ]
                 )
-
-        controller.setEnrollmentService(enrollmentService)
-        controller.setProviderTypeService(providerTypeService)
     }
 
     private toDate(d) {

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportControllerTest.groovy
@@ -23,9 +23,8 @@ class ReviewedDocumentsReportControllerTest extends Specification {
     }
 
     void setup() {
-        controller = new ReviewedDocumentsReportController()
         enrollmentService = Mock(ProviderEnrollmentService)
-        controller.setEnrollmentService(enrollmentService)
+        controller = new ReviewedDocumentsReportController(enrollmentService)
     }
 
     private toDate(d) {

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/RiskLevelsReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/RiskLevelsReportControllerTest.groovy
@@ -26,9 +26,8 @@ class RiskLevelsReportControllerTest extends Specification {
     }
 
     void setup() {
-        controller = new RiskLevelsReportController()
         enrollmentService = Mock(ProviderEnrollmentService)
-        controller.setEnrollmentService(enrollmentService)
+        controller = new RiskLevelsReportController(enrollmentService)
     }
 
     private toDate(d) {

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/TimeToReviewReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/TimeToReviewReportControllerTest.groovy
@@ -29,10 +29,8 @@ class TimeToReviewReportControllerTest extends Specification {
     }
 
     void setup() {
-        controller = new TimeToReviewReportController()
         service = Mock(ProviderEnrollmentService)
-
-        controller.setEnrollmentService(service)
+        controller = new TimeToReviewReportController(service)
 
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     }


### PR DESCRIPTION
When a project is set up to support it, Spring is able to automatically discover new controllers (and other components) by looking for the proper annotation. This makes configuration much simpler, and makes it easier to, for example, add new controllers.

Spring is also able to automatically determine a component's dependencies if they are declared as constructor arguments. In addition to simplifying configuration, this allows us to reduce Java boilerplate code by removing getters and setters.

The report controllers all are already annotated with `@Controller`. They are also all in a single, small package, and there are no packages below that package. These two factors make the report controllers the ideal first step in moving towards a more modern Spring configuration.

Update the report controllers to use constructor-argument dependency injection, and then tell Spring to look for the annotation rather than explicitly configure each controller in XML.

I tested this by building and deploying, and then logging in as an admin and viewing each of the reports to confirm that they continue to work.