### PR TITLE
Remove unused EntityManager from ScreeningHandler

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
@@ -34,8 +34,6 @@ import org.drools.runtime.StatefulKnowledgeSession;
 import org.drools.runtime.process.WorkItem;
 import org.drools.runtime.process.WorkItemManager;
 
-import javax.persistence.EntityManager;
-
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -46,16 +44,10 @@ import java.util.logging.Logger;
  * @version 1.0
  */
 public class ScreeningHandler extends GenericHandler {
-
     /**
      * Provider service.
      */
     private final ProviderEnrollmentService providerService;
-
-    /**
-     * Entity manager.
-     */
-    private final EntityManager entityManager;
 
     private final Logger logger = Logger.getLogger(getClass().getName());
 
@@ -67,7 +59,6 @@ public class ScreeningHandler extends GenericHandler {
     public ScreeningHandler() {
         CMSConfigurator config = new CMSConfigurator();
         this.providerService = config.getEnrollmentService();
-        this.entityManager = config.getPortalEntityManager();
         systemUser = config.getSystemUser();
     }
 


### PR DESCRIPTION
In #883, @mwolfthal found and fixed an unused field in `ScreeningHandler`. This is an unambiguous improvement to the PSM, so I wanted to make sure it got merged.