### PR TITLE
Make DSLTester inner class static

### DIFF
--- a/psm-app/cms-business-process/src/test/java/gov/medicaid/domain/rules/DSLTester.java
+++ b/psm-app/cms-business-process/src/test/java/gov/medicaid/domain/rules/DSLTester.java
@@ -157,7 +157,7 @@ public class DSLTester {
         }
     }
 
-    public class EventListener extends DefaultAgendaEventListener {
+    public static class EventListener extends DefaultAgendaEventListener {
         @Override
         public void beforeActivationFired(final BeforeActivationFiredEvent event) {
             final Rule rule = event.getActivation().getRule();


### PR DESCRIPTION
SpotBugs recommended:

> [Should be a static inner class](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#sic-should-be-a-static-inner-class-sic-inner-should-be-static)
> 
> This class is an inner class, but does not use its embedded reference to the object which created it.  This reference makes the instances of the class larger, and may keep the reference to the creator object alive longer than necessary.  If possible, the class should be made static.

Make the inner class static, as SpotBugs suggests.

I tested this by running `DSLTester.main()` and briefly comparing its output before and after the change.

Issue #915 Use static analysis to find bugs