### PR TITLE
Fix 41: Create/Delete Provider Types

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -16,12 +16,9 @@
 
 package gov.medicaid.services.impl;
 
-import gov.medicaid.domain.model.ApplicantType;
-import gov.medicaid.entities.AgreementDocument;
 import gov.medicaid.entities.BeneficialOwnerType;
 import gov.medicaid.entities.EntityStructureType;
 import gov.medicaid.entities.LookupEntity;
-import gov.medicaid.entities.ProviderType;
 import gov.medicaid.entities.dto.ViewStatics;
 import gov.medicaid.services.LookupService;
 import gov.medicaid.services.util.Util;
@@ -34,12 +31,8 @@ import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Defines the UI related services.
@@ -63,30 +56,6 @@ public class LookupServiceBean implements LookupService {
      * Empty constructor.
      */
     public LookupServiceBean() {
-    }
-
-    public List<ProviderType> getAllProviderTypes() {
-        return em.createQuery(
-                "FROM ProviderType",
-                ProviderType.class
-        ).getResultList();
-    }
-
-    /**
-     * Retrieves the provider types filtered by applicant type.
-     *
-     * @param applicantType
-     *            individual or organizations
-     * @return the filtered provider types
-     */
-    public List<ProviderType> getProviderTypes(ApplicantType applicantType) {
-        return em.createQuery(
-                "FROM ProviderType WHERE applicantType = :type",
-                ProviderType.class
-        ).setParameter(
-                "type",
-                applicantType
-        ).getResultList();
     }
 
     /**
@@ -216,32 +185,5 @@ public class LookupServiceBean implements LookupService {
             results = findAllLookups(gov.medicaid.entities.BeneficialOwnerType.class);
         }
         return results;
-    }
-
-    @Override
-    public void updateProviderTypeAgreementSettings(
-            ProviderType providerType,
-            long[] agreementIds
-    ) {
-        providerType.setAgreementDocuments(
-                new HashSet<>(getAgreementDocuments(agreementIds))
-        );
-        em.merge(providerType);
-    }
-
-    private List<AgreementDocument> getAgreementDocuments(long[] agreementIds) {
-        if (agreementIds.length == 0) {
-            return new ArrayList<>();
-        } else {
-            return em.createQuery(
-                    "FROM AgreementDocument WHERE id IN :ids",
-                    AgreementDocument.class
-            ).setParameter(
-                    "ids",
-                    Arrays.stream(agreementIds)
-                            .boxed()
-                            .collect(Collectors.toList())
-            ).getResultList();
-        }
     }
 }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -17,7 +17,6 @@
 package gov.medicaid.services.impl;
 
 import gov.medicaid.domain.model.ApplicantType;
-import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.entities.AgreementDocument;
 import gov.medicaid.entities.BeneficialOwnerType;
 import gov.medicaid.entities.EntityStructureType;
@@ -33,12 +32,12 @@ import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
-import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -88,41 +87,6 @@ public class LookupServiceBean implements LookupService {
                 "type",
                 applicantType
         ).getResultList();
-    }
-
-    @Override
-    public ProviderType getProviderTypeWithAgreementDocuments(
-            ProviderInformationType providerInformationType
-    ) {
-        return getProviderTypeWithNamedEntityGraph(
-                providerInformationType,
-                "ProviderType with AgreementDocuments"
-        );
-    }
-
-    @Override
-    public ProviderType getProviderTypeWithLicenseTypes(
-            ProviderInformationType providerInformationType
-    ) {
-        return getProviderTypeWithNamedEntityGraph(
-                providerInformationType,
-                "ProviderType with LicenseTypes"
-        );
-    }
-
-    private ProviderType getProviderTypeWithNamedEntityGraph(
-            ProviderInformationType providerInformationType,
-            String entityGraphName
-    ) {
-        EntityGraph graph = em.getEntityGraph(entityGraphName);
-        return em.createQuery(
-                "FROM ProviderType WHERE description = :description",
-                ProviderType.class
-        ).setParameter(
-                "description", providerInformationType.getProviderType()
-        ).setHint(
-                "javax.persistence.loadgraph", graph
-        ).getSingleResult();
     }
 
     /**
@@ -260,7 +224,7 @@ public class LookupServiceBean implements LookupService {
             long[] agreementIds
     ) {
         providerType.setAgreementDocuments(
-                getAgreementDocuments(agreementIds)
+                new HashSet<>(getAgreementDocuments(agreementIds))
         );
         em.merge(providerType);
     }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
@@ -80,7 +80,7 @@ public class ProviderTypeServiceBean extends BaseService implements ProviderType
         }
 
         try {
-            if (providerType.getCode() == null) {
+            if (Util.isBlank(providerType.getCode())) {
                 providerType.setCode(generateCode(getLookupService().findAllLookups(ProviderType.class)));
             }
             getEm().persist(providerType);

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
@@ -18,6 +18,7 @@ package gov.medicaid.services.impl;
 
 import gov.medicaid.domain.model.ApplicantType;
 import gov.medicaid.entities.AgreementDocument;
+import gov.medicaid.entities.LicenseType;
 import gov.medicaid.entities.ProviderType;
 import gov.medicaid.entities.ProviderTypeSearchCriteria;
 import gov.medicaid.entities.SearchResult;
@@ -289,6 +290,17 @@ public class ProviderTypeServiceBean extends BaseService implements ProviderType
         getEm().merge(providerType);
     }
 
+    @Override
+    public void updateProviderTypeLicenseSettings(
+            ProviderType providerType,
+            String[] licenseCodes
+    ) {
+        providerType.setLicenseTypes(
+                new HashSet<>(getLicenseTypes(licenseCodes))
+        );
+        getEm().merge(providerType);
+    }
+
     private List<AgreementDocument> getAgreementDocuments(long[] agreementIds) {
         if (agreementIds.length == 0) {
             return new ArrayList<>();
@@ -301,6 +313,20 @@ public class ProviderTypeServiceBean extends BaseService implements ProviderType
                     Arrays.stream(agreementIds)
                             .boxed()
                             .collect(Collectors.toList())
+            ).getResultList();
+        }
+    }
+
+    private List<LicenseType> getLicenseTypes(String[] licenseCodes) {
+        if (licenseCodes.length == 0) {
+            return new ArrayList<>();
+        } else {
+            return getEm().createQuery(
+                    "FROM LicenseType WHERE code IN :codes",
+                    LicenseType.class
+            ).setParameter(
+                    "codes",
+                    Arrays.asList(licenseCodes)
             ).getResultList();
         }
     }

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
@@ -195,7 +195,8 @@ public class ProviderTypeServiceBean extends BaseService implements ProviderType
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public void delete(long id) throws PortalServiceException {
+    @Override
+    public void delete(String id) throws PortalServiceException {
         try {
             ProviderType obj = getEm().find(ProviderType.class, id);
             if (obj == null) {
@@ -299,6 +300,20 @@ public class ProviderTypeServiceBean extends BaseService implements ProviderType
                 new HashSet<>(getLicenseTypes(licenseCodes))
         );
         getEm().merge(providerType);
+    }
+
+    @Override
+    public void updateProviderTypeCanDelete(ProviderType providerType) {
+        providerType.setCanDelete(
+            0 == ((Number) (getEm().createQuery("SELECT count(*) FROM Entity WHERE providerType = :providerType")
+                     .setParameter("providerType", providerType)
+                     .getSingleResult()))
+                 .intValue() &&
+            0 == ((Number) (getEm().createQuery("SELECT count(*) FROM ProviderTypeSetting WHERE providerTypeCode = :providerTypeCode")
+                     .setParameter("providerTypeCode", providerType.getCode())
+                     .getSingleResult()))
+                 .intValue()
+        );
     }
 
     private List<AgreementDocument> getAgreementDocuments(long[] agreementIds) {

--- a/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ProviderTypeServiceBeanTest.groovy
+++ b/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ProviderTypeServiceBeanTest.groovy
@@ -1,0 +1,118 @@
+package gov.medicaid.services.impl
+
+import gov.medicaid.entities.AgreementDocument
+import gov.medicaid.entities.LicenseType
+import gov.medicaid.entities.ProviderType
+import gov.medicaid.entities.ProviderTypeSearchCriteria
+import gov.medicaid.services.LookupService
+import spock.lang.Specification
+
+import javax.persistence.EntityGraph
+import javax.persistence.EntityManager
+import javax.persistence.Query
+import javax.persistence.TypedQuery
+
+class ProviderTypeServiceBeanTest extends Specification {
+    ProviderTypeServiceBean providerTypeService
+    EntityManager entityManager
+    EntityGraph entityGraph
+
+    def setup() {
+        entityGraph = Mock(EntityGraph)
+        entityManager = Mock(EntityManager)
+        entityManager.getEntityGraph(_) >> entityGraph
+        providerTypeService = new ProviderTypeServiceBean()
+        providerTypeService.em = entityManager
+    }
+
+    def "Find ProviderType List doesn't use EntityGraph"() {
+        when:
+        def criteria = new ProviderTypeSearchCriteria()
+        criteria.setPageNumber(1)
+        criteria.setPageSize(10)
+        def query = Mock(Query)
+        query.getSingleResult() >> 0
+        query.getResultList() >> []
+        entityManager.createQuery(_) >> query
+
+        def typedQuery = Mock(TypedQuery)
+        typedQuery.getResultList() >> []
+        entityManager.createQuery(_, _) >> typedQuery
+
+        def searchResult = providerTypeService.search(criteria)
+        def allResult = providerTypeService.getAllProviderTypes()
+
+        then:
+        0 * entityManager.getEntityGraph(_)
+        searchResult.items.size == 0
+        allResult.size == 0
+    }
+
+    def "Get ProviderType searches for Agreements/Licenses"() {
+        when:
+        entityManager.find(_, _, _) >> new ProviderType([code: '00'])
+        def pt = providerTypeService.get('00')
+
+        then:
+        1 * entityManager.getEntityGraph("ProviderType with AgreementDocuments and LicenseTypes")
+        pt.code == '00'
+    }
+
+    def "Get ProviderType then update"() {
+        given:
+        entityManager.find(_, _, _) >> new ProviderType([code: '00'])
+
+        def agreementDocumentQuery = Mock(TypedQuery)
+        agreementDocumentQuery.setParameter(_, _) >> agreementDocumentQuery
+        agreementDocumentQuery.getResultList() >> [
+            new AgreementDocument([id: 1]),
+            new AgreementDocument([id: 2])
+        ]
+        entityManager.createQuery(_, AgreementDocument.class) >> agreementDocumentQuery
+
+        def licenseTypeQuery = Mock(TypedQuery)
+        licenseTypeQuery.setParameter(_, _) >> licenseTypeQuery
+        licenseTypeQuery.getResultList() >> [
+            new LicenseType(),
+            new LicenseType(),
+            new LicenseType()
+        ]
+        entityManager.createQuery(_, LicenseType.class) >> licenseTypeQuery
+
+        def countQuery = Mock(Query)
+        countQuery.getSingleResult() >> 0
+        countQuery.setParameter(_, _) >> countQuery
+        entityManager.createQuery(_) >> countQuery
+
+        when:
+        def pt = providerTypeService.get('00')
+        providerTypeService.updateProviderTypeAgreementSettings(pt, [0, 1] as long[]);
+        providerTypeService.updateProviderTypeLicenseSettings(pt, ["0", "1", "2"] as String[]);
+        providerTypeService.updateProviderTypeCanDelete(pt);
+
+        then:
+        pt.agreementDocuments.size() == 2
+        pt.licenseTypes.size() == 3
+        pt.canDelete == true
+    }
+
+    def "Create ProviderType generates codes"() {
+        when:
+
+        def providerTypes = []
+        def lookupService = Mock(LookupService)
+        providerTypeService.setLookupService(lookupService)
+        lookupService.findAllLookups(ProviderType.class) >> providerTypes
+
+        entityManager.persist(_) >> { args -> providerTypes.add(args[0]) }
+
+        providerTypeService.create(new ProviderType())
+        providerTypeService.create(new ProviderType())
+        providerTypeService.create(new ProviderType())
+        providerTypeService.create(new ProviderType())
+        def code = providerTypeService.create(new ProviderType())
+
+        then:
+        code == 'AE'
+    }
+}

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/service_admin_create_edit_provider_type_common.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/service_admin_create_edit_provider_type_common.jsp
@@ -1,49 +1,89 @@
- <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
-  - Description: This is the admin provider types create/edit common page.
---%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
-<div class="newEnrollmentPanel">
-    <div class="section">
+<form:form id="providerTypeForm" modelAttribute="providerType" action="${editCreateProviderTypeFormAction}" method="post">
+  <form:hidden path="code"/>
+  <div id="addProviderPanel">
+    <div class="newEnrollmentPanel jerrish">
+      <div class="section">
         <div class="wholeCol">
-            <label for="createEditProviderTypeProviderType">Provider Type</label>
-            <form:input id="createEditProviderTypeProviderType" path="description" cssClass="text"/>
+          <label for="createEditProviderTypeProviderType">Provider Type</label>
+          <form:input id="createEditProviderTypeProviderType" path="description" cssClass="text"/>
         </div>
         <div class="tableHeader"><span>Agreements and Addendums</span></div>
         <div class="wholeCol">
+          <div class="row">
             <div class="row">
-                	<div class="row">
-                        <div class="col2">
-                            <div class="row">
-                                <form:checkbox id="addTypeCheck56" path="hasAgreement"/>
-                                <label for="addTypeCheck56">Provider Agreement</label>
-                            </div>
-                            <div class="row">
-                                <form:checkbox id="addTypeCheck57" path="hasAddendum"/>
-                                <label for="addTypeCheck57">Provider Agreement Addendum</label>
-                            </div>
-                        </div>
-                        <div class="col3">
-                            <div class="row">
-                                <form:select title="Agreement" path="agreement.id" items="${agreements}" itemLabel="title" itemValue="id">
-                                </form:select>
-                            </div>
-                            <div class="row">
-                                <form:select title="Addendum" path="addendum.id" items="${addendums}" itemLabel="title" itemValue="id">
-                                </form:select>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+              <div class="col2">
+                <c:forEach var="doc" items="${selectedAgreements}">
+                  <div class="row">
+                    <input
+                      id="selected_provider_agreement_${doc.id}"
+                      type="checkbox"
+                      name="providerAgreements"
+                      checked="checked"
+                      value="${doc.id}"
+                    />
+                    <label for="selected_provider_agreement_${doc.id}">${doc.title}</label>
+                  </div>
+                </c:forEach>
+                <c:forEach var="doc" items="${remainingAgreements}">
+                  <div class="row">
+                    <input
+                      id="remaining_provider_agreement_${doc.id}"
+                      type="checkbox"
+                      name="providerAgreements"
+                      value="${doc.id}"
+                    />
+                    <label for="remaining_provider_agreement_${doc.id}">${doc.title}</label>
+                  </div>
+                </c:forEach>
+              </div>
             </div>
+          </div>
+        </div>
+        <div class="tableHeader"><span>Applicable Licenses</span></div>
+        <div class="wholeCol">
+          <div id="providerTypeLicensesContainer">
+            <c:forEach var="selectedLicenseCode" items="${selectedLicenseCodes}">
+              <div class="providerTypeLicenseRow">
+                <label>
+                  <div class="providerTypeLicenseRowLabel">Applicable License</div>
+                  <select class="providerTypeLicenses" name="providerLicenses">
+                    <c:forEach var="licenseType" items="${allLicenseTypes}">
+                      <option
+                        value="${licenseType.code}"
+                        ${licenseType.code == selectedLicenseCode ? 'selected' : ''}
+                      >
+                        ${licenseType.description}
+                      </option>
+                    </c:forEach>
+                  </select>
+                  <a href="javascript:;" class="remove">REMOVE</a>
+                </label>
+              </div>
+            </c:forEach>
+          </div>
+          <div class="row">
+            <a href="javascript:;" id="addProviderTypeLicense">+ Add Another Applicable License</a>
+          </div>
+        </div>
+        <div class="bl"></div>
+        <div class="br"></div>
+      </div>
+      <div class="buttons">
+        <a href="${ctx}/admin/viewProviderTypes" class="greyBtn">Cancel</a>
+        <button class="saveProviderTypeBtn greyBtn" type="submit">Save</button>
+      </div>
     </div>
-    <div class="bl"></div>
-    <div class="br"></div>
-</div>
-<div class="buttons">
-    <a href="${ctx}/admin/viewProviderTypes" class="greyBtn">Cancel</a>
-    <button class="saveProviderTypeBtn greyBtn" type="submit">Save</button>
+  </div><!--/ #addProviderPanel -->
+</form:form>
+<div id="licenseTemplate" class="providerTypeLicenseRow">
+  <label>
+    <div class="providerTypeLicenseRowLabel">Applicable License</div>
+    <select class="providerTypeLicenses" name="providerLicenses">
+      <c:forEach var="licenseType" items="${allLicenseTypes}">
+        <option value="${licenseType.code}">${licenseType.description}</option>
+      </c:forEach>
+    </select>
+    <a href="javascript:;" class="remove">REMOVE</a>
+  </label>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
@@ -25,40 +25,23 @@
             Functions
           </div>
           <h1>Functions</h1>
-
-          <c:if test="${not empty requestScope['flash_error']}">
-            <div class="clear"></div>
-            <div class="errorInfo formErrorMarker" style="display: block;">
-              <h3>Please correct the following errors:</h3>
-              <p class="bindingError"><c:out value="${requestScope['flash_error']}"></c:out></p>
-              <div class="tl"></div>
-              <div class="tr"></div>
-              <div class="bl"></div>
-              <div class="br"></div>
-            </div>
-            <div class="clear"></div>
-          </c:if>
+          <div class="tabSection">
+            <%@include file="/WEB-INF/pages/provider/enrollment/steps/errors.jsp" %>
+          </div>
           <div class="tabSection functionTab" id="enrollmentSection">
             <c:set var="functionsServiceActiveMenuProviderTypes" value="1"/>
             <h:handlebars template="admin/includes/functions_service_nav" context="${pageContext}" />
-
-
             <div class="tabContent" id="tabProviderTypes">
-              <form:form id="providerTypeForm" modelAttribute="providerType" action="${ctx}/admin/createProviderType" method="post">
-                <div id="addProviderPanel">
-                  <div class="sideBorder"><h3>Add Provider Type</h3></div>
-                  <%@ include file="/WEB-INF/pages/admin/includes/service_admin_create_edit_provider_type_common.jsp" %>
-                </div>
-              </form:form>
-              <!--/ #addProviderPanel -->
+              <div class="sideBorder"><h3>Add Provider Type</h3></div>
+              <c:set var="editCreateProviderTypeFormAction" value="${ctx}/admin/createProviderType" />
+              <%@ include file="/WEB-INF/pages/admin/includes/service_admin_create_edit_provider_type_common.jsp" %>
             </div>
           </div>
         </div>
-      </div>
       <!-- /#mainContent -->
-
+      </div>
       <h:handlebars template="includes/footer" context="${pageContext}"/>
-    </div>
     <!-- /#wrapper -->
+    </div>
   </body>
 </html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
@@ -60,6 +60,32 @@
                           </div>
                         </div>
                       </div>
+                      <div class="tableHeader"><span>Applicable Licenses</span></div>
+                      <div class="wholeCol">
+                        <div id="providerTypeLicensesContainer">
+                          <c:forEach var="selectedLicenseType" items="${selectedLicenseTypes}">
+                            <div class="providerTypeLicenseRow">
+                              <label>
+                                <div class="providerTypeLicenseRowLabel">Applicable License:</div>
+                                <select class="providerTypeLicenses" name="providerLicenses">
+                                  <c:forEach var="licenseType" items="${allLicenseTypes}">
+                                    <option
+                                      value="${licenseType.code}"
+                                      ${licenseType.code eq selectedLicenseType.code ? 'selected' : ''}
+                                    >
+                                      ${licenseType.description}
+                                    </option>
+                                  </c:forEach>
+                                </select>
+                                <a href="javascript:;" class="remove">REMOVE</a>
+                              </label>
+                            </div>
+                          </c:forEach>
+                        </div>
+                        <div class="row">
+                          <a href="javascript:;" id="addProviderTypeLicense">+ Add Another Applicable License</a>
+                        </div>
+                      </div>
                       <div class="bl"></div>
                       <div class="br"></div>
                     </div>
@@ -70,6 +96,17 @@
                   </div>
                 </div><!--/ #addProviderPanel -->
               </form:form>
+              <div id="licenseTemplate" class="providerTypeLicenseRow">
+                <label>
+                  <div class="providerTypeLicenseRowLabel">Applicable License:</div>
+                  <select class="providerTypeLicenses" name="providerLicenses">
+                    <c:forEach var="licenseType" items="${allLicenseTypes}">
+                      <option value="${licenseType.code}">${licenseType.description}</option>
+                    </c:forEach>
+                  </select>
+                  <a href="javascript:;" class="remove">REMOVE</a>
+                </label>
+              </div>
             </div>
           </div>
         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
@@ -32,91 +32,16 @@
             <c:set var="functionsServiceActiveMenuProviderTypes" value="1"/>
             <h:handlebars template="admin/includes/functions_service_nav" context="${pageContext}" />
             <div class="tabContent" id="tabProviderTypes">
-              <form:form id="providerTypeForm" modelAttribute="providerType" action="${ctx}/admin/updateProviderType" method="post">
-                <form:hidden path="code"/>
-                <div id="addProviderPanel">
-                  <div class="sideBorder"><h3>Edit Provider Type</h3></div>
-                  <div class="newEnrollmentPanel jerrish">
-                    <div class="section">
-                      <div class="wholeCol">
-                        <label for="editProviderTypeProviderType">Provider Type</label>
-                        <form:input id="editProviderTypeProviderType" path="description" cssClass="text"/>
-                      </div>
-                      <div class="tableHeader"><span>Agreements and Addendums</span></div>
-                      <div class="wholeCol">
-                        <div class="row">
-                          <div class="row">
-                            <div class="col2">
-                              <c:forEach var="doc" items="${selectedAgreements}">
-                                <div class="row">
-                                  <input id="selected_provider_agreement_${doc.id}" type="checkbox" name="providerAgreements" checked="checked" value="${doc.id}"/>
-                                  <label for="selected_provider_agreement_${doc.id}">${doc.title}</label>
-                                </div>
-                              </c:forEach>
-                              <c:forEach var="doc" items="${remainingAgreements}">
-                                <div class="row">
-                                  <input id="remaining_provider_agreement_${doc.id}" type="checkbox" name="providerAgreements" value="${doc.id}"/>
-                                  <label for="remaining_provider_agreement_${doc.id}">${doc.title}</label>
-                                </div>
-                              </c:forEach>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="tableHeader"><span>Applicable Licenses</span></div>
-                      <div class="wholeCol">
-                        <div id="providerTypeLicensesContainer">
-                          <c:forEach var="selectedLicenseCode" items="${selectedLicenseCodes}">
-                            <div class="providerTypeLicenseRow">
-                              <label>
-                                <div class="providerTypeLicenseRowLabel">Applicable License:</div>
-                                <select class="providerTypeLicenses" name="providerLicenses">
-                                  <c:forEach var="licenseType" items="${allLicenseTypes}">
-                                    <option
-                                      value="${licenseType.code}"
-                                      ${licenseType.code eq selectedLicenseType.code ? 'selected' : ''}
-                                    >
-                                      ${licenseType.description}
-                                    </option>
-                                  </c:forEach>
-                                </select>
-                                <a href="javascript:;" class="remove">REMOVE</a>
-                              </label>
-                            </div>
-                          </c:forEach>
-                        </div>
-                        <div class="row">
-                          <a href="javascript:;" id="addProviderTypeLicense">+ Add Another Applicable License</a>
-                        </div>
-                      </div>
-                      <div class="bl"></div>
-                      <div class="br"></div>
-                    </div>
-                    <div class="buttons">
-                      <a href="${ctx}/admin/viewProviderTypes" class="greyBtn">Cancel</a>
-                      <button class="saveProviderTypeBtn greyBtn" type="submit">Save</button>
-                    </div>
-                  </div>
-                </div><!--/ #addProviderPanel -->
-              </form:form>
-              <div id="licenseTemplate" class="providerTypeLicenseRow">
-                <label>
-                  <div class="providerTypeLicenseRowLabel">Applicable License:</div>
-                  <select class="providerTypeLicenses" name="providerLicenses">
-                    <c:forEach var="licenseType" items="${allLicenseTypes}">
-                      <option value="${licenseType.code}">${licenseType.description}</option>
-                    </c:forEach>
-                  </select>
-                  <a href="javascript:;" class="remove">REMOVE</a>
-                </label>
-              </div>
+              <div class="sideBorder"><h3>Edit Provider Type</h3></div>
+              <c:set var="editCreateProviderTypeFormAction" value="${ctx}/admin/updateProviderType" />
+              <%@ include file="/WEB-INF/pages/admin/includes/service_admin_create_edit_provider_type_common.jsp" %>
             </div>
           </div>
         </div>
-        <!-- /#mainContent -->
-
-        <h:handlebars template="includes/footer" context="${pageContext}"/>
+      <!-- /#mainContent -->
       </div>
-      <!-- /#wrapper -->
+      <h:handlebars template="includes/footer" context="${pageContext}"/>
+    <!-- /#wrapper -->
+    </div>
   </body>
 </html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
@@ -25,6 +25,9 @@
             Functions
           </div>
           <h1>Functions</h1>
+          <div class="tabSection">
+            <%@include file="/WEB-INF/pages/provider/enrollment/steps/errors.jsp" %>
+          </div>
           <div class="tabSection functionTab" id="enrollmentSection">
             <c:set var="functionsServiceActiveMenuProviderTypes" value="1"/>
             <h:handlebars template="admin/includes/functions_service_nav" context="${pageContext}" />
@@ -63,7 +66,7 @@
                       <div class="tableHeader"><span>Applicable Licenses</span></div>
                       <div class="wholeCol">
                         <div id="providerTypeLicensesContainer">
-                          <c:forEach var="selectedLicenseType" items="${selectedLicenseTypes}">
+                          <c:forEach var="selectedLicenseCode" items="${selectedLicenseCodes}">
                             <div class="providerTypeLicenseRow">
                               <label>
                                 <div class="providerTypeLicenseRowLabel">Applicable License:</div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
@@ -59,6 +59,16 @@
                         </div>
                       </div>
                     </div>
+                    <div class="tableHeader"><span>Applicable Licenses</span></div>
+                    <div class="wholeCol">
+                      <div class="row">
+                        <div class="col2">
+                          <c:forEach var="licenseType" items="${licenseTypes}">
+                            <div class="row">${licenseType.description}</div>
+                          </c:forEach>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div class="bl"></div>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -1275,7 +1275,7 @@ input.date{
   width:160px;
 }
 
-.tableData table .remove{
+.remove{
   width:16px;
   height:16px;
   display:block;
@@ -1286,7 +1286,7 @@ input.date{
   background-position:0 0;
 }
 
-.tableData table .remove:hover{
+.remove:hover{
   background-position:0 -16px;
 }
 
@@ -3547,6 +3547,34 @@ a.okBtn {
 ,#deleteAgreementModal .buttons .deleteOKBtn {
   margin:0 10px 0 170px;
 }
+
+.providerTypeLicenseRow {
+  width:100%;
+  clear:both;
+}
+
+.providerTypeLicenseRow label {
+  width:100%;
+}
+
+.providerTypeLicenseRow .providerTypeLicenseRowLabel {
+  float:left;
+}
+
+.providerTypeLicenseRow .providerTypeLicenses {
+  float:left;
+  width:400px;
+}
+
+.providerTypeLicenseRow .remove {
+  float:left;
+  margin-top:10px;
+}
+
+#licenseTemplate {
+  display:none;
+}
+
 #editModal .modalBody .buttons .saveBtn {
   width:auto;
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -255,7 +255,7 @@ public class ProviderTypeController {
         providerType = providerTypeService.get(providerType.getCode());
         long[] agreementIds = ServletRequestUtils.getLongParameters(request, "providerAgreements");
 
-        lookupService.updateProviderTypeAgreementSettings(providerType, agreementIds);
+        providerTypeService.updateProviderTypeAgreementSettings(providerType, agreementIds);
 
         ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
         model.addObject("providerType", providerType);

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -126,6 +126,7 @@ public class ProviderTypeController {
         ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
         model.addObject("providerType", providerType);
         model.addObject("agreements", providerType.getAgreementDocuments());
+        model.addObject("licenseTypes", providerType.getLicenseTypes());
         return model;
     }
 
@@ -260,6 +261,7 @@ public class ProviderTypeController {
         ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
         model.addObject("providerType", providerType);
         model.addObject("agreements", providerType.getAgreementDocuments());
+        model.addObject("licenseTypes", providerType.getLicenseTypes());
         return model;
     }
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -41,6 +41,7 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * <p>
@@ -180,7 +181,7 @@ public class ProviderTypeController {
         criteria.setPageSize(-1);
         List<AgreementDocument> agreements = agreementDocumentService.search(criteria).getItems();
         List<AgreementDocument> remainingAgreements = new ArrayList<AgreementDocument>(agreements);
-        List<AgreementDocument> selectedAgreements = providerType.getAgreementDocuments();
+        Set<AgreementDocument> selectedAgreements = providerType.getAgreementDocuments();
 
         for (AgreementDocument agreement: agreements) {
             for (AgreementDocument selectedAgreement: selectedAgreements) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -87,7 +87,15 @@ public class ProviderTypeController {
         criteria.setPageNumber(1);
         criteria.setPageSize(10);
         criteria.setSortColumn("description");
-        return search(criteria);
+
+        SearchResult<ProviderType> result = providerTypeService.search(criteria);
+        result.getItems().forEach(providerTypeService::updateProviderTypeCanDelete);
+        ModelAndView model = new ModelAndView("admin/service_admin_provider_types");
+        model.addObject("providerTypesSearchResult", result);
+        model.addObject("searchCriteria", criteria);
+        ControllerHelper.addPaginationDetails(result, model);
+        ControllerHelper.addPaginationLinks(result, model);
+        return model;
     }
 
     /**
@@ -104,6 +112,7 @@ public class ProviderTypeController {
     public ModelAndView search(@ModelAttribute("criteria") ProviderTypeSearchCriteria criteria)
         throws PortalServiceException {
         SearchResult<ProviderType> result = providerTypeService.search(criteria);
+        result.getItems().forEach(providerTypeService::updateProviderTypeCanDelete);
         ModelAndView model = new ModelAndView("admin/service_admin_provider_types");
         model.addObject("providerTypesSearchResult", result);
         model.addObject("searchCriteria", criteria);
@@ -125,6 +134,7 @@ public class ProviderTypeController {
     @RequestMapping(value = "/admin/getProviderType", method = RequestMethod.GET)
     public ModelAndView get(@RequestParam("providerTypeId") String providerTypeId) throws PortalServiceException {
         ProviderType providerType = providerTypeService.get(providerTypeId);
+        providerTypeService.updateProviderTypeCanDelete(providerType);
         return view(providerType);
     }
 
@@ -271,9 +281,9 @@ public class ProviderTypeController {
      */
     @RequestMapping(value = "/admin/deleteProviderTypes", method = RequestMethod.GET)
     @ResponseBody
-    public String delete(@RequestParam("providerTypeIds") long[] providerTypeIds, HttpServletRequest request)
+    public String delete(@RequestParam("providerTypeIds") String[] providerTypeIds, HttpServletRequest request)
         throws PortalServiceException {
-        for (long providerTypeId : providerTypeIds) {
+        for (String providerTypeId : providerTypeIds) {
             providerTypeService.delete(providerTypeId);
         }
         return "success";

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -124,11 +124,7 @@ public class ProviderTypeController {
     @RequestMapping(value = "/admin/getProviderType", method = RequestMethod.GET)
     public ModelAndView get(@RequestParam("providerTypeId") String providerTypeId) throws PortalServiceException {
         ProviderType providerType = providerTypeService.get(providerTypeId);
-        ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
-        model.addObject("providerType", providerType);
-        model.addObject("agreements", providerType.getAgreementDocuments());
-        model.addObject("licenseTypes", providerType.getLicenseTypes());
-        return model;
+        return view(providerType);
     }
 
     /**
@@ -227,9 +223,7 @@ public class ProviderTypeController {
             // Retrieve
             providerType = providerTypeService.get(providerType.getCode());
 
-            ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
-            model.addObject("providerType", providerType);
-            return model;
+            return view(providerType);
         } else {
 
             ModelAndView mv = beginCreate();
@@ -266,11 +260,7 @@ public class ProviderTypeController {
         providerTypeService.updateProviderTypeAgreementSettings(providerType, agreementIds);
         providerTypeService.updateProviderTypeLicenseSettings(providerType, licenseIds);
 
-        ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
-        model.addObject("providerType", providerType);
-        model.addObject("agreements", providerType.getAgreementDocuments());
-        model.addObject("licenseTypes", providerType.getLicenseTypes());
-        return model;
+        return view(providerType);
     }
 
     /**
@@ -291,5 +281,13 @@ public class ProviderTypeController {
             providerTypeService.delete(providerTypeId);
         }
         return "success";
+    }
+
+    private ModelAndView view(ProviderType providerType) {
+        ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
+        model.addObject("providerType", providerType);
+        model.addObject("agreements", providerType.getAgreementDocuments());
+        model.addObject("licenseTypes", providerType.getLicenseTypes());
+        return model;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -206,7 +206,7 @@ public class ProviderTypeController {
             return view(providerType);
         } else {
             FormError error = new FormError();
-            error.setFieldId("placeholder");
+            error.setFieldId("providerTypeDescription");
 
             if (blank) {
                 error.setMessage("Please specify a provider type.");
@@ -248,7 +248,7 @@ public class ProviderTypeController {
 
         if (typeByDesc != null && !typeByDesc.getCode().equals(providerType.getCode())) {
             FormError error = new FormError();
-            error.setFieldId("placeholder");
+            error.setFieldId("providerTypeDescription");
             error.setMessage("Cannot have a duplicate description: " + providerType.getDescription());
 
             return addCommonElements(

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -251,7 +251,7 @@ public class ProviderTypeController {
     @RequestMapping(value = "/admin/updateProviderType", method = RequestMethod.POST)
     public ModelAndView edit(@ModelAttribute("providerType") ProviderType providerType, HttpServletRequest request)
         throws PortalServiceException {
-        // providerTypeService.update(providerType);
+        providerTypeService.update(providerType);
         // Retrieve
         providerType = providerTypeService.get(providerType.getCode());
         long[] agreementIds = ServletRequestUtils.getLongParameters(request, "providerAgreements");

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -20,6 +20,7 @@ import gov.medicaid.controllers.ControllerHelper;
 import gov.medicaid.entities.AgreementDocument;
 import gov.medicaid.entities.AgreementDocumentSearchCriteria;
 import gov.medicaid.entities.AgreementDocumentType;
+import gov.medicaid.entities.LicenseType;
 import gov.medicaid.entities.ProviderType;
 import gov.medicaid.entities.ProviderTypeSearchCriteria;
 import gov.medicaid.entities.SearchResult;
@@ -196,6 +197,11 @@ public class ProviderTypeController {
         model.addObject("providerType", providerType);
         model.addObject("selectedAgreements", selectedAgreements);
         model.addObject("remainingAgreements", remainingAgreements);
+
+        List<LicenseType> allLicenseTypes = lookupService.findAllLookups(LicenseType.class);
+
+        model.addObject("selectedLicenseTypes", providerType.getLicenseTypes());
+        model.addObject("allLicenseTypes", allLicenseTypes);
         return model;
     }
 
@@ -255,8 +261,10 @@ public class ProviderTypeController {
         // Retrieve
         providerType = providerTypeService.get(providerType.getCode());
         long[] agreementIds = ServletRequestUtils.getLongParameters(request, "providerAgreements");
+        String[] licenseIds = ServletRequestUtils.getStringParameters(request, "providerLicenses");
 
         providerTypeService.updateProviderTypeAgreementSettings(providerType, agreementIds);
+        providerTypeService.updateProviderTypeLicenseSettings(providerType, licenseIds);
 
         ModelAndView model = new ModelAndView("admin/service_admin_view_provider_type");
         model.addObject("providerType", providerType);

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -454,6 +454,17 @@ $(document).ready(function () {
         });
   });
 
+  // For provider type editing/adding
+  $('.providerTypeLicenseRow .remove').on('click', function () {
+    $(this).closest('.providerTypeLicenseRow').remove();
+  });
+
+  $('#addProviderTypeLicense').on('click', function () {
+    var newLicenseRow = $('#licenseTemplate').clone(true, true);
+    newLicenseRow.removeAttr('id');
+    $('#providerTypeLicensesContainer').append(newLicenseRow);
+  });
+
   // delete agreement documents part
   var deleteAgreementDocumentIds = [];
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
@@ -82,6 +82,11 @@ public class PsmPage extends PageObject {
         throw new RuntimeException("Switching windows failed, title was: " + getTitle());
     }
 
+    public void checkForFormError(String errorClass, String errorText) {
+        assertThat($(".errorInfo > ." + errorClass).getText())
+            .contains(errorText);
+    }
+
     private static Optional<URL> getAxeCoreUrl(WebDriver driver) {
         return Optional
                 .ofNullable(driver.getCurrentUrl())

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationInfoPage.java
@@ -2,8 +2,6 @@ package gov.medicaid.features.enrollment.ui;
 
 import cucumber.api.PendingException;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class OrganizationInfoPage extends EnrollmentPage {
     private static final String ORGANIZATION_FEIN_ERROR_MESSAGE =
             "Organization FEIN length must be 9 characters.";
@@ -105,7 +103,6 @@ public class OrganizationInfoPage extends EnrollmentPage {
     }
 
     public void checkForFeinError() throws Exception {
-        assertThat($(".errorInfo > ._15_fein").getText())
-                .contains(ORGANIZATION_FEIN_ERROR_MESSAGE);
+        checkForFormError("_15_fein", ORGANIZATION_FEIN_ERROR_MESSAGE);
     }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
@@ -55,8 +55,7 @@ public class PersonalInfoPage extends PsmPage {
     }
 
     public void checkForTooYoungError() throws Exception {
-        assertThat($(".errorInfo > ._02_dob").getText())
-                .contains(PROVIDER_TOO_YOUNG_ERROR_MESSAGE);
+        checkForFormError("_02_dob", PROVIDER_TOO_YOUNG_ERROR_MESSAGE);
     }
 
     public void checkForSameAsAboveEmailError() throws Exception {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -30,6 +30,11 @@ public class GeneralSteps {
     }
 
     @Step
+    public void checkForFormError(String errorClass, String errorText) {
+        psmPage.checkForFormError(errorClass, errorText);
+    }
+
+    @Step
     public void navigateToRegisterNewAccountPage() {
         loginPage.open();
         loginPage.click$(".registerNewAccountLink");

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ProviderTypeStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ProviderTypeStepDefinitions.java
@@ -1,0 +1,68 @@
+package gov.medicaid.features.service_admin.steps;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+
+import gov.medicaid.features.general.steps.GeneralSteps;
+
+import net.thucydides.core.annotations.Steps;
+
+public class ProviderTypeStepDefinitions {
+    @Steps
+    ProviderTypeSteps providerTypeSteps;
+
+    @Steps
+    GeneralSteps generalSteps;
+
+    @Given("^I create a Provider Type with Description '(.*)'$")
+    public void i_create_a_Provider_Type_with_Description(String desc) {
+        generalSteps.clickLinkAssertTitle(".addProviderBtn", "Create Provider Type");
+        providerTypeSteps.setProviderTypeDescription(desc);
+        providerTypeSteps.submitProviderType();
+    }
+
+    @Then("^I should see a Provider Type Description error '(.*)'$")
+    public void i_should_see_a_provider_type_description_error(String errorText) {
+        generalSteps.checkForFormError("providerTypeDescription", errorText);
+    }
+
+    @Given("^I am on the Functions View Provider Type page for '(.*)'$")
+    public void i_am_on_the_Functions_View_Provider_Type_page_for(String desc) {
+        providerTypeSteps.viewProviderType(desc);
+    }
+
+    @Then("^I should see a Provider Type with Description '(.*)'$")
+    public void i_should_see_a_Provider_Type_with_Description(String desc) {
+        providerTypeSteps.confirmOnViewPage(desc);
+    }
+
+    @Given("^I am on the Functions Edit Provider Type page for '(.*)'$")
+    public void i_am_on_the_Functions_Edit_Provider_Type_page_for(String desc) {
+        providerTypeSteps.editProviderType(desc);
+    }
+
+    @Given("^I change the Provider Type Description to '(.*)'$")
+    public void i_change_the_Provider_Type_Description_to(String newDesc) {
+        providerTypeSteps.setProviderTypeDescription(newDesc);
+    }
+
+    @Given("^I add Provider Type Agreements and Licenses$")
+    public void i_add_Provider_Type_Agreements_and_Licenses() {
+        providerTypeSteps.addProviderTypeAgreementsAndLicenses();
+    }
+
+    @Given("^I submit the Provider Type Edit$")
+    public void i_submit_the_Provider_Type_Edit() {
+        providerTypeSteps.submitProviderType();
+    }
+
+    @Given("^I delete the Provider Type '(.*)'$")
+    public void i_delete_the_Provider_Type(String desc) {
+        providerTypeSteps.deleteProviderType(desc);
+    }
+
+    @Then("^I should not see a Provider Type with Description '(.*)'$")
+    public void i_should_not_see_a_Provider_Type_with_Description(String desc) {
+        providerTypeSteps.confirmNoProviderTypeInList(desc);
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ProviderTypeSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ProviderTypeSteps.java
@@ -1,0 +1,49 @@
+package gov.medicaid.features.service_admin.steps;
+
+import gov.medicaid.features.service_admin.ui.ProviderTypePage;
+
+import net.thucydides.core.annotations.Step;
+
+public class ProviderTypeSteps {
+    ProviderTypePage providerTypePage;
+
+    @Step
+    public void setProviderTypeDescription(String desc) {
+        providerTypePage.updateDescriptionInput(desc);
+    }
+
+    @Step
+    public void submitProviderType() {
+        providerTypePage.submitSave();
+    }
+
+    @Step
+    public void confirmOnViewPage(String desc) {
+        providerTypePage.assertViewing(desc);
+    }
+
+    @Step
+    public void viewProviderType(String desc) {
+        providerTypePage.view(desc);
+    }
+
+    @Step
+    public void editProviderType(String desc) {
+        providerTypePage.edit(desc);
+    }
+
+    @Step
+    public void addProviderTypeAgreementsAndLicenses() {
+        providerTypePage.addAgreementsAndLicenses();
+    }
+
+    @Step
+    public void confirmNoProviderTypeInList(String desc) {
+        providerTypePage.noProviderTypeInList(desc);
+    }
+
+    @Step
+    public void deleteProviderType(String desc) {
+        providerTypePage.delete(desc);
+    }
+}

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/ui/ProviderTypePage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/ui/ProviderTypePage.java
@@ -1,0 +1,76 @@
+package gov.medicaid.features.service_admin.ui;
+
+import gov.medicaid.features.PsmPage;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProviderTypePage extends PsmPage {
+    public void updateDescriptionInput(String desc) {
+        $("#createEditProviderTypeProviderType").clear();
+        $("#createEditProviderTypeProviderType").sendKeys(desc);
+    }
+
+    public void submitSave() {
+        click$(".saveProviderTypeBtn");
+    }
+
+    public void assertViewing(String desc) {
+        assertThat(getTitle()).contains("View Provider Type - Functions (Service Admin)");
+
+        Optional<WebElement> descRow = getDriver().findElements(By.cssSelector(".wholeCol"))
+            .stream()
+            .filter(div ->
+                div.findElements(By.cssSelector("label")).size() == 1 &&
+                "Provider Type".equals(div.findElement(By.cssSelector("label")).getText()))
+            .findFirst();
+
+        assertThat(descRow.isPresent()).isTrue();
+        assertThat(descRow.get().getText().contains(desc));
+    }
+
+    public void view(String desc) {
+        getAndAssertProviderTypeRow(desc).findElement(By.cssSelector(".viewProviderLink")).click();
+    }
+
+    public void edit(String desc) {
+        getAndAssertProviderTypeRow(desc).findElement(By.cssSelector(".editProviderLink")).click();
+    }
+
+    public void noProviderTypeInList(String desc) {
+        assertThat(getProviderTypeRow(desc)).isEmpty();
+    }
+
+    public void delete(String desc) {
+        getAndAssertProviderTypeRow(desc).findElement(By.cssSelector(".deleteProviderTypeBtn")).click();
+
+        assertThat($("#deleteProviderTypesModal").isDisplayed()).isTrue();
+
+        $("#deleteProviderTypesModal .saveBtn").click();
+    }
+
+    public void addAgreementsAndLicenses() {
+        click$("#remaining_provider_agreement_1");
+        click$("#remaining_provider_agreement_3");
+        click$("#addProviderTypeLicense");
+    }
+
+    private WebElement getAndAssertProviderTypeRow(String desc) {
+        Optional<WebElement> descRow = getProviderTypeRow(desc);
+        assertThat(descRow.isPresent()).isTrue();
+        return descRow.get();
+    }
+
+    private Optional<WebElement> getProviderTypeRow(String desc) {
+        return getDriver().findElements(By.cssSelector("tr"))
+            .stream()
+            .filter(div ->
+                div.findElements(By.cssSelector("td label")).size() > 0 &&
+                desc.equals(div.findElement(By.cssSelector("td label")).getText()))
+            .findFirst();
+    }
+}

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/provider_types.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/provider_types.feature
@@ -1,0 +1,46 @@
+@providertype
+Feature: Admin Provider Types Editing Pages
+  Users wish to change provider types
+
+  Scenario: Admin Provider Type Creation
+    Given I am logged in as an admin
+    And I am on the Functions Provider Types page
+    And I create a Provider Type with Description 'Z - TEST PROVIDER TYPE'
+    Then I should see a Provider Type with Description 'Z - TEST PROVIDER TYPE'
+    And I should have no errors
+
+  Scenario: Admin Provider Type Creation with No Description
+    Given I am logged in as an admin
+    And I am on the Functions Provider Types page
+    And I create a Provider Type with Description ''
+    Then I should see a Provider Type Description error 'Please specify a provider type'
+
+  Scenario: Admin Provider Type Creation with Duplicate Description
+    Given I am logged in as an admin
+    And I am on the Functions Provider Types page
+    And I create a Provider Type with Description 'Acupuncturist'
+    Then I should see a Provider Type Description error 'Specified provider type already exists'
+
+  Scenario: Admin Provider Type View
+    Given I am logged in as an admin
+    And I am on the Functions Provider Types page
+    And I am on the Functions View Provider Type page for 'Z - TEST PROVIDER TYPE'
+    Then I should see a Provider Type with Description 'Z - TEST PROVIDER TYPE'
+    And I should have no errors
+
+  Scenario: Admin Provider Type Edit
+    Given I am logged in as an admin
+    And I am on the Functions Provider Types page
+    And I am on the Functions Edit Provider Type page for 'Z - TEST PROVIDER TYPE'
+    And I change the Provider Type Description to 'Z2 - TEST PROVIDER TYPE'
+    And I add Provider Type Agreements and Licenses
+    And I submit the Provider Type Edit
+    Then I should see a Provider Type with Description 'Z2 - TEST PROVIDER TYPE'
+    And I should have no accessibility issues
+    And I should have no errors
+
+  Scenario: Admin Provider Type Delete
+    Given I am logged in as an admin
+    And I am on the Functions Provider Types page
+    And I delete the Provider Type 'Z2 - TEST PROVIDER TYPE'
+    Then I should not see a Provider Type with Description 'Z2 - TEST PROVIDER TYPE'

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -35,10 +35,14 @@ import gov.medicaid.entities.dto.FormError;
 import gov.medicaid.services.CMSConfigurator;
 import gov.medicaid.services.LookupService;
 import gov.medicaid.services.ProviderEnrollmentService;
+import gov.medicaid.services.ProviderTypeService;
+
 import org.springframework.web.util.HtmlUtils;
 
 import javax.servlet.http.HttpServletRequest;
+
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -77,6 +81,11 @@ public abstract class BaseFormBinder implements FormBinder {
      * Enrollment service.
      */
     private ProviderEnrollmentService enrollmentService;
+
+    /**
+     * ProviderType service.
+     */
+    private ProviderTypeService providerTypeService;
 
     /**
      * The form namespace.
@@ -249,7 +258,7 @@ public abstract class BaseFormBinder implements FormBinder {
      * @param key the attribute key (this will prepend the namespace)
      * @param values the values to be set
      */
-    protected void attr(Map<String, Object> mv, String key, List<? extends LookupEntity> values) {
+    protected void attr(Map<String, Object> mv, String key, Collection<? extends LookupEntity> values) {
         mv.put(name(key), values);
     }
 
@@ -342,6 +351,7 @@ public abstract class BaseFormBinder implements FormBinder {
         CMSConfigurator config = new CMSConfigurator();
         lookupService = config.getLookupService();
         enrollmentService = config.getEnrollmentService();
+        providerTypeService = config.getProviderTypeService();
         serverHashKey = config.getServerHashKey();
         systemUser = config.getSystemUser();
     }
@@ -362,6 +372,24 @@ public abstract class BaseFormBinder implements FormBinder {
      */
     public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
         this.enrollmentService = enrollmentService;
+    }
+
+    /**
+     * Gets the value of the field <code>providerTypeService</code>.
+     *
+     * @return the providerTypeService
+     */
+    public ProviderTypeService getProviderTypeService() {
+        return providerTypeService;
+    }
+
+    /**
+     * Sets the value of the field <code>providerTypeService</code>.
+     *
+     * @param providerTypeService the providerTypeService to set
+     */
+    public void setProviderTypeService(ProviderTypeService providerTypeService) {
+        this.providerTypeService = providerTypeService;
     }
 
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
@@ -203,7 +203,7 @@ public class FacilityLicenseFormBinder extends BaseFormBinder {
 
         attr(mv, "categorySize", services.size());
 
-        ProviderType pt = getLookupService().getProviderTypeWithLicenseTypes(provider);
+        ProviderType pt = getProviderTypeService().getByDescription(provider.getProviderType());
 
         if (!readOnly) {
             attr(mv, "licenseTypes", pt.getLicenseTypes());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
@@ -42,11 +42,13 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This binder handles the provider type selection form.
@@ -111,10 +113,8 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
         statement.setName(param(request, "name"));
         statement.setTitle(param(request, "title"));
 
-        ProviderType pt = getLookupService().getProviderTypeWithAgreementDocuments(
-                provider
-        );
-        List<AgreementDocument> docs = pt.getAgreementDocuments();
+        ProviderType pt = getProviderTypeService().getByDescription(provider.getProviderType());
+        Set<AgreementDocument> docs = pt.getAgreementDocuments();
 
         List<ProviderAgreementType> xList = new ArrayList<ProviderAgreementType>();
         HashSet<String> agreed = new HashSet<String>();
@@ -159,10 +159,8 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
     public void bindToPage(CMSUser user, EnrollmentType enrollment, Map<String, Object> mv, boolean readOnly) {
         attr(mv, "bound", "Y");
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
-        ProviderType pt = getLookupService().getProviderTypeWithAgreementDocuments(
-                provider
-        );
-        List<AgreementDocument> docs = pt.getAgreementDocuments();
+        ProviderType pt = getProviderTypeService().getByDescription(provider.getProviderType());
+        Set<AgreementDocument> docs = pt.getAgreementDocuments();
 
         // for renewal the form should be blank
         if (enrollment.getRequestType() == RequestType.RENEWAL && provider.getRenewalShowBlankStatement() == null) {
@@ -284,10 +282,8 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 
         List<AcceptedAgreements> hList = profile.getAgreements();
 
-        ProviderType pt = getLookupService().getProviderTypeWithAgreementDocuments(
-                provider
-        );
-        List<AgreementDocument> activeList = pt.getAgreementDocuments();
+        ProviderType pt = getProviderTypeService().getByDescription(provider.getProviderType());
+        Set<AgreementDocument> activeList = pt.getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
         // Retain any previously accepted agreements that is no longer shown in the page
@@ -331,7 +327,7 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
      * @param list the list to be mapped
      * @return the lookup map
      */
-    private Map<String, AgreementDocument> mapDocumentsById(List<AgreementDocument> list) {
+    private Map<String, AgreementDocument> mapDocumentsById(Collection<AgreementDocument> list) {
         Map<String, AgreementDocument> map = new HashMap<String, AgreementDocument>();
         for (AgreementDocument item : list) {
             map.put(String.valueOf(item.getId()), item);
@@ -391,10 +387,8 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
         provider.setHasCivilPenalty(profile.getCivilPenaltyInd());
         provider.setHasPreviousExclusion(profile.getPreviousExclusionInd());
 
-        ProviderType pt = getLookupService().getProviderTypeWithAgreementDocuments(
-                provider
-        );
-        List<AgreementDocument> activeList = pt.getAgreementDocuments();
+        ProviderType pt = getProviderTypeService().getByDescription(provider.getProviderType());
+        Set<AgreementDocument> activeList = pt.getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
         AcceptedAgreementsType acceptedAgreements = XMLUtility.nsGetAcceptedAgreements(enrollment);

--- a/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
@@ -172,7 +172,7 @@ public class LicenseInformationFormBinder extends BaseFormBinder {
             attr(mv, "attachmentSize", i);
         }
 
-        ProviderType pt = getLookupService().getProviderTypeWithLicenseTypes(provider);
+        ProviderType pt = getProviderTypeService().getByDescription(provider.getProviderType());
 
         if (!readOnly) {
             attr(mv, "licenseTypes", pt.getLicenseTypes());

--- a/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
@@ -147,7 +147,7 @@ public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
         if (enrollment.getProviderInformation().getProviderType().equals(gov.medicaid.domain.model.ProviderType.PHARMACY.value())) {
             mv.put("onlyPharmacist", true);
         } else {
-            mv.put("individualMemberProviderTypes", sortCollection(getLookupService().getProviderTypes(ApplicantType.INDIVIDUAL)));
+            mv.put("individualMemberProviderTypes", sortCollection(getProviderTypeService().getProviderTypes(ApplicantType.INDIVIDUAL)));
         }
 
     }

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
@@ -36,11 +36,13 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This binder handles the provider type selection form.
@@ -91,8 +93,8 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         statement.setName(param(request, "name"));
         statement.setTitle(param(request, "title"));
 
-        List<AgreementDocument> docs = getLookupService().getProviderTypeWithAgreementDocuments(
-                provider
+        Set<AgreementDocument> docs = getProviderTypeService().getByDescription(
+            provider.getProviderType()
         ).getAgreementDocuments();
 
         List<ProviderAgreementType> xList = new ArrayList<ProviderAgreementType>();
@@ -144,8 +146,8 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         attr(mv, "bound", "Y");
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
 
-        List<AgreementDocument> docs = getLookupService().getProviderTypeWithAgreementDocuments(
-                provider
+        Set<AgreementDocument> docs = getProviderTypeService().getByDescription(
+            provider.getProviderType()
         ).getAgreementDocuments();
 
         if (enrollment.getRequestType() == RequestType.RENEWAL && "Y".equals(provider.getRenewalShowBlankStatement())) {
@@ -252,8 +254,8 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
 
         List<AcceptedAgreements> hList = profile.getAgreements();
 
-        List<AgreementDocument> activeList = getLookupService().getProviderTypeWithAgreementDocuments(
-                provider
+        Set<AgreementDocument> activeList = getProviderTypeService().getByDescription(
+            provider.getProviderType()
         ).getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 
@@ -298,7 +300,7 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
      * @param list the list to be mapped
      * @return the lookup map
      */
-    private Map<String, AgreementDocument> mapDocumentsById(List<AgreementDocument> list) {
+    private Map<String, AgreementDocument> mapDocumentsById(Collection<AgreementDocument> list) {
         Map<String, AgreementDocument> map = new HashMap<String, AgreementDocument>();
         for (AgreementDocument item : list) {
             map.put(String.valueOf(item.getId()), item);
@@ -356,8 +358,8 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         ProviderInformationType provider = XMLUtility.nsGetProvider(enrollment);
         ProviderProfile profile = ticket.getDetails();
 
-        List<AgreementDocument> activeList = getLookupService().getProviderTypeWithAgreementDocuments(
-                provider
+        Set<AgreementDocument> activeList = getProviderTypeService().getByDescription(
+            provider.getProviderType()
         ).getAgreementDocuments();
         Map<String, AgreementDocument> documentMap = mapDocumentsById(activeList);
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
@@ -103,16 +103,16 @@ public class ProviderTypeFormBinder extends BaseFormBinder {
         if (Util.isBlank(provider.getProviderType()) || enrollment.getRequestType() == null
             || enrollment.getRequestType() == RequestType.ENROLLMENT) {
             // can still change applicant type.
-            mv.put("individualProviderTypes", sortCollection(getLookupService().getProviderTypes(ApplicantType.INDIVIDUAL)));
-            mv.put("organizationProviderTypes", sortCollection(getLookupService().getProviderTypes(ApplicantType.ORGANIZATION)));
+            mv.put("individualProviderTypes", sortCollection(getProviderTypeService().getProviderTypes(ApplicantType.INDIVIDUAL)));
+            mv.put("organizationProviderTypes", sortCollection(getProviderTypeService().getProviderTypes(ApplicantType.ORGANIZATION)));
         } else {
             // already set as org or individual
             ProviderType pt = getLookupService()
                 .findLookupByDescription(ProviderType.class, provider.getProviderType());
             if (pt.getApplicantType() == ApplicantType.INDIVIDUAL) {
-                mv.put("individualProviderTypes", sortCollection(getLookupService().getProviderTypes(ApplicantType.INDIVIDUAL)));
+                mv.put("individualProviderTypes", sortCollection(getProviderTypeService().getProviderTypes(ApplicantType.INDIVIDUAL)));
             } else {
-                mv.put("organizationProviderTypes", sortCollection(getLookupService().getProviderTypes(ApplicantType.ORGANIZATION)));
+                mv.put("organizationProviderTypes", sortCollection(getProviderTypeService().getProviderTypes(ApplicantType.ORGANIZATION)));
             }
         }
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
@@ -26,10 +26,9 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.NamedAttributeNode;
 import javax.persistence.NamedEntityGraph;
-import javax.persistence.NamedEntityGraphs;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Represents a provider type.
@@ -39,16 +38,13 @@ import java.util.List;
  */
 @javax.persistence.Entity
 @Table(name = "provider_types")
-@NamedEntityGraphs({
-        @NamedEntityGraph(
-                name = "ProviderType with AgreementDocuments",
-                attributeNodes = {@NamedAttributeNode("agreementDocuments")}
-        ),
-        @NamedEntityGraph(
-                name = "ProviderType with LicenseTypes",
-                attributeNodes = {@NamedAttributeNode("licenseTypes")}
-        )
-})
+@NamedEntityGraph(
+    name = "ProviderType with AgreementDocuments and LicenseTypes",
+    attributeNodes = {
+        @NamedAttributeNode("agreementDocuments"),
+        @NamedAttributeNode("licenseTypes")
+    }
+)
 public class ProviderType extends LookupEntity {
 
     /**
@@ -79,7 +75,7 @@ public class ProviderType extends LookupEntity {
                     referencedColumnName = "agreement_document_id"
             )
     )
-    private List<AgreementDocument> agreementDocuments;
+    private Set<AgreementDocument> agreementDocuments;
 
     @ManyToMany
     @JoinTable(
@@ -93,7 +89,7 @@ public class ProviderType extends LookupEntity {
                     referencedColumnName = "code"
             )
     )
-    private List<LicenseType> licenseTypes;
+    private Set<LicenseType> licenseTypes;
 
    /**
      * Gets the value of the field <code>applicantType</code>.
@@ -119,19 +115,19 @@ public class ProviderType extends LookupEntity {
         this.canDelete = canDelete;
     }
 
-    public List<AgreementDocument> getAgreementDocuments() {
+    public Set<AgreementDocument> getAgreementDocuments() {
         return agreementDocuments;
     }
 
-    public void setAgreementDocuments(List<AgreementDocument> agreementDocuments) {
+    public void setAgreementDocuments(Set<AgreementDocument> agreementDocuments) {
         this.agreementDocuments = agreementDocuments;
     }
 
-    public List<LicenseType> getLicenseTypes() {
+    public Set<LicenseType> getLicenseTypes() {
         return licenseTypes;
     }
 
-    public void setLicenseTypes(List<LicenseType> licenseTypes) {
+    public void setLicenseTypes(Set<LicenseType> licenseTypes) {
         this.licenseTypes = licenseTypes;
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -227,6 +227,15 @@ public class CMSConfigurator {
     }
 
     /**
+     * Retrieves the provider type service.
+     *
+     * @return the provider type service from the JNDI tree.
+     */
+    public ProviderTypeService getProviderTypeService() {
+        return (ProviderTypeService) fromContext("jndi.ProviderTypeService", false);
+    }
+
+    /**
      * Retrieves the object from the JNDI tree.
      *
      * @param jndiName the JNDI name configuration property

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -16,10 +16,8 @@
 
 package gov.medicaid.services;
 
-import gov.medicaid.domain.model.ApplicantType;
 import gov.medicaid.entities.BeneficialOwnerType;
 import gov.medicaid.entities.LookupEntity;
-import gov.medicaid.entities.ProviderType;
 
 import java.util.List;
 
@@ -30,20 +28,6 @@ import java.util.List;
  * @version 1.0
  */
 public interface LookupService {
-    /**
-     * @return all provider types
-     */
-    List<ProviderType> getAllProviderTypes();
-
-    /**
-     * Retrieves the provider types filtered by applicant type.
-     *
-     * @param applicantType
-     *            individual or organizations
-     * @return the filtered provider types
-     */
-    List<ProviderType> getProviderTypes(ApplicantType applicantType);
-
     /**
      * Retrieves the lookup with the given description.
      *
@@ -107,15 +91,4 @@ public interface LookupService {
      * @return the matched lookups
      */
     List<BeneficialOwnerType> findBeneficialOwnerTypes(String entityType);
-
-    /**
-     * Updates the ProviderTypeSettings for agreements.
-     *
-     * @param providerType providerType
-     * @param agreementIds agreement ids
-     */
-    void updateProviderTypeAgreementSettings(
-            ProviderType providerType,
-            long[] agreementIds
-    );
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -17,7 +17,6 @@
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.ApplicantType;
-import gov.medicaid.domain.model.ProviderInformationType;
 import gov.medicaid.entities.BeneficialOwnerType;
 import gov.medicaid.entities.LookupEntity;
 import gov.medicaid.entities.ProviderType;
@@ -44,27 +43,6 @@ public interface LookupService {
      * @return the filtered provider types
      */
     List<ProviderType> getProviderTypes(ApplicantType applicantType);
-
-    /**
-     * Finds a ProviderType by its description, and eager-load
-     * its related AgreementDocuments.
-     *
-     * @param providerInformationType The XML-backed provider type to look up in
-     *                                the database.
-     * @return The ProviderType, with its agreementDocuments field fully
-     * initialized.
-     */
-    ProviderType getProviderTypeWithAgreementDocuments(ProviderInformationType providerInformationType);
-
-    /**
-     * Finds a ProviderType by its description, and eager-load
-     * its related LicenseTypes.
-     *
-     * @param providerInformationType The XML-backed provider type to look up in
-     *                                the database.
-     * @return The ProviderType, with its licenseTypes field fully initialized.
-     */
-    ProviderType getProviderTypeWithLicenseTypes(ProviderInformationType providerInformationType);
 
     /**
      * Retrieves the lookup with the given description.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
@@ -16,11 +16,14 @@
 
 package gov.medicaid.services;
 
+import gov.medicaid.domain.model.ApplicantType;
 import gov.medicaid.entities.ProviderType;
 import gov.medicaid.entities.ProviderTypeSearchCriteria;
 import gov.medicaid.entities.SearchResult;
 
 import javax.jws.WebService;
+
+import java.util.List;
 
 /**
  * This represents the service API to manage provider types.
@@ -90,4 +93,29 @@ public interface ProviderTypeService {
      * @throws PortalServiceException - If an error occurs while performing the operation
      */
     SearchResult<ProviderType> search(ProviderTypeSearchCriteria criteria) throws PortalServiceException;
+
+    /**
+     * @return all provider types
+     */
+    List<ProviderType> getAllProviderTypes();
+
+    /**
+     * Retrieves the provider types filtered by applicant type.
+     *
+     * @param applicantType
+     *            individual or organizations
+     * @return the filtered provider types
+     */
+    List<ProviderType> getProviderTypes(ApplicantType applicantType);
+
+    /**
+     * Updates the ProviderTypeSettings for agreements.
+     *
+     * @param providerType providerType
+     * @param agreementIds agreement ids
+     */
+    void updateProviderTypeAgreementSettings(
+            ProviderType providerType,
+            long[] agreementIds
+    );
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
@@ -118,4 +118,15 @@ public interface ProviderTypeService {
             ProviderType providerType,
             long[] agreementIds
     );
+
+    /**
+     * Updates the ProviderTypeSettings for licenses.
+     *
+     * @param providerType providerType
+     * @param licenseIds license ids
+     */
+    void updateProviderTypeLicenseSettings(
+            ProviderType providerType,
+            String[] licenseIds
+    );
 }

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
@@ -64,6 +64,14 @@ public interface ProviderTypeService {
     ProviderType get(String string) throws PortalServiceException;
 
     /**
+     * This method gets a provider type by its description. If not found, returns null.
+     *
+     * @param description - the description of the provider type to retrieve
+     * @return - the requested provider type
+     */
+    ProviderType getByDescription(String description);
+
+    /**
      * This method deletes the provider type with the given ID.
      *
      * @param id - the ID of the provider type to delete

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
@@ -80,7 +80,7 @@ public interface ProviderTypeService {
      * @param id - the ID of the provider type to delete
      * @throws PortalServiceException - If there are any errors during the execution of this method
      */
-    void delete(long id) throws PortalServiceException;
+    void delete(String id) throws PortalServiceException;
 
     /**
      * This method gets all the provider types that meet the search criteria. If none available, the search result will
@@ -129,4 +129,11 @@ public interface ProviderTypeService {
             ProviderType providerType,
             String[] licenseIds
     );
+
+    /**
+     * Updates the ProviderType can delete setting.
+     *
+     * @param providerType providerType
+     */
+    void updateProviderTypeCanDelete(ProviderType providerType);
 }


### PR DESCRIPTION
This grew to more than just #41, as it appeared the entire provider type editing UI was incomplete.

Test by adding, editing, and deleting provider types from the admin interface.  Additional check to see if agreements and license options are added to enrollments.