### PR TITLE
454 fix license renewal end date for pca

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
@@ -455,7 +455,9 @@ public class PresentationServiceBean extends BaseService implements Presentation
                 viewModel.addTabModel(ViewStatics.INDIVIDUAL_PCA_INFORMATION, page);
 
                 page = new UITabModel();
-                page.addForm(ViewStatics.LICENSE_INFO_FORM, new FormSettings());
+                FormSettings licenseInfoFormSettings = new FormSettings();
+                licenseInfoFormSettings.addSetting("requireRenewalDate", false);
+                page.addForm(ViewStatics.LICENSE_INFO_FORM, licenseInfoFormSettings);
                 viewModel.addTabModel(ViewStatics.TRAINING_INFORMATION, page);
 
                 page = new UITabModel();

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
@@ -7,6 +7,7 @@
 
 <c:set var="hideRenewalDate" value="${viewModel.tabModels['Personal Information'].formSettings['Personal Information Form'].settings['hideRenewalDate']}"></c:set>
 <c:set var="hideLicenseNumber" value="${viewModel.tabModels['Personal Information'].formSettings['Personal Information Form'].settings['hideLicenseNumber']}"></c:set>
+<c:set var="requireRenewalDate" value="${viewModel.tabModels['Training Information'].formSettings['License Information Form'].settings['requireRenewalDate']}"></c:set>
 
 <div class="tableData" id="tableLicense">
     <input type="hidden" name="formNames" value="<%= ViewStatics.LICENSE_INFO_FORM %>">
@@ -32,7 +33,14 @@
                         <th width="0"> </th>
                         </c:when>
                         <c:otherwise>
-                            <th>Renewal End Date<span class="required">*</span><span class="sep"></span></th>
+                            <c:choose>
+                                <c:when test="${requireRenewalDate == false}">
+                                    <th>Renewal End Date<span class="sep"></span></th>
+                                </c:when>
+                                <c:otherwise>
+                                    <th>Renewal End Date<span class="required">*</span><span class="sep"></span></th>
+                                </c:otherwise>
+                            </c:choose>
                         </c:otherwise>
                 </c:choose>
                 <th>Issuing State<span class="required">*</span><span class="sep"></span></th>
@@ -48,15 +56,12 @@
                     <td>
                         <c:set var="formName" value="_03_licenseType_${status.index - 1}"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <select title="Type of License (License ${status.index})" onchange="doIndividualLicenseSelect(this);" class="bigSelect" name="${formName}">
+                        <select title="Type of License (License ${status.index})" class="bigSelect" name="${formName}">
                             <option value="">Please select</option>
                             <c:forEach var="opt" items="${requestScope['_03_licenseTypes']}">
                                 <option ${formValue eq opt.description ? 'selected' : ''} value="${opt.description}"><c:out value="${opt.description}" /></option>
                             </c:forEach>
                         </select>
-                        <c:if test="${formValue eq 'PCA Training Certificate'}">
-                            <c:set var="disableRenewalDate" value="${true}"></c:set>
-                        </c:if>
                     </td>
                     <td>
                         <c:set var="formName" value="_03_attachment_${status.index - 1}" />
@@ -96,7 +101,7 @@
                                 <span class="dateWrapper">
                                     <c:set var="formName" value="_03_renewalDate_${status.index - 1}"></c:set>
                                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                                    <input type="text" title="Renewal End Date (License ${status.index})" class="date ${disableRenewalDate ? 'disabled' : ''}" ${disableRenewalDate ? 'disabled="disabled"' : ''} name="${formName}" value="${formValue}"/>
+                                    <input type="text" title="Renewal End Date (License ${status.index})" class="date" name="${formName}" value="${formValue}"/>
                                 </span>
                             </td>
                          </c:otherwise>
@@ -134,7 +139,7 @@
                 <td>
                     <c:set var="formName" value="_03_licenseType"></c:set>
                     <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                    <select title="Type of License" onchange="doIndividualLicenseSelect(this);" class="bigSelect" name="${formName}">
+                    <select title="Type of License" class="bigSelect" name="${formName}">
                         <option value="">Please select</option>
                         <c:forEach var="opt" items="${requestScope['_03_licenseTypes']}">
                             <option value="${opt.description}"><c:out value="${opt.description}" /></option>

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -2585,19 +2585,6 @@ function updateBeneficialOwnerTypes(val) {
 
 }
 
