### PR TITLE
Upgrade to WildFly 11.0.0.Final

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,7 @@ file.  See `docker/README.md` for details.
 The Provider Screening Module is a Java EE Enterprise Application. It depends
 on a correctly-configured Java EE Application Server. While it was originally
 written for the Java EE 6 profile, it is currently being ported to run on Java
-EE 7 Application Servers, starting with WildFly 10.
+EE 7 Application Servers, starting with WildFly 11.
 
 These requirements are based on our understanding of the application at this
 time, and will evolve as we understand it more.
@@ -82,7 +82,7 @@ This is just an overview; see installation instructions below.
   stretch.  If you prefer Debian testing, we have had success with
   Debian testing (aka buster).  A developer has also successfully
   installed the PSM on Red Hat 7.3 Enterprise Linux. If that's not
-  feasible for your environment, any of the supported WildFly 10.1
+  feasible for your environment, any of the supported WildFly 11
   operating systems should work, but our ability to help troubleshoot
   issues that come up may be limited.  Once we test this on a few more
   platforms, we will expand the list of compatible operating systems
@@ -90,7 +90,7 @@ This is just an overview; see installation instructions below.
 - **Java**: We're using OpenJDK 8, which is currently 8u121, but you should
   keep up with the latest releases and post if you have issues relating to
   upgrading.
-- **Java EE Application Server**: currently WildFly 10.1. We may support other
+- **Java EE Application Server**: currently WildFly 11. We may support other
   application servers in the future.
 
 ## Database
@@ -156,20 +156,20 @@ configuration for a development install.
 ## Configure WildFly
 
 Building and deploying the PSM application requies WildFly to be installed and