-function doIndividualLicenseSelect(el) {
-  var parentRow = $(el).closest('tr');
-  var licenseTypeFieldName = $(el).attr("name");
-  var renewalEndDateFieldName = licenseTypeFieldName.replace("licenseType", "renewalDate");
-
-  var renewalEndDate = $(parentRow).find('input[name="' + renewalEndDateFieldName + '"]').first();
-  if ($(el).val() == 'PCA Training Certificate') {
-    $(renewalEndDate).addClass('disabled').attr('disabled', 'disabled');
-  } else {
-    $(renewalEndDate).removeClass('disabled').removeAttr('disabled');
-  }
-}
-
 function doInServiceSelect(el) {
   var code = $(el).val();
   $(el).closest('.assuredServicePanel').find('.ext-services').addClass('hide');

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
@@ -23,6 +23,16 @@ public class DataCoverageStepDefinitions {
         enrollmentSteps.enterLicenseInfo();
     }
 
+    @When("^I enter valid personal care assistant license information with a renewal date$")
+    public void enter_valid_personal_care_assistant_license_information_with_renewal_date() {
+        enrollmentSteps.enterPersonCareAssistantLicenseInfoWithRenewalDate();
+    }
+
+    @When("^I enter valid personal care assistant license information without a renewal date$")
+    public void enter_valid_personal_care_assistant_license_information_without_renewal_date() {
+        enrollmentSteps.enterPersonCareAssistantLicenseInfoWithoutRenewalDate();
+    }
+
     @When("^I enter license info where renewal date is before issue date$")
     public void enter_license_info_where_renewal_date_is_before_issue_date() {
         enrollmentSteps.enterLicenseInfoWithRenewalDateBeforeIssueDate();
@@ -66,6 +76,12 @@ public class DataCoverageStepDefinitions {
     @Then("^the license is accepted$")
     public void license_is_accepted() {
         enrollmentSteps.advanceFromIndividualLicenseInfoToPracticeInfo();
+    }
+
+    @Then("^the personal care assistant license is accepted$")
+    public void personal_care_assistant_license_is_accepted() {
+        enrollmentSteps.
+                advanceFromPersonalCareAssistantLicenseInfoToPracticeInfo();
     }
 
     @Then("^the practice information is accepted$")

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -8,6 +8,7 @@ import gov.medicaid.features.enrollment.ui.LicenseInfoPage;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
 import gov.medicaid.features.enrollment.ui.OrganizationSummaryPage;
 import gov.medicaid.features.enrollment.ui.OwnershipInfoPage;
+import gov.medicaid.features.enrollment.ui.PersonalCareAssistantPersonalInfoPage;
 import gov.medicaid.features.enrollment.ui.PersonalInfoPage;
 import gov.medicaid.features.enrollment.ui.PracticeInfoPage;
 import gov.medicaid.features.enrollment.ui.ProviderStatementPage;
@@ -62,12 +63,22 @@ public class EnrollmentSteps {
     private static final String PRACTICE_STATE_TAX_ID = "1234567";
     private static final String PRACTICE_YEAR_END = "12/31";
 
+    private static final String RESIDENTIAL_ADDRESS =
+            "456 N. Main Street";
+    private static final String RESIDENTIAL_CITY = "Duluth";
+    private static final String RESIDENTIAL_STATE_FULL = "Minnesota";
+    private static final String RESIDENTIAL_ZIP = "55802";
+    private static final String RESIDENTIAL_COUNTY = "St. Louis";
+
+
+
     private LoginPage loginPage;
     private DashboardPage dashboardPage;
     private EnrollmentPage enrollmentPage;
     private SelectProviderTypePage selectProviderTypePage;
     private OrganizationInfoPage organizationInfoPage;
     private IndividualInfoPage individualInfoPage;
+    private PersonalCareAssistantPersonalInfoPage personCareAssistantPersonalInfoPage;
     private PersonalInfoPage personalInfoPage;
     private LicenseInfoPage licenseInfoPage;
     private PracticeInfoPage practiceInfoPage;
@@ -95,6 +106,12 @@ public class EnrollmentSteps {
         selectProviderTypePage.clickNext();
     }
 
+    public void selectPersonalCareAssistantlProviderType() {
+        selectProviderTypePage.selectProviderType("Personal Care Assistant");
+        licenseType = "Personal Care Assistant";
+        selectProviderTypePage.clickNext();
+    }
+
     @Step
     void enterIndividualPersonalInfo() {
         personalInfoPage.enterFirstName(FIRST_NAME);
@@ -105,6 +122,23 @@ public class EnrollmentSteps {
         personalInfoPage.enterDOB(DATE_OF_BIRTH);
         personalInfoPage.enterEmail(EMAIL);
         personalInfoPage.checkSameAsAbove();
+    }
+
+    @Step
+    void enterPersonCareAssistantIndividualPersonalInfo() {
+        personCareAssistantPersonalInfoPage.enterFirstName(FIRST_NAME);
+        personCareAssistantPersonalInfoPage.enterMiddleName(MIDDLE_NAME);
+        personCareAssistantPersonalInfoPage.enterLastName(LAST_NAME);
+        personCareAssistantPersonalInfoPage.
+                enterResidentialAddress(RESIDENTIAL_ADDRESS);
+        personCareAssistantPersonalInfoPage.enterCity(RESIDENTIAL_CITY);
+        personCareAssistantPersonalInfoPage.selectState(RESIDENTIAL_STATE_FULL);
+        personCareAssistantPersonalInfoPage.setZipcode(RESIDENTIAL_ZIP);
+        personCareAssistantPersonalInfoPage.selectCounty(RESIDENTIAL_COUNTY);
+        personCareAssistantPersonalInfoPage.enterSSN(SSN);
+        personCareAssistantPersonalInfoPage.enterDOB(DATE_OF_BIRTH);
+        personCareAssistantPersonalInfoPage.selectEighteenOrOlder();
+        personCareAssistantPersonalInfoPage.clickNext();
     }
 
     @Step
@@ -197,6 +231,23 @@ public class EnrollmentSteps {
     }
 
     @Step
+    public void enterPersonCareAssistantLicenseInfoWithRenewalDate() {
+        licenseInfoPage.addLicense();
+        licenseInfoPage.enterLicenseNumber(LICENSE_NUMBER);
+        licenseInfoPage.enterIssueDate(LICENSE_ISSUE_DATE);
+        licenseInfoPage.enterRenewalDate(LICENSE_RENEWAL_DATE);
+        licenseInfoPage.enterIssueState(LICENSE_ISSUING_STATE_FULL);
+    }
+
+    @Step
+    public void enterPersonCareAssistantLicenseInfoWithoutRenewalDate() {
+        licenseInfoPage.addLicense();
+        licenseInfoPage.enterLicenseNumber(LICENSE_NUMBER);
+        licenseInfoPage.enterIssueDate(LICENSE_ISSUE_DATE);
+        licenseInfoPage.enterIssueState(LICENSE_ISSUING_STATE_FULL);
+    }
+
+    @Step
     public void enterLicenseInfoWithRenewalDateBeforeIssueDate() {
         licenseInfoPage.addLicense();
         licenseInfoPage.addLicenseType(licenseType);
@@ -215,6 +266,12 @@ public class EnrollmentSteps {
     public void advanceFromIndividualLicenseInfoToPracticeInfo() {
         licenseInfoPage.clickNext();
         assertThat(licenseInfoPage.getTitle()).contains("Practice Information");
+    }
+
+    @Step
+    public void advanceFromPersonalCareAssistantLicenseInfoToPracticeInfo() {
+        licenseInfoPage.clickNext();
+        assertThat(licenseInfoPage.getTitle()).contains("Individual Agency Information");
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -19,6 +19,12 @@ public class IndividualEnrollmentStepDefinitions {
         enrollmentSteps.selectIndividualProviderType();
     }
 
+    @When("^I am on the personal assistant enrollment page$")
+    public void i_am_on_the_personal_care_assistant_enrollment_page() {
+        enrollmentSteps.selectPersonalCareAssistantlProviderType();
+        enrollmentSteps.enterPersonCareAssistantIndividualPersonalInfo();
+    }
+
     @When("I am on the individual provider license info page")
     public void i_am_on_the_individual_provider_license_info_page() {
         i_am_on_the_personal_info_page();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalCareAssistantPersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalCareAssistantPersonalInfoPage.java
@@ -1,0 +1,70 @@
+package gov.medicaid.features.enrollment.ui;
+
+import gov.medicaid.features.PsmPage;
+
+import java.time.LocalDate;
+
+/**
+ * PageObject to interact with the "Individual PCA Info" step of an individual
+ * provider enrollment. This page is reached by logging in, creating an
+ * enrollment, and selecting an individual provider type.
+ */
+public class PersonalCareAssistantPersonalInfoPage extends PsmPage {
+
+    public void enterDOB(LocalDate dateOfBirth) {
+        $("[name=_10_dob]").type(format(dateOfBirth));
+    }
+
+    public void enterFirstName(String firstName) {
+        $("#firstName").type(firstName);
+    }
+
+    public void enterMiddleName(String middleName) {
+        $("#middleName").type(middleName);
+    }
+
+    public void enterLastName(String lastName) {
+        $("[name=_10_lastName]").type(lastName);
+    }
+
+    public void enterSSN(String SSN) {
+        $("[name=_10_ssn]").type(SSN);
+    }
+
+    public void enterResidentialAddress(String residentialAddress) {
+        $("[name=_10_addressLine1]")
+                .type(residentialAddress);
+    }
+
+    public void enterCity(String city) {
+        $("#ind_pca_information__10_city").type(city);
+    }
+
+    public void selectCounty(String countyName) {
+        $(".countySelectFor").selectByVisibleText(countyName);
+    }
+
+    public void selectState(String state) {
+        $(".stateSelectFor").selectByVisibleText(state);
+    }
+
+    public void setZipcode(String zipcode) {
+        $(".zipInputFor").sendKeys(zipcode);
+    }
+
+    public void enterEmail(String email) {
+        $("#emailAddress").type(email);
+    }
+
+    public void selectEighteenOrOlder() {
+        click($("#ind_pca_information__10_adultInd_yes"));
+    }
+
+    public void clickNext() {
+        click($(".nextBtn"));
+    }
+
+    public void addLicense() {
+        click($("#addLicense"));
+    }
+}


### PR DESCRIPTION
On both the 'Register New' and the edit existing enrollment application pages, 'Personal Care Assistant Enrollment Application' > training tab. Enable an optional license/certification renewal end date.

This pull request also adds serenity tests verifying the 'optional license/certification renewal end date', works as expected.

Issue #454 License renewal end date grayed out for pca