-configured. See also the [WildFly 10 Getting Started
-Guide](https://docs.jboss.org/author/display/WFLY10/Getting+Started+Guide).
+configured. See also the [WildFly Getting Started
+Guide](https://docs.jboss.org/author/display/WFLY/Getting+Started+Guide).
 
 1. Get WildFly: Visit
    [http://wildfly.org/downloads/](http://wildfly.org/downloads/). Download
-   the [10.1.0.Final full
-   distribution](http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.tar.gz).
+   the [11.0.0.Final full
+   distribution](http://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final.tar.gz).
 
    ```ShellSession
    $ cd {/path/to/this_psm_repo}
    $ # this should be a peer directory, so:
    $ cd ..
-   $ tar -xzf wildfly-10.1.0.Final.tar.gz
-   $ cd wildfly-10.1.0.Final
+   $ tar -xzf wildfly-11.0.0.Final.tar.gz
+   $ cd wildfly-11.0.0.Final
    ```
 
 1. Add a WildFly management console user named 'psm' with a password of 'psm':
@@ -267,7 +267,7 @@ $ ./bin/jboss-cli.sh --connect --command="deploy ../postgresql-{VERSION}.jar"
 If you get an error saying that the `.jar` file "is not a valid node
 type name", double-check that it's in the correct directory. If it is,
 then place the `.jar` file in
-`wildfly-10.1.0.Final/standalone/deployments` and then restart the
+`wildfly-11.0.0.Final/standalone/deployments` and then restart the
 WildFly server. The terminal logging for WildFly should then include
 an `INFO` line like:
 

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -67,7 +67,7 @@ ext.libs = [
 
 ext.provided_libs = [
     ejb_api: 'javax.ejb:javax.ejb-api:3.2',
-    hibernate_core: 'org.hibernate:hibernate-core:5.0.10.Final',
+    hibernate_core: 'org.hibernate:hibernate-core:5.1.10.Final',
     hibernate_jpa: 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final',
     jsp_api: 'javax.servlet.jsp:javax.servlet.jsp-api:2.3.0',
     servlet_api: 'javax.servlet:javax.servlet-api:3.1.0',

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,8 @@ set -e
 # test data from the repo.  If you're deploying in earnest, you'll
 # want to adjust things.
 
-WILDFLY_DIR="./wildfly-10.1.0.Final"
+WILDFLY_VERSION="10.1.0.Final"
+WILDFLY_DIR="./wildfly-${WILDFLY_VERSION}"
 
 function download_and_sha1 {
 	base=$(basename $1)
@@ -127,10 +128,10 @@ fi
 # At this point, we are one dir above a checkout of the psm repo, so
 # we can download and install Wildfly
 echo "Downloading and installing Wildfly"
-download_and_sha1 "http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.tar.gz" \
+download_and_sha1 "http://download.jboss.org/wildfly/${WILDFLY_VERSION}/wildfly-${WILDFLY_VERSION}.tar.gz" \
 				  9ee3c0255e2e6007d502223916cefad2a1a5e333
 rm -rf ${WILDFLY_DIR}
-tar -xzf wildfly-10.1.0.Final.tar.gz
+tar -xzf wildfly-${WILDFLY_VERSION}.tar.gz
 
 # Config postgres - setup user/pass and make db
 pushd /tmp > /dev/null # Prevent complaining about not being able to change to dir (permission denied)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,6 +19,8 @@ set -e
 # test data from the repo.  If you're deploying in earnest, you'll
 # want to adjust things.
 
+WILDFLY_DIR="./wildfly-10.1.0.Final"
+
 function download_and_sha1 {
 	base=$(basename $1)
 	[ -e $base ] || curl -OL $1
@@ -40,7 +42,7 @@ function seed_db {
 }
 
 function start_jboss {
-	./wildfly-10.1.0.Final/bin/standalone.sh \
+	${WILDFLY_DIR}/bin/standalone.sh \
 		-c standalone-full.xml \
 		-b 0.0.0.0 \
 		-bmanagement 0.0.0.0 &
@@ -114,8 +116,8 @@ fi
 # /tmp/pass.txt.  If, however, the password is in the xml config from
 # a prior run, just use that password.
 pword=""
-if grep -q user-name.psm..user-name wildfly-10.1.0.Final/standalone/configuration/standalone-full.xml; then
-	pword=$(grep -m 1 -A 1 user-name.psm..user-name wildfly-10.1.0.Final/standalone/configuration/standalone-full.xml | \
+if grep -q user-name.psm..user-name ${WILDFLY_DIR}/standalone/configuration/standalone-full.xml; then
+	pword=$(grep -m 1 -A 1 user-name.psm..user-name ${WILDFLY_DIR}/standalone/configuration/standalone-full.xml | \
 		grep password | \
 		sed "s/.*<password>//" | \
 		sed "s/<.password>//")
@@ -127,7 +129,7 @@ fi
 echo "Downloading and installing Wildfly"
 download_and_sha1 "http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.tar.gz" \
 				  9ee3c0255e2e6007d502223916cefad2a1a5e333
-rm -rf "wildfly-10.1.0.Final"
+rm -rf ${WILDFLY_DIR}
 tar -xzf wildfly-10.1.0.Final.tar.gz
 
 # Config postgres - setup user/pass and make db
@@ -139,12 +141,12 @@ sudo -upostgres psql -c "create database psm with owner psm encoding=utf8 templa
 popd > /dev/null
 
 # Set up user and run wildfly server
-JBOSS_CLI=./wildfly-10.1.0.Final/bin/jboss-cli.sh
-./wildfly-10.1.0.Final/bin/add-user.sh psm "${pword}"
+JBOSS_CLI=${WILDFLY_DIR}/bin/jboss-cli.sh
+${WILDFLY_DIR}/bin/add-user.sh psm "${pword}"
 start_jboss
 
 # Configure wildfly service bindings
-if ! grep -Fq "<remote-destination host=\"localhost\" port=\"1025\"/>" ./wildfly-10.1.0.Final/standalone/configuration/standalone-full.xml; then
+if ! grep -Fq "<remote-destination host=\"localhost\" port=\"1025\"/>" ${WILDFLY_DIR}/standalone/configuration/standalone-full.xml; then
 	echo Tell Wildfly to use localhost:1025 for mail service.
 	${JBOSS_CLI} --connect << EOF
 /socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=mail-smtp:write-attribute(name=port,value=1025)
@@ -161,7 +163,7 @@ ${JBOSS_CLI} --connect --command="deploy --force postgresql-$JDBC_VERSION.jar"
 
 echo Configure Wildfly to use Postgres
 if ! grep -Fq 'TaskServiceDS' \
-	 ./wildfly-10.1.0.Final/standalone/configuration/standalone-full.xml; then
+	 ${WILDFLY_DIR}/standalone/configuration/standalone-full.xml; then
 ${JBOSS_CLI} --connect <<EOF
 xa-data-source add \
   --name=TaskServiceDS \
@@ -179,7 +181,7 @@ xa-data-source add \
 EOF
 fi
 
-if ! grep -Fq 'MitaDS' ./wildfly-10.1.0.Final/standalone/configuration/standalone-full.xml; then
+if ! grep -Fq 'MitaDS' ${WILDFLY_DIR}/standalone/configuration/standalone-full.xml; then
 ${JBOSS_CLI} --connect <<EOF
 xa-data-source add \
   --name=MitaDS \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ set -e
 # test data from the repo.  If you're deploying in earnest, you'll
 # want to adjust things.
 
-WILDFLY_VERSION="10.1.0.Final"
+WILDFLY_VERSION="11.0.0.Final"
 WILDFLY_DIR="./wildfly-${WILDFLY_VERSION}"
 
 function download_and_sha1 {
@@ -129,7 +129,7 @@ fi
 # we can download and install Wildfly
 echo "Downloading and installing Wildfly"
 download_and_sha1 "http://download.jboss.org/wildfly/${WILDFLY_VERSION}/wildfly-${WILDFLY_VERSION}.tar.gz" \
-				  9ee3c0255e2e6007d502223916cefad2a1a5e333
+                  0e89fe0860a87bfd6b09379ee38d743642edfcfb
 rm -rf ${WILDFLY_DIR}
 tar -xzf wildfly-${WILDFLY_VERSION}.tar.gz
 

--- a/scripts/rebuild-and-change-schema-for-testing.sh
+++ b/scripts/rebuild-and-change-schema-for-testing.sh
@@ -9,7 +9,7 @@
 # in your home directory:
 # https://www.postgresql.org/docs/current/static/libpq-pgpass.html
 
-WILDFLY_CLI=../../wildfly-10.1.0.Final/bin/jboss-cli.sh
+WILDFLY_CLI=../../wildfly-11.0.0.Final/bin/jboss-cli.sh
 
 RESPONSE=$(${WILDFLY_CLI} --connect --command=":read-attribute(name=server-state)")
 # Check whether WildFly is running.
@@ -19,7 +19,7 @@ RESPONSE=$(${WILDFLY_CLI} --connect --command=":read-attribute(name=server-state
 if echo $RESPONSE | grep "Failed"
 then
     echo "Please start WildFly in another terminal first:"
-    echo "wildfly-10.1.0.Final/bin/standalone.sh -c standalone-full.xml"
+    echo "wildfly-11.0.0.Final/bin/standalone.sh -c standalone-full.xml"
 else
     set -e
     cd ../psm-app

--- a/scripts/rebuild-and-change-schema-for-testing.sh
+++ b/scripts/rebuild-and-change-schema-for-testing.sh
@@ -9,7 +9,9 @@
 # in your home directory:
 # https://www.postgresql.org/docs/current/static/libpq-pgpass.html
 
-RESPONSE=$(../../wildfly-10.1.0.Final/bin/jboss-cli.sh --connect --command=":read-attribute(name=server-state)")
+WILDFLY_CLI=../../wildfly-10.1.0.Final/bin/jboss-cli.sh
+
+RESPONSE=$(${WILDFLY_CLI} --connect --command=":read-attribute(name=server-state)")
 # Check whether WildFly is running.
 # TODO: use something like
 # http://www.mastertheboss.com/jboss-server/jboss-monitoring/monitor-wildfly-with-your-bash-skills
@@ -30,9 +32,9 @@ else
     # Once we have a new dev enrollment schema:
     # psql -h localhost -U psm psm < psm-app/db/dev_enrollment.sql
     echo "Deploying new EAR"
-    ../wildfly-10.1.0.Final/bin/jboss-cli.sh --connect \
+    ${WILDFLY_CLI} --connect \
        --command="deploy --force
        psm-app/cms-portal-services/build/libs/cms-portal-services.ear"
     echo "Ready to test at http://localhost:8080/cms/ ."
-    echo "To stop WildFly server:  wildfly-10.1.0.Final/bin/jboss-cli.sh --connect --command=:shutdown "
+    echo "To stop WildFly server:  ${WILDFLY_CLI} --connect --command=:shutdown "
 fi


### PR DESCRIPTION
Update our documentation to refer to WildFly 11 instead of 10.1, and update our build to compile with the version of Hibernate bundled with WildFly 11.

I've been using WildFly 11 for dev [since December](https://github.com/SolutionGuidance/psm/issues/520#issuecomment-351488742) without incident, and we're using WildFly 11 for our Jenkins integration tests.

I still need to:

- [x] Upgrade [the CD server](http://testing.psm.solutionguidance.com:8080/cms/login)
- [x] Upgrade [the demo server](https://demo.psm.solutionguidance.com/)

After merging, we should notify the mailing list of the upgrade.

Resolves #520 Upgrade to WildFly 11