### PR TITLE
Fix #766. Rework the admin enrollments Notes tab

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_notes_dialog.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_notes_dialog.jsp
@@ -59,7 +59,7 @@
               <textarea id="viewNotesModalNotesBody" rows="6" cols="60" class="textarea disable" disabled="disabled"></textarea>
               <div class="buttons">
                 <div class="links">
-                  <a id="preNote" href="javascript:;">&laquo; Previous</a>
+                  <a id="prevNote" href="javascript:;">&laquo; Previous</a>
                   <a id="nextNote" href="javascript:;" class="nextLink">Next &raquo;</a>
                 </div>
                 <a href="javascript:;" class="greyBtn closeModal">CANCEL</a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -1,15 +1,8 @@
-<%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
-  - Description: it is used to render the enrollment search filter panel section.
---%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <table
   id="${searchTableId}"
   class="generalTable fixedWidthTable ${active_enrollment_tab eq 'notes' ? 'table-enrollment-notes-sort' : ''}"
-  >
+>
   <colgroup>
     <c:choose>
       <c:when test="${active_enrollment_tab=='notes'}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -103,7 +103,7 @@
       <c:set var="sortColumnTitle" value="Request Type"/>
       <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
 
-      <c:if test="${addStatusColumn=='yes'}">
+      <c:if test="${addStatusColumn == 'yes'}">
         <c:set var="sortFieldOfEntity" value="5"/>
         <c:set var="sortColumnTitle" value="Status"/>
         <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
@@ -116,9 +116,6 @@
       <c:set var="sortFieldOfEntity" value="6"/>
       <c:set var="sortColumnTitle" value="Status Date"/>
       <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
-      <c:if test="${active_enrollment_tab == 'all'}">
-        <th class="alignCenter">Notes<span class="sep"></span></th>
-      </c:if>
       <th class="alignCenter">Action</th>
     </tr>
   </thead>
@@ -176,35 +173,6 @@
           <c:otherwise><td>${item.riskLevel}</td></c:otherwise>
         </c:choose>
         <td><fmt:formatDate value="${item.statusDate}" pattern="MM/dd/yyyy"/></td>
-        <c:if test="${active_enrollment_tab == 'all'}">
-          <td class="alignCenter">
-            <a
-              href="javascript:;"
-              rel="${item.ticketId}"
-              class="writeNotes"
-              >
-              Write
-            </a>
-            <span class="sep <c:if test="${!(fn:length(item.notes)>0)}">hide</c:if>">|</span>
-            <a
-              href="javascript:;"
-              rel="${item.ticketId}"
-              class='viewNotes<c:if test="${!(fn:length(item.notes)>0)}"> hide disabledLink</c:if>'
-              >
-              View
-            </a>
-            <div id="notesSection" class="hide">
-              <c:forEach var="noteItem" items="${item.notes}" varStatus="noteStatus">
-                <span
-                  class="note_${item.ticketId}"
-                  id="note_${item.ticketId}_${noteStatus.count}"
-                  >
-                  ${noteItem.text}
-                </span>
-              </c:forEach>
-            </div>
-          </td>
-        </c:if>
         <td class="alignCenter nopad">
           <c:choose>
             <c:when test="${fn:toLowerCase(item.status)=='pending'}">
@@ -264,6 +232,26 @@
               <span class="sep">|</span>
             </c:otherwise>
           </c:choose>
+
+          <c:if test="${isServiceAdministrator}">
+            <a
+              href="javascript:;"
+              rel="${item.ticketId}"
+              class="writeNotes"
+            >
+              Add Note
+            </a>
+            <span class="sep">|</span>
+            <a
+              href="javascript:;"
+              rel="${item.ticketId}"
+              class='viewNotes<c:if test="${!(fn:length(item.notes)>0)}"> hide disabledLink</c:if>'
+            >
+              View Notes
+            </a>
+            <span class="sep <c:if test="${!(fn:length(item.notes)>0)}">hide</c:if>">|</span>
+          </c:if>
+
           <a rel="${item.ticketId}" class="printEnrollment" href="javascript:;">
             Print
           </a>
@@ -276,3 +264,19 @@
     </c:forEach>
   </tbody>
 </table>
+<%@ include file="/WEB-INF/pages/admin/includes/enrollment_notes_dialog.jsp" %>
+
+<c:if test="${isServiceAdministrator}">
+  <%-- This is how the view notes modal accesses and stores notes. --%>
+  <div id="notesSection" class="hide">
+    <c:forEach var="item" items="${searchResult.items}">
+      <c:forEach var="noteItem" items="${item.notes}" varStatus="noteStatus">
+        <%-- There needs to be no extra whitespace inside this span. --%>
+        <span
+          class="note_${item.ticketId}"
+          id="note_${item.ticketId}_${noteStatus.count}"
+        >${noteItem.text}</span>
+      </c:forEach>
+    </c:forEach>
+  </div>
+</c:if>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -1,11 +1,11 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <table
   id="${searchTableId}"
-  class="generalTable fixedWidthTable ${active_enrollment_tab eq 'notes' ? 'table-enrollment-notes-sort' : ''}"
+  class="generalTable fixedWidthTable ${active_enrollment_tab == 'all' ? 'table-enrollment-all-sort' : ''}"
 >
   <colgroup>
     <c:choose>
-      <c:when test="${active_enrollment_tab=='notes'}">
+      <c:when test="${active_enrollment_tab == 'all'}">
         <col width="32"/>
         <col width="95"/>
         <col width="81"/>
@@ -60,8 +60,8 @@
       <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
 
       <c:choose>
-        <c:when test="${active_enrollment_tab=='notes'}">
-          <th class="towline">
+        <c:when test="${active_enrollment_tab == 'all'}">
+          <th class="twoline">
             <c:choose>
               <c:when test="${searchCriteria.sortColumn == '3'}">
                 <a class="sortable_column" rel="3" href="javascript:;">
@@ -116,7 +116,7 @@
       <c:set var="sortFieldOfEntity" value="6"/>
       <c:set var="sortColumnTitle" value="Status Date"/>
       <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
-      <c:if test="${active_enrollment_tab=='notes'}">
+      <c:if test="${active_enrollment_tab == 'all'}">
         <th class="alignCenter">Notes<span class="sep"></span></th>
       </c:if>
       <th class="alignCenter">Action</th>
@@ -176,7 +176,7 @@
           <c:otherwise><td>${item.riskLevel}</td></c:otherwise>
         </c:choose>
         <td><fmt:formatDate value="${item.statusDate}" pattern="MM/dd/yyyy"/></td>
-        <c:if test="${active_enrollment_tab=='notes'}">
+        <c:if test="${active_enrollment_tab == 'all'}">
           <td class="alignCenter">
             <a
               href="javascript:;"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -1,44 +1,26 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <table
   id="${searchTableId}"
-  class="generalTable fixedWidthTable ${active_enrollment_tab == 'all' ? 'table-enrollment-all-sort' : ''}"
+  class="generalTable fixedWidthTable"
 >
   <colgroup>
+    <col width="27"/>
+    <col width="90"/>
+    <col width="85"/>
+    <col width="100"/>
+    <col width="110"/>
+    <col width="100"/>
+    <c:if test="${addStatusColumn=='yes'}">
+      <col width="70"/>
+    </c:if>
+    <col width="80"/>
+    <col width="85"/>
     <c:choose>
-      <c:when test="${active_enrollment_tab == 'all'}">
-        <col width="32"/>
-        <col width="95"/>
-        <col width="81"/>
-        <col width="97"/>
-        <col width="109"/>
-        <col width="100"/>
-        <col width="81"/>
-        <col width="90"/>
-        <col width="81"/>
-        <col width="183"/>
-      </c:when>
       <c:when test="${addStatusColumn=='yes'}">
-        <col width="27"/>
-        <col width="87"/>
-        <col width="112"/>
-        <col width="100"/>
-        <col width="115"/>
-        <col width="100"/>
-        <col width="65"/>
-        <col width="84"/>
-        <col width="90"/>
-        <col width="181"/>
+        <col width="214"/>
       </c:when>
       <c:otherwise>
-        <col width="42"/>
-        <col width="109"/>
-        <col width="118"/>
-        <col width="107"/>
-        <col width="115"/>
-        <col width="106"/>
-        <col width="87"/>
-        <col width="96"/>
-        <col width="181"/>
+        <col width="284"/>
       </c:otherwise>
     </c:choose>
   </colgroup>
@@ -59,38 +41,12 @@
       <c:set var="sortColumnTitle" value="NPI/UMPI"/>
       <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
 
-      <c:choose>
-        <c:when test="${active_enrollment_tab == 'all'}">
-          <th class="twoline">
-            <c:choose>
-              <c:when test="${searchCriteria.sortColumn == '3'}">
-                <a class="sortable_column" rel="3" href="javascript:;">
-                  <span>Date<br />Submitted</span>
-                  <c:choose>
-                    <c:when test="${searchCriteria.ascending}">
-                      <span class="sort-up"></span>
-                    </c:when>
-                    <c:otherwise>
-                      <span class="sort-down"></span>
-                    </c:otherwise>
-                  </c:choose>
-                </a>
-              </c:when>
-              <c:otherwise>
-                <a class="sortable_column" rel="3" href="javascript:;">
-                  <span>Date<br />Submitted</span>
-                </a>
-              </c:otherwise>
-            </c:choose>
-            <span class="sep"></span>
-          </th>
-        </c:when>
-        <c:otherwise>
-          <c:set var="sortFieldOfEntity" value="3"/>
-          <c:set var="sortColumnTitle" value="Date Submitted"/>
-          <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
-        </c:otherwise>
-      </c:choose>
+      <c:set var="sortFieldOfEntity" value="3"/>
+      <c:set var="sortColumnTitle" value="Date<br />Submitted"/>
+      <c:set var="thClass" value="twoline"/>
+      <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+      <c:set var="thClass" value=""/>
+
       <c:set var="sortFieldOfEntity" value="8"/>
       <c:set var="sortColumnTitle" value="Provider Type"/>
       <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
@@ -114,8 +70,11 @@
       <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
 
       <c:set var="sortFieldOfEntity" value="6"/>
-      <c:set var="sortColumnTitle" value="Status Date"/>
+      <c:set var="sortColumnTitle" value="Status<br />Date"/>
+      <c:set var="thClass" value="twoline"/>
       <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
+      <c:set var="thClass" value=""/>
+
       <th class="alignCenter">Action</th>
     </tr>
   </thead>
@@ -123,7 +82,7 @@
   <tbody>
     <c:forEach var="item" items="${searchResult.items}">
       <tr>
-        <td class="alignCenter">
+        <td class="alignCenter tdCheckbox">
           <input
             type="checkbox"
             title="Enrollment ${item.ticketId}"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_tab_section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_tab_section.jsp
@@ -3,6 +3,14 @@
   <div class="tabR">
     <div class="tabM">
       <a
+        class="tab allTab <c:if test="${active_enrollment_tab == 'all'}">active</c:if>"
+        href="${ctx}/provider/enrollments/all?showFilterPanel=true"
+      >
+        <span class="aR">
+          <span class="aM">All</span>
+        </span>
+      </a>
+      <a
         class="tab draftTab <c:if test="${active_enrollment_tab=='draft'}">active</c:if>"
         href="${ctx}/provider/enrollments/draft?statuses=Draft&showFilterPanel=true"
       >
@@ -32,14 +40,6 @@
       >
         <span class="aR">
           <span class="aM">Denied</span>
-        </span>
-      </a>
-      <a
-        class="tab notesTab <c:if test="${active_enrollment_tab=='notes'}">active</c:if>"
-        href="${ctx}/provider/enrollments/notes?statuses=&showFilterPanel=true"
-      >
-        <span class="aR">
-          <span class="aM">Notes</span>
         </span>
       </a>
       <a href="${ctx}/provider/enrollment/start" class="purpleBtn">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_tab_section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_tab_section.jsp
@@ -1,45 +1,50 @@
-<%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
-  - Description: it is used to render the enrollment tab section.
---%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <div class="tabHead">
-    <div class="tabR">
-        <div class="tabM">
-            <a class="tab draftTab <c:if test="${active_enrollment_tab=='draft'}">active</c:if>"
-              href="${ctx}/provider/enrollments/draft?statuses=Draft&showFilterPanel=true">
-              <span class="aR">
-                <span class="aM">Draft</span>
-              </span>
-            </a>
-            <a class="tab pendingTab <c:if test="${active_enrollment_tab=='pending'}">active</c:if>"
-              href="${ctx}/provider/enrollments/pending?statuses=Pending&showFilterPanel=true">
-              <span class="aR">
-                <span class="aM">Pending</span>
-              </span>
-            </a>
-            <a class="tab approvedTab <c:if test="${active_enrollment_tab=='approved'}">active</c:if>"
-              href="${ctx}/provider/enrollments/approved?statuses=Approved&showFilterPanel=true">
-              <span class="aR">
-                <span class="aM">Approved</span>
-              </span>
-            </a>
-            <a class="tab deniedTab <c:if test="${active_enrollment_tab=='rejected'}">active</c:if>"
-              href="${ctx}/provider/enrollments/rejected?statuses=Rejected&showFilterPanel=true">
-              <span class="aR">
-                <span class="aM">Denied</span>
-              </span>
-            </a>
-            <a class="tab notesTab <c:if test="${active_enrollment_tab=='notes'}">active</c:if>"
-              href="${ctx}/provider/enrollments/notes?statuses=&showFilterPanel=true">
-              <span class="aR">
-                <span class="aM">Notes</span>
-              </span>
-            </a>
-            <a href="${ctx}/provider/enrollment/start" class="purpleBtn">New Enrollment/Renewal</a>
-        </div>
+  <div class="tabR">
+    <div class="tabM">
+      <a
+        class="tab draftTab <c:if test="${active_enrollment_tab=='draft'}">active</c:if>"
+        href="${ctx}/provider/enrollments/draft?statuses=Draft&showFilterPanel=true"
+      >
+        <span class="aR">
+          <span class="aM">Draft</span>
+        </span>
+      </a>
+      <a
+        class="tab pendingTab <c:if test="${active_enrollment_tab=='pending'}">active</c:if>"
+        href="${ctx}/provider/enrollments/pending?statuses=Pending&showFilterPanel=true"
+      >
+        <span class="aR">
+          <span class="aM">Pending</span>
+        </span>
+      </a>
+      <a
+        class="tab approvedTab <c:if test="${active_enrollment_tab=='approved'}">active</c:if>"
+        href="${ctx}/provider/enrollments/approved?statuses=Approved&showFilterPanel=true"
+      >
+        <span class="aR">
+          <span class="aM">Approved</span>
+        </span>
+      </a>
+      <a
+        class="tab deniedTab <c:if test="${active_enrollment_tab=='rejected'}">active</c:if>"
+        href="${ctx}/provider/enrollments/rejected?statuses=Rejected&showFilterPanel=true"
+      >
+        <span class="aR">
+          <span class="aM">Denied</span>
+        </span>
+      </a>
+      <a
+        class="tab notesTab <c:if test="${active_enrollment_tab=='notes'}">active</c:if>"
+        href="${ctx}/provider/enrollments/notes?statuses=&showFilterPanel=true"
+      >
+        <span class="aR">
+          <span class="aM">Notes</span>
+        </span>
+      </a>
+      <a href="${ctx}/provider/enrollment/start" class="purpleBtn">
+        New Enrollment/Renewal
+      </a>
     </div>
+  </div>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollments_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollments_link.jsp
@@ -1,0 +1,12 @@
+<c:choose>
+  <c:when test="${isServiceAdministrator}">
+    <a href="<c:url value="/provider/enrollments/all?showFilterPanel=true" />">
+      Enrollments
+    </a>
+  </c:when>
+  <c:otherwise>
+    <a href="<c:url value="/provider/dashboard/drafts" />">
+      Enrollments
+    </a>
+  </c:otherwise>
+</c:choose>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sort_column_header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sort_column_header.jsp
@@ -1,5 +1,5 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
-<th>
+<th class="${thClass}">
   <c:choose>
     <c:when test="${searchCriteria.sortColumn == sortFieldOfEntity}">
       <a

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sort_column_header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sort_column_header.jsp
@@ -1,28 +1,29 @@
-<%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
-  - Description: it is used to render the sort column header.
---%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <th>
-    <c:choose>
-        <c:when test="${searchCriteria.sortColumn == sortFieldOfEntity}">
-            <a class="sortable_column" rel="${sortFieldOfEntity}" href="javascript:;"><span>${sortColumnTitle}</span>
-                <c:choose>
-                    <c:when test="${searchCriteria.ascending}">
-                        <span class="sort-up"></span>
-                    </c:when>
-                    <c:otherwise>
-                        <span class="sort-down"></span>
-                    </c:otherwise>
-                </c:choose>
-            </a>
-        </c:when>
-        <c:otherwise>
-            <a class="sortable_column" rel="${sortFieldOfEntity}" href="javascript:;"><span>${sortColumnTitle}</span></a>
-        </c:otherwise>
-    </c:choose>
-    <span class="sep"></span>
+  <c:choose>
+    <c:when test="${searchCriteria.sortColumn == sortFieldOfEntity}">
+      <a
+        class="sortable_column"
+        rel="${sortFieldOfEntity}"
+        href="javascript:;"
+      ><span>${sortColumnTitle}</span>
+        <c:choose>
+          <c:when test="${searchCriteria.ascending}">
+            <span class="sort-up"></span>
+          </c:when>
+          <c:otherwise>
+            <span class="sort-down"></span>
+          </c:otherwise>
+        </c:choose>
+      </a>
+    </c:when>
+    <c:otherwise>
+      <a
+        class="sortable_column"
+        rel="${sortFieldOfEntity}"
+        href="javascript:;"
+      ><span>${sortColumnTitle}</span></a>
+    </c:otherwise>
+  </c:choose>
+  <span class="sep"></span>
 </th>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
@@ -66,6 +66,9 @@
               <c:otherwise>
                 <div class="tableWrapper">
                   <div class="tableContainer">
+                    <c:if test="${active_enrollment_tab == 'all'}">
+                      <c:set var="addStatusColumn" value="yes"/>
+                    </c:if>
                     <%@ include file="/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp" %>
                   </div>
                   <!-- /.tableContainer -->
@@ -90,8 +93,5 @@
       <!-- #footer -->
     </div>
     <!-- /#wrapper -->
-    <c:if test="${tabName == 'all'}">
-      <%@ include file="/WEB-INF/pages/admin/includes/enrollment_notes_dialog.jsp" %>
-    </c:if>
   </body>
 </html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
@@ -2,6 +2,9 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:choose>
+    <c:when test="${tabName == 'all'}">
+      <c:set var="listType" value="All Enrollments"/>
+    </c:when>
     <c:when test="${tabName == 'approved'}">
       <c:set var="listType" value="Approved Enrollments"/>
     </c:when>
@@ -13,9 +16,6 @@
     </c:when>
     <c:when test="${tabName == 'draft'}">
       <c:set var="listType" value="Draft Enrollments"/>
-    </c:when>
-    <c:when test="${tabName == 'notes'}">
-      <c:set var="listType" value="Notes"/>
     </c:when>
   </c:choose>
   <c:set var="title" value="${listType}"/>
@@ -44,7 +44,7 @@
             <%@ include file="/WEB-INF/pages/admin/includes/enrollment_tab_section.jsp" %>
             <%@ include file="/WEB-INF/pages/admin/includes/enrollment_search_form.jsp" %>
             <!-- /.tabHead -->
-            <div class="tabContent" id="${tabName == 'notes' ? 'tabNotes' : ''}">
+            <div class="tabContent" id="${tabName == 'all' ? 'tabAll' : ''}">
               <div class="pagination">
                 <%@ include file="/WEB-INF/pages/admin/includes/page_left_navigation.jsp" %>
                 <%@ include file="/WEB-INF/pages/admin/includes/enrollment_buttons.jsp" %>
@@ -90,7 +90,7 @@
       <!-- #footer -->
     </div>
     <!-- /#wrapper -->
-    <c:if test="${tabName == 'notes'}">
+    <c:if test="${tabName == 'all'}">
       <%@ include file="/WEB-INF/pages/admin/includes/enrollment_notes_dialog.jsp" %>
     </c:if>
   </body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
@@ -44,7 +44,7 @@
             <%@ include file="/WEB-INF/pages/admin/includes/enrollment_tab_section.jsp" %>
             <%@ include file="/WEB-INF/pages/admin/includes/enrollment_search_form.jsp" %>
             <!-- /.tabHead -->
-            <div class="tabContent" id="${tabName == 'all' ? 'tabAll' : ''}">
+            <div class="tabContent">
               <div class="pagination">
                 <%@ include file="/WEB-INF/pages/admin/includes/page_left_navigation.jsp" %>
                 <%@ include file="/WEB-INF/pages/admin/includes/enrollment_buttons.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
@@ -33,7 +33,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value='/provider/dashboard/drafts' />">Enrollments</a>
+            <%@ include file="/WEB-INF/pages/admin/includes/enrollments_link.jsp" %>
             <span>${listType}</span>
           </div>
           <h1>${listType}</h1>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -21,7 +21,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value='/provider/dashboard/drafts' />">Enrollments</a>
+            <%@ include file="/WEB-INF/pages/admin/includes/enrollments_link.jsp" %>
             <span>${listType}</span>
           </div>
           <h1>${listType}</h1>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -22,7 +22,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value="/provider/dashboard/drafts" />">Enrollments</a>
+            <%@ include file="/WEB-INF/pages/admin/includes/enrollments_link.jsp" %>
             <span>Edit Enrollment</span>
           </div>
           <div class="head">
@@ -203,7 +203,14 @@
                 <c:otherwise>
                   <div class="buttonBox">
                     <input type="hidden" name="pageName" value="${pageName}"/>
-                    <c:url var="cancelUrl" value="/provider/dashboard/drafts"/>
+                    <c:choose>
+                      <c:when test="${isServiceAdministrator}">
+                        <c:url var="cancelUrl" value="/provider/enrollments/all"/>
+                      </c:when>
+                      <c:otherwise>
+                        <c:url var="cancelUrl" value="/provider/dashboard/drafts"/>
+                      </c:otherwise>
+                    </c:choose>
                     <a class="greyBtn" href="${cancelUrl}">
                       Cancel
                     </a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
@@ -24,7 +24,7 @@
           <c:choose>
             <c:when test="${isRenewalEnrollment}">
               <div class="breadCrumb">
-                <a href="<c:url value="/provider/dashboard/drafts" />">Enrollments</a>
+                <%@ include file="/WEB-INF/pages/admin/includes/enrollments_link.jsp" %>
                 <span>Enrollment Renewal</span>
               </div>
               <div class="head">
@@ -36,7 +36,7 @@
             </c:when>
             <c:otherwise>
               <div class="breadCrumb">
-                <a href="<c:url value="/provider/dashboard/drafts" />">Enrollments</a>
+                <%@ include file="/WEB-INF/pages/admin/includes/enrollments_link.jsp" %>
                 <span>Register New Enrollment</span>
               </div>
               <div class="head">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
@@ -21,7 +21,7 @@
           </div>
           <!-- /.mainNav -->
           <div class="breadCrumb">
-            <a href="<c:url value="/provider/dashboard/list" />">Enrollments</a>
+            <%@ include file="/WEB-INF/pages/admin/includes/enrollments_link.jsp" %>
             <span>View Enrollment Details</span>
           </div>
 

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -505,12 +505,15 @@ input.date{
 .generalTable th.tablesorter-headerSortUp .sort{
   background:url(../i/icon-sort-down.png) no-repeat left center;
 }
-.generalTable tr td{
-  padding:5px 10px;
+.generalTable tr td {
+  padding: 5px 0px 5px 10px;
   vertical-align:middle;
 }
 .generalTable tr.even td{
   background:#ecf2f3;
+}
+.generalTable tr td.tdCheckbox {
+  padding-left: 0px;
 }
 .generalTable tr td.alignCenter{
   text-align:center;
@@ -2370,16 +2373,11 @@ input.date{
   width:60%;
 }
 
-#enrollmentSection #tabAll .generalTable tr td {
-  padding:5px;
-}
-
-#enrollmentSection #tabAll .generalTable tr th.twoline {
-  vertical-align:top;
+.generalTable tr th.twoline {
   line-height:13px;
 }
 
-#enrollmentSection #tabAll .generalTable tr th.twoline a {
+.generalTable tr th.twoline a {
   width:auto;
   display:inline-block;
   padding:2px 0;
@@ -2469,15 +2467,6 @@ input.date{
   text-indent:20px;
   /* text shadow */
   text-shadow:#ffffff 0 2px 0;
-}
-
-#searchResultsSection .tableContainer #resultsTable th,
-.table-enrollment-all-sort th {
-  padding:0 0 0 5px;
-}
-
-#searchResultsSection .tableContainer #resultsTable td{
-  padding:5px;
 }
 
 /* Advanced Search */
@@ -2769,6 +2758,12 @@ a.searchBtn {
 }
 
 /* writeNotesModal */
+
+.writeNotes,
+.viewNotes {
+  white-space: nowrap;
+}
+
 #writeNotesModal{
   width:564px;
 }
@@ -3665,9 +3660,6 @@ a.okBtn {
   padding-left: 5px;
 }
 
-#searchResultsSection .tableContainer #resultsTable td{
-  padding: 10px 5px;
-}
 .fileWrapper{
   width:100px;
 }
@@ -3876,12 +3868,6 @@ input.text{
 }
 #tabServiceAgents .detailPanel .row {
   padding: 2px 0;
-}
-#serviceAdminresultsTable th{
-  padding:0 0 0 5px;
-}
-#serviceAdminresultsTable td{
-  padding:10px 5px;
 }
 .detailPanel .green{
   font-size:14px;

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -2370,16 +2370,16 @@ input.date{
   width:60%;
 }
 
-#enrollmentSection #tabNotes .generalTable tr td{
+#enrollmentSection #tabAll .generalTable tr td {
   padding:5px;
 }
 
-#enrollmentSection #tabNotes .generalTable tr th.towline{
+#enrollmentSection #tabAll .generalTable tr th.twoline {
   vertical-align:top;
   line-height:13px;
 }
 
-#enrollmentSection #tabNotes .generalTable tr th.towline a{
+#enrollmentSection #tabAll .generalTable tr th.twoline a {
   width:auto;
   display:inline-block;
   padding:2px 0;
@@ -2472,7 +2472,7 @@ input.date{
 }
 
 #searchResultsSection .tableContainer #resultsTable th,
-.table-enrollment-notes-sort th{
+.table-enrollment-all-sort th {
   padding:0 0 0 5px;
 }
 

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -7,34 +7,41 @@
             <a href="{{ctx}}/system/user/list">USER ACCOUNTS</a>
             {{#if hasArrow}}<span class="arrow"></span>{{/if}}
           </li>
-        {{else}}
+        {{else if isServiceAdministrator}}
           <li class="{{#if activeTabDashboard }} active {{/if}}">
             <a href="{{ctx}}/landing">DASHBOARD</a>
             {{#if activeTabDashboard }} <span class="arrow"></span> {{/if}}
           </li>
-
           <li class="{{#if activeTabEnrollments }} active {{/if}}">
             <a class="enrollmentsLink" href="{{ctx}}/provider/dashboard/drafts">ENROLLMENTS</a>
             {{#if activeTabEnrollments }} <span class="arrow"></span> {{/if}}
           </li>
-
-          {{#if isServiceAdministrator}}
-            <li class="{{#if activeTabScreenings }} active {{/if}}">
-              <a class="screeningsLink" href="{{ctx}}/agent/screenings">SCREENINGS</a>
-              {{#if activeTabScreenings }} <span class="arrow"></span> {{/if}}
-            </li>
-
-            <li class="{{#if activeTabReports }} active {{/if}}">
-              <a class="reportsLink" href="{{ctx}}/admin/reports">REPORTS</a>
-              {{#if activeTabReports }} <span class="arrow"></span> {{/if}}
-            </li>
-
-            <li class="{{#if activeTabFunctions }} active {{/if}}">
-              <a class="functionsLink" href="{{ctx}}/admin/viewProviderTypes">FUNCTIONS</a>
-              {{#if activeTabFunctions }} <span class="arrow"></span> {{/if}}
-            </li>
-          {{/if}}
-
+          <li class="{{#if activeTabScreenings }} active {{/if}}">
+            <a class="screeningsLink" href="{{ctx}}/agent/screenings">SCREENINGS</a>
+            {{#if activeTabScreenings }} <span class="arrow"></span> {{/if}}
+          </li>
+          <li class="{{#if activeTabReports }} active {{/if}}">
+            <a class="reportsLink" href="{{ctx}}/admin/reports">REPORTS</a>
+            {{#if activeTabReports }} <span class="arrow"></span> {{/if}}
+          </li>
+          <li class="{{#if activeTabFunctions }} active {{/if}}">
+            <a class="functionsLink" href="{{ctx}}/admin/viewProviderTypes">FUNCTIONS</a>
+            {{#if activeTabFunctions }} <span class="arrow"></span> {{/if}}
+          </li>
+          <li class="last {{#if activeTabProfile }} active {{/if}}">
+            <a href="{{ctx}}/myprofile" id="my_profile_tab">MY PROFILE</a>
+            {{#if activeTabProfile }} <span class="arrow"></span> {{/if}}
+          </li>
+        {{else}}
+          {{!-- Provider --}}
+          <li class="{{#if activeTabDashboard }} active {{/if}}">
+            <a href="{{ctx}}/landing">DASHBOARD</a>
+            {{#if activeTabDashboard }} <span class="arrow"></span> {{/if}}
+          </li>
+          <li class="{{#if activeTabEnrollments }} active {{/if}}">
+            <a class="enrollmentsLink" href="{{ctx}}/provider/dashboard/drafts">ENROLLMENTS</a>
+            {{#if activeTabEnrollments }} <span class="arrow"></span> {{/if}}
+          </li>
           <li class="last {{#if activeTabProfile }} active {{/if}}">
             <a href="{{ctx}}/myprofile" id="my_profile_tab">MY PROFILE</a>
             {{#if activeTabProfile }} <span class="arrow"></span> {{/if}}

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -13,7 +13,7 @@
             {{#if activeTabDashboard }} <span class="arrow"></span> {{/if}}
           </li>
           <li class="{{#if activeTabEnrollments }} active {{/if}}">
-            <a class="enrollmentsLink" href="{{ctx}}/provider/dashboard/drafts">ENROLLMENTS</a>
+            <a class="enrollmentsLink" href="{{ctx}}/provider/enrollments/all?showFilterPanel=true">ENROLLMENTS</a>
             {{#if activeTabEnrollments }} <span class="arrow"></span> {{/if}}
           </li>
           <li class="{{#if activeTabScreenings }} active {{/if}}">

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -658,16 +658,16 @@ public class EnrollmentController extends BaseController {
         ModelAndView mv = new ModelAndView(viewName, "results", results);
         if (criteria.getStatuses() == null || criteria.getStatuses().isEmpty()) {
             mv.addObject("Status", "");
-            // populate notes
-
-            List<UserRequest> items = results.getItems();
-            if (items != null) {
-                for (UserRequest item : items) {
-                    item.setNotes(enrollmentService.findNotes(item.getTicketId()));
-                }
-            }
         } else {
             mv.addObject("Status", criteria.getStatuses().get(0));
+        }
+
+        // populate notes
+        List<UserRequest> items = results.getItems();
+        if (items != null) {
+            for (UserRequest item : items) {
+                item.setNotes(enrollmentService.findNotes(item.getTicketId()));
+            }
         }
 
         // load all actions that can be performed by user, JSP should check that processInstanceId are equal

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -121,14 +121,14 @@ $(document).ready(function () {
   }
 
   var profileIdForWritingNotes = 0;
-  $('.writeNotes').live('click', function () {
+  $('.writeNotes').click(function () {
     closeModal();
     $('#writeNotesModal .textarea').val('Write your note here...');
     profileIdForWritingNotes = $(this).attr("rel");
     loadModal('#writeNotesModal');
   });
 
-  $('#saveNote').live('click', function () {
+  $('#saveNote').click(function () {
     if (!screenLock) {
       screenLock = true;
     }
@@ -148,10 +148,16 @@ $(document).ready(function () {
           success: function (data) {
             closeModal();
             if (data.success) {
-              $("#notesSection").append('<span class="note_' + profileIdForWritingNotes + '" id="note_' + profileIdForWritingNotes + '_' + ($(".note_" + profileIdForWritingNotes).size() + 1) + '">' + input + '</span>');
-              $("a[rel='" + profileIdForWritingNotes + "'].viewNotes").removeClass("disabledLink");
-              $("a[rel='" + profileIdForWritingNotes + "'].viewNotes").removeClass("hide");
-              $("a[rel='" + profileIdForWritingNotes + "'].viewNotes").next().removeClass("hide");
+              var nextCount = $(".note_" + profileIdForWritingNotes).size() + 1;
+              $("#notesSection").append(
+                '<span class="note_' + profileIdForWritingNotes +
+                '" id="note_' + profileIdForWritingNotes + '_' + nextCount +
+                '">' + input + '</span>'
+              );
+              var viewLink = $("a[rel='" + profileIdForWritingNotes + "'].viewNotes");
+              viewLink.removeClass("disabledLink");
+              viewLink.removeClass("hide");
+              viewLink.next().removeClass("hide");
             } else {
               alert(data.message);
             }
@@ -165,7 +171,7 @@ $(document).ready(function () {
 
   var enrollmentIdForNotes = 0;
   var currentShowingNoteCount = 1;
-  $('.viewNotes').live('click', function () {
+  $('.viewNotes').click(function () {
     if ($(this).hasClass('disabledLink')) {
       return false;
     }
@@ -177,12 +183,12 @@ $(document).ready(function () {
     loadModal('#viewNotesModal');
   });
 
-  $("#nextNote").live("click", function () {
+  $("#nextNote").click(function () {
     currentShowingNoteCount++;
     showNoteBody();
   });
 
-  $("#preNote").live("click", function () {
+  $("#prevNote").click(function () {
     currentShowingNoteCount--;
     showNoteBody();
   });
@@ -196,20 +202,20 @@ $(document).ready(function () {
     }
 
     if ($("#note_" + enrollmentIdForNotes + "_" + (currentShowingNoteCount - 1)).size() == 0) {
-      $("#preNote").hide();
+      $("#prevNote").hide();
     } else {
-      $("#preNote").show();
+      $("#prevNote").show();
     }
   }
 
   //Textarea
-  $('#writeNotesModal .textarea').live('focus', function () {
+  $('#writeNotesModal .textarea').on('focus', function () {
     if ($(this).val() == 'Write your note here...') {
       $(this).val('');
     }
   });
 
-  $('#writeNotesModal .textarea').live('blur', function () {
+  $('#writeNotesModal .textarea').on('blur', function () {
     if ($(this).val() == '') {
       $(this).val('Write your note here...');
     }
@@ -1184,17 +1190,6 @@ $(document).ready(function () {
     closeModal();
   });
 
-  //Textarea
-  $('#writeNotesModal .textarea').live('focus', function () {
-    $(this).val('');
-  });
-
-  $('#writeNotesModal .textarea').live('blur', function () {
-    if ($(this).val() == '') {
-      $(this).val('Write your note here...');
-    }
-  });
-
   //Next Button
   $('.createEnrollmentBtn').live('click', function () {
     if ($('#createEnrollment .newEnrollment').attr('checked')) {
@@ -1218,16 +1213,6 @@ $(document).ready(function () {
     }
   });
 
-  /*
-  $('.writeNotes').live('click',function(){
-   closeModal();
-   loadModal('#writeNotesModal');
-  });
-  $('.viewNotes').live('click',function(){
-   closeModal();
-   loadModal('#viewNotesModal');
-  });
-   */
   $('.newEnrollmentSaveDraftBtn').live('click', function () {
     closeModal();
     loadModal('#saveDraftModal');

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -994,18 +994,6 @@ $(document).ready(function () {
   /* START OF SERVICE AGENT SCRIPT ------------------------------------------------ */
 
   /*
-  $('.table-enrollment-sort').tablesorter({
-   headers:{0:{ sorter: false},8:{ sorter: false}},
-   widgets        : ['zebra', 'columns'],
-   usNumberFormat : false,
-   sortRestart    : true
-  });
-  $('.table-enrollment-all-sort').tablesorter({
-   headers:{0:{ sorter: false},8:{ sorter: false},9:{ sorter: false}},
-   widgets        : ['zebra', 'columns'],
-   usNumberFormat : false,
-   sortRestart    : true
-  });
   $('#resultsTable').tablesorter({
    headers:{0:{ sorter: false},9:{ sorter: false}},
    widgets        : ['zebra', 'columns'],

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -151,7 +151,7 @@ $(document).ready(function () {
               $("#notesSection").append('<span class="note_' + profileIdForWritingNotes + '" id="note_' + profileIdForWritingNotes + '_' + ($(".note_" + profileIdForWritingNotes).size() + 1) + '">' + input + '</span>');
               $("a[rel='" + profileIdForWritingNotes + "'].viewNotes").removeClass("disabledLink");
               $("a[rel='" + profileIdForWritingNotes + "'].viewNotes").removeClass("hide");
-              $("a[rel='" + profileIdForWritingNotes + "'].viewNotes").prev().removeClass("hide");
+              $("a[rel='" + profileIdForWritingNotes + "'].viewNotes").next().removeClass("hide");
             } else {
               alert(data.message);
             }

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -1000,7 +1000,7 @@ $(document).ready(function () {
    usNumberFormat : false,
    sortRestart    : true
   });
-  $('.table-enrollment-notes-sort').tablesorter({
+  $('.table-enrollment-all-sort').tablesorter({
    headers:{0:{ sorter: false},8:{ sorter: false},9:{ sorter: false}},
    widgets        : ['zebra', 'columns'],
    usNumberFormat : false,

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -892,7 +892,7 @@ $(document).ready(function () {
     usNumberFormat: false,
     sortRestart: true
   });
-  $('.table-enrollment-notes-sort').tablesorter({
+  $('.table-enrollment-all-sort').tablesorter({
     headers: { 0: { sorter: false }, 8: { sorter: false }, 9: { sorter: false } },
     widgets: ['zebra', 'columns'],
     usNumberFormat: false,
@@ -1307,7 +1307,7 @@ $(document).ready(function () {
     if ($('.dashboardTable').length > 0)$('.dashboardTable').trigger("update");
     if ($('#draftEnrollmentTable').length > 0)$('#draftEnrollmentTable').trigger("update");
     if ($('.table-enrollment-sort').length > 0)$('.table-enrollment-sort').trigger("update");
-    if ($('.table-enrollment-notes-sort').length > 0)$('.table-enrollment-notes-sort').trigger("update");
+    if ($('.table-enrollment-all-sort').length > 0)$('.table-enrollment-all-sort').trigger("update");
     if ($('#resultsTable').length > 0)$('#resultsTable').trigger("update");
     if ($('#userAccountsTab .generalTable').length > 0)$('#userAccountsTab .generalTable').trigger("update");
     if ($('#userAccountResultsTable').length > 0)$('#userAccountResultsTable').trigger("update");

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -886,18 +886,6 @@ $(document).ready(function () {
     usNumberFormat: false,
     sortRestart: true
   });
-  $('.table-enrollment-sort').tablesorter({
-    headers: { 0: { sorter: false }, 8: { sorter: false } },
-    widgets: ['zebra', 'columns'],
-    usNumberFormat: false,
-    sortRestart: true
-  });
-  $('.table-enrollment-all-sort').tablesorter({
-    headers: { 0: { sorter: false }, 8: { sorter: false }, 9: { sorter: false } },
-    widgets: ['zebra', 'columns'],
-    usNumberFormat: false,
-    sortRestart: true
-  });
   $('#resultsTable').tablesorter({
     headers: { 0: { sorter: false }, 9: { sorter: false } },
     widgets: ['zebra', 'columns'],
@@ -1306,8 +1294,6 @@ $(document).ready(function () {
     if ($('#draftTable').length > 0)$('#draftTable').trigger("update");
     if ($('.dashboardTable').length > 0)$('.dashboardTable').trigger("update");
     if ($('#draftEnrollmentTable').length > 0)$('#draftEnrollmentTable').trigger("update");
-    if ($('.table-enrollment-sort').length > 0)$('.table-enrollment-sort').trigger("update");
-    if ($('.table-enrollment-all-sort').length > 0)$('.table-enrollment-all-sort').trigger("update");
     if ($('#resultsTable').length > 0)$('#resultsTable').trigger("update");
     if ($('#userAccountsTab .generalTable').length > 0)$('#userAccountsTab .generalTable').trigger("update");
     if ($('#userAccountResultsTable').length > 0)$('#userAccountResultsTable').trigger("update");

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1053,17 +1053,6 @@ $(document).ready(function () {
     closeModal();
   });
 
-  //Textarea
-  $('#writeNotesModal .textarea').live('focus', function () {
-    $(this).val('');
-  });
-
-  $('#writeNotesModal .textarea').live('blur', function () {
-      if ($(this).val() == '') {
-        $(this).val('Write your note here...');
-      }
-    });
-
   //Next Button
   $('.createEnrollmentBtn').live('click', function () {
     if ($('#createEnrollment .newEnrollment').attr('checked')) {
@@ -1086,16 +1075,6 @@ $(document).ready(function () {
       }
     }
   });
-
-  $('.writeNotes').live('click', function () {
-    closeModal();
-    loadModal('#writeNotesModal');
-  });
-
-  $('.viewNotes').live('click', function () {
-      closeModal();
-      loadModal('#viewNotesModal');
-    });
 
   $('.newEnrollmentSaveDraftBtn').live('click', function () {
       closeModal();

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -570,7 +570,7 @@ $(document).ready(function () {
     usNumberFormat: false,
     sortRestart: true
   });
-  $('.table-enrollment-notes-sort').tablesorter({
+  $('.table-enrollment-all-sort').tablesorter({
     headers: { 0: { sorter: false }, 8: { sorter: false }, 9: { sorter: false } },
     widgets: ['zebra', 'columns'],
     usNumberFormat: false,
@@ -1018,7 +1018,7 @@ $(document).ready(function () {
     if ($('.dashboardTable').length > 0)$('.dashboardTable').trigger("update");
     if ($('#draftEnrollmentTable').length > 0)$('#draftEnrollmentTable').trigger("update");
     if ($('.table-enrollment-sort').length > 0)$('.table-enrollment-sort').trigger("update");
-    if ($('.table-enrollment-notes-sort').length > 0)$('.table-enrollment-notes-sort').trigger("update");
+    if ($('.table-enrollment-all-sort').length > 0)$('.table-enrollment-all-sort').trigger("update");
     if ($('#resultsTable').length > 0)$('#resultsTable').trigger("update");
     if ($('#userAccountsTab .generalTable').length > 0)$('#userAccountsTab .generalTable').trigger("update");
     if ($('#userAccountResultsTable').length > 0)$('#userAccountResultsTable').trigger("update");

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -742,17 +742,6 @@ $(document).ready(function () {
     closeModal();
   });
 
-  //Textarea
-  $('#writeNotesModal .textarea').live('focus', function () {
-    $(this).val('');
-  });
-
-  $('#writeNotesModal .textarea').live('blur', function () {
-    if ($(this).val() == '') {
-      $(this).val('Write your note here...');
-    }
-  });
-
   //Next Button
   $('.createEnrollmentBtn').live('click', function () {
     if ($('#createEnrollment .newEnrollment').attr('checked')) {
@@ -774,16 +763,6 @@ $(document).ready(function () {
         window.location.href = 'renewal-enrollment-payment-service-agent-personal.html';
       }
     }
-  });
-
-  $('.writeNotes').live('click', function () {
-    closeModal();
-    loadModal('#writeNotesModal');
-  });
-
-  $('.viewNotes').live('click', function () {
-    closeModal();
-    loadModal('#viewNotesModal');
   });
 
   $('.newEnrollmentSaveDraftBtn').live('click', function () {

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -564,18 +564,6 @@ $(document).ready(function () {
     usNumberFormat: false,
     sortRestart: true
   });
-  $('.table-enrollment-sort').tablesorter({
-    headers: { 0: { sorter: false }, 8: { sorter: false } },
-    widgets: ['zebra', 'columns'],
-    usNumberFormat: false,
-    sortRestart: true
-  });
-  $('.table-enrollment-all-sort').tablesorter({
-    headers: { 0: { sorter: false }, 8: { sorter: false }, 9: { sorter: false } },
-    widgets: ['zebra', 'columns'],
-    usNumberFormat: false,
-    sortRestart: true
-  });
   $('#resultsTable').tablesorter({
     headers: { 0: { sorter: false }, 9: { sorter: false } },
     widgets: ['zebra', 'columns'],
@@ -1017,8 +1005,6 @@ $(document).ready(function () {
     if ($('#draftTable').length > 0)$('#draftTable').trigger("update");
     if ($('.dashboardTable').length > 0)$('.dashboardTable').trigger("update");
     if ($('#draftEnrollmentTable').length > 0)$('#draftEnrollmentTable').trigger("update");
-    if ($('.table-enrollment-sort').length > 0)$('.table-enrollment-sort').trigger("update");
-    if ($('.table-enrollment-all-sort').length > 0)$('.table-enrollment-all-sort').trigger("update");
     if ($('#resultsTable').length > 0)$('#resultsTable').trigger("update");
     if ($('#userAccountsTab .generalTable').length > 0)$('#userAccountsTab .generalTable').trigger("update");
     if ($('#userAccountResultsTable').length > 0)$('#userAccountResultsTable').trigger("update");

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/DashboardStepDefinitions.java
@@ -8,29 +8,24 @@ public class DashboardStepDefinitions {
     @Steps
     GeneralSteps generalSteps;
 
-    @When("^I am on the Draft page$")
-    public void i_am_on_the_draft_page() {
-        generalSteps.navigateToDraftPage();
+    @When("^I am on the provider Draft page$")
+    public void i_am_on_the_provider_draft_page() {
+        generalSteps.goToProviderDraftPage();
     }
 
-    @When("^I am on the Pending page$")
-    public void i_am_on_the_pending_page() {
-        generalSteps.navigateToPendingPage();
+    @When("^I am on the provider Pending page$")
+    public void i_am_on_the_provider_pending_page() {
+        generalSteps.goToProviderPendingPage();
     }
 
-    @When("^I am on the Approved page$")
-    public void i_am_on_the_approved_page() {
-        generalSteps.navigateToApprovedPage();
+    @When("^I am on the provider Approved page$")
+    public void i_am_on_the_provider_approved_page() {
+        generalSteps.goToProviderApprovedPage();
     }
 
-    @When("^I am on the Denied page$")
-    public void i_am_on_the_denied_page() {
-        generalSteps.navigateToDeniedPage();
-    }
-
-    @When("^I am on the Notes page$")
-    public void i_am_on_the_notes_page() {
-        generalSteps.navigateToNotesPage();
+    @When("^I am on the provider Denied page$")
+    public void i_am_on_the_provider_denied_page() {
+        generalSteps.goToProviderDeniedPage();
     }
 
     @When("^I open the filter panel$")

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -55,32 +55,26 @@ public class GeneralSteps {
     }
 
     @Step
-    public void navigateToDraftPage() {
+    public void goToProviderDraftPage() {
         clickLinkAssertTitle(".enrollmentsLink", "Draft Enrollments");
     }
 
     @Step
-    public void navigateToPendingPage() {
-        navigateToDraftPage();
+    public void goToProviderPendingPage() {
+        goToProviderDraftPage();
         clickLinkAssertTitle(".pendingTab", "Pending Enrollments");
     }
 
     @Step
-    public void navigateToApprovedPage() {
-        navigateToDraftPage();
+    public void goToProviderApprovedPage() {
+        goToProviderDraftPage();
         clickLinkAssertTitle(".approvedTab", "Approved Enrollments");
     }
 
     @Step
-    public void navigateToDeniedPage() {
-        navigateToDraftPage();
+    public void goToProviderDeniedPage() {
+        goToProviderDraftPage();
         clickLinkAssertTitle(".deniedTab", "Denied Enrollments");
-    }
-
-    @Step
-    public void navigateToNotesPage() {
-        navigateToDraftPage();
-        clickLinkAssertTitle(".notesTab", "Notes");
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -19,6 +19,31 @@ public class AdminStepDefinitions {
         generalSteps.login("admin", "admin");
     }
 
+    @When("^I am on the admin All Enrollments page$")
+    public void i_am_on_the_admin_all_enrollments_page() {
+        adminSteps.goToAdminAllEnrollmentsPage();
+    }
+
+    @When("^I am on the admin Draft page$")
+    public void i_am_on_the_admin_draft_page() {
+        adminSteps.goToAdminDraftPage();
+    }
+
+    @When("^I am on the admin Pending page$")
+    public void i_am_on_the_admin_pending_page() {
+        adminSteps.goToAdminPendingPage();
+    }
+
+    @When("^I am on the admin Approved page$")
+    public void i_am_on_the_admin_approved_page() {
+        adminSteps.goToAdminApprovedPage();
+    }
+
+    @When("^I am on the admin Denied page$")
+    public void i_am_on_the_admin_denied_page() {
+        adminSteps.goToAdminDeniedPage();
+    }
+
     @When("^I open the Write Note modal$")
     public void i_open_the_write_note_modal() {
         adminSteps.openWriteNoteModal();
@@ -26,20 +51,20 @@ public class AdminStepDefinitions {
 
     @When("^I am on the COS page$")
     public void i_am_on_the_cos_page() {
-        generalSteps.navigateToDraftPage();
+        adminSteps.goToAdminDraftPage();
         generalSteps.clickLinkAssertTitle(".cosLink", "Category of Service");
     }
 
     @When("^I am on the Print Enrollment page$")
     public void i_am_on_the_print_enrollment_page() {
-        generalSteps.navigateToDraftPage();
+        adminSteps.goToAdminAllEnrollmentsPage();
         // assert fails because print page is opened in a new window
         generalSteps.clickLinkAssertTitle(".printEnrollment", "View Enrollment");
     }
 
     @When("^I am on the Review Enrollment page$")
     public void i_am_on_the_review_enrollment_page() {
-        generalSteps.navigateToPendingPage();
+        adminSteps.goToAdminPendingPage();
         generalSteps.clickLinkAssertTitle(".reviewLink", "Review Enrollment");
     }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
@@ -3,8 +3,10 @@ package gov.medicaid.features.service_admin.steps;
 import gov.medicaid.features.PsmPage;
 import gov.medicaid.features.enrollment.ui.OrganizationInfoPage;
 
+import gov.medicaid.features.general.steps.GeneralSteps;
 import net.thucydides.core.annotations.Step;
 
+import net.thucydides.core.annotations.Steps;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -13,9 +15,40 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("unused")
 public class AdminSteps {
 
-    private PsmPage psmPage;
+    @Steps
+    GeneralSteps generalSteps;
 
+    private PsmPage psmPage;
     private OrganizationInfoPage organizationInfoPage;
+
+    @Step
+    public void goToAdminAllEnrollmentsPage() {
+        generalSteps.clickLinkAssertTitle(".enrollmentsLink", "All Enrollments");
+    }
+
+    @Step
+    public void goToAdminDraftPage() {
+        goToAdminAllEnrollmentsPage();
+        generalSteps.clickLinkAssertTitle(".draftTab", "Draft Enrollments");
+    }
+
+    @Step
+    public void goToAdminPendingPage() {
+        goToAdminAllEnrollmentsPage();
+        generalSteps.clickLinkAssertTitle(".pendingTab", "Pending Enrollments");
+    }
+
+    @Step
+    public void goToAdminApprovedPage() {
+        goToAdminAllEnrollmentsPage();
+        generalSteps.clickLinkAssertTitle(".approvedTab", "Approved Enrollments");
+    }
+
+    @Step
+    public void goToAdminDeniedPage() {
+        goToAdminAllEnrollmentsPage();
+        generalSteps.clickLinkAssertTitle(".deniedTab", "Denied Enrollments");
+    }
 
     @Step
     public void openWriteNoteModal() {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ViewEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ViewEnrollmentStepDefinitions.java
@@ -14,7 +14,7 @@ public class ViewEnrollmentStepDefinitions {
 
     @When("^I am on the View Enrollment Organization Info page$")
     public void i_am_on_the_view_enrollment_organization_info_page() {
-        generalSteps.navigateToPendingPage();
+        adminSteps.goToAdminPendingPage();
         adminSteps.advanceFromPendingPageToViewOrganizationInfoPage();
     }
 

--- a/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/accessibility.feature
@@ -21,28 +21,28 @@ Feature: General Accessibility Checks
 
   Scenario: Provider Draft Page
     Given I am logged in as a provider
-    And I am on the Draft page
+    And I am on the provider Draft page
     When I open the filter panel
     Then I should have no accessibility issues
     And I should see enrollments
 
   Scenario: Provider Pending Page
     Given I am logged in as a provider
-    And I am on the Pending page
+    And I am on the provider Pending page
     When I open the filter panel
     Then I should have no accessibility issues
     And I should see enrollments
 
   Scenario: Provider Approved Page
     Given I am logged in as a provider
-    And I am on the Approved page
+    And I am on the provider Approved page
     When I open the filter panel
     Then I should have no accessibility issues
     And I should see enrollments
 
   Scenario: Provider Denied Page
     Given I am logged in as a provider
-    And I am on the Denied page
+    And I am on the provider Denied page
     When I open the filter panel
     Then I should have no accessibility issues
     And I should see enrollments

--- a/psm-app/integration-tests/src/test/resources/features/general/search.feature
+++ b/psm-app/integration-tests/src/test/resources/features/general/search.feature
@@ -4,7 +4,7 @@ Feature: Provider Search Checks
 
   Scenario: Provider Draft Page Filtered
     Given I am logged in as a provider
-    And I am on the Draft page
+    And I am on the provider Draft page
     When I open the filter panel
     And I filter by NPI '1111111112'
     Then I should have no errors
@@ -12,7 +12,7 @@ Feature: Provider Search Checks
 
   Scenario: Provider Pending Page Filtered
     Given I am logged in as a provider
-    And I am on the Pending page
+    And I am on the provider Pending page
     When I open the filter panel
     And I filter by NPI '1111111112'
     Then I should have no errors
@@ -20,7 +20,7 @@ Feature: Provider Search Checks
 
   Scenario: Provider Approved Page Filtered
     Given I am logged in as a provider
-    And I am on the Approved page
+    And I am on the provider Approved page
     When I open the filter panel
     And I filter by NPI '1111111112'
     Then I should have no errors
@@ -28,7 +28,7 @@ Feature: Provider Search Checks
 
   Scenario: Provider Denied Page Filtered
     Given I am logged in as a provider
-    And I am on the Denied page
+    And I am on the provider Denied page
     When I open the filter panel
     And I filter by NPI '1111111112'
     Then I should have no errors

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -8,41 +8,41 @@ Feature: General Accessibility Checks for Admins
     Given I am logged in as an admin
     Then I should have no accessibility issues
 
+  # fails: <textarea> form input in the notes modal needs a label
+  @ignore
+  Scenario: Admin All Enrollments Page
+    Given I am logged in as an admin
+    And I am on the admin All Enrollments page
+    And I open the filter panel
+    And I open the Write Note modal
+    Then I should have no accessibility issues
+    And I should see enrollments
+
   Scenario: Admin Draft Page
     Given I am logged in as an admin
-    And I am on the Draft page
+    And I am on the admin Draft page
     And I open the filter panel
     Then I should have no accessibility issues
     And I should see enrollments
 
   Scenario: Admin Pending Page
     Given I am logged in as an admin
-    And I am on the Pending page
+    And I am on the admin Pending page
     And I open the filter panel
     Then I should have no accessibility issues
     And I should see enrollments
 
   Scenario: Admin Approved Page
     Given I am logged in as an admin
-    And I am on the Approved page
+    And I am on the admin Approved page
     And I open the filter panel
     Then I should have no accessibility issues
     And I should see enrollments
 
   Scenario: Admin Denied Page
     Given I am logged in as an admin
-    And I am on the Denied page
+    And I am on the admin Denied page
     And I open the filter panel
-    Then I should have no accessibility issues
-    And I should see enrollments
-
-  # fails: duplicate IDs
-  @ignore
-  Scenario: Admin Notes Page
-    Given I am logged in as an admin
-    And I am on the Notes page
-    And I open the filter panel
-    And I open the Write Note modal
     Then I should have no accessibility issues
     And I should see enrollments
 

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/search.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/search.feature
@@ -4,9 +4,19 @@ Feature: Admin Search Checks
 
   # Issue 914
   @ignore
+  Scenario: Admin All Enrollments Page Filtered
+    Given I am logged in as an admin
+    And I am on the admin All Enrollments page
+    When I open the filter panel
+    And I filter by NPI '1111111112'
+    Then I should have no errors
+    And I should see search results
+
+  # Issue 914
+  @ignore
   Scenario: Admin Draft Page Filtered
     Given I am logged in as an admin
-    And I am on the Draft page
+    And I am on the admin Draft page
     When I open the filter panel
     And I filter by NPI '1111111112'
     Then I should have no errors
@@ -16,7 +26,7 @@ Feature: Admin Search Checks
   @ignore
   Scenario: Admin Pending Page Filtered
     Given I am logged in as an admin
-    And I am on the Pending page
+    And I am on the admin Pending page
     When I open the filter panel
     And I filter by NPI '1111111112'
     Then I should have no errors
@@ -26,7 +36,7 @@ Feature: Admin Search Checks
   @ignore
   Scenario: Admin Approved Page Filtered
     Given I am logged in as an admin
-    And I am on the Approved page
+    And I am on the admin Approved page
     When I open the filter panel
     And I filter by NPI '1111111112'
     Then I should have no errors
@@ -36,17 +46,7 @@ Feature: Admin Search Checks
   @ignore
   Scenario: Admin Denied Page Filtered
     Given I am logged in as an admin
-    And I am on the Denied page
-    When I open the filter panel
-    And I filter by NPI '1111111112'
-    Then I should have no errors
-    And I should see search results
-
-  # Issue 914
-  @ignore
-  Scenario: Admin Notes Page Filtered
-    Given I am logged in as an admin
-    And I am on the Notes page
+    And I am on the admin Denied page
     When I open the filter panel
     And I filter by NPI '1111111112'
     Then I should have no errors


### PR DESCRIPTION
Change the Notes tab (on the service admin Enrollments pages) to an All Enrollments tab, and move it to the front, before the Draft tab.  Make it the new default tab when you click "Enrollments" in the main navigation menu (instead of the Draft tab).  Add a "Status" column and remove the "Notes" column in the All Enrollments table.  Move the links to create and view notes (that were in the Notes column) into the "Actions" column so they are accessible on any of these enrollments pages (and also the advanced search and quick search results pages).  Adjust spacing to make the Actions column wider.

Rationale: Having the Notes functionality restricted to the Notes tab was not a good UI design (see #766) but having a tab that showed all applications regardless of status (like the Notes tab did) was a good thing, and it makes sense to have that as the first/default tab.

(The current plan is for this notes functionality to be revised and/or replaced with the new mechanisms for providing feedback (see #950 #951 #952).  This PR prepares the way for further work in this area.)

Tested by navigating to service admin > enrollments and seeing the new All tab, and navigating between it and the other tabs.  Then creating and viewing notes in the different tabs, using the links under "Actions".  Also checking that this revised table appears and the notes links work correctly on the search results pages for advanced and quick search.

Notes tab (before):

![screenshot_2018-07-21 notes](https://user-images.githubusercontent.com/1091693/43084636-151d8194-8e67-11e8-8200-30fd4ca84555.png)

All tab (after):

![screenshot_2018-07-21 all enrollments](https://user-images.githubusercontent.com/1091693/43084657-1b1073d6-8e67-11e8-97d4-151642095a83.png)

Along the way this also fixes the formatting of the table header on the search results pages:

Before:
![screenshot_2018-07-21 advanced search 1](https://user-images.githubusercontent.com/1091693/43084732-431a2fac-8e67-11e8-905e-e01e65ed00a3.png)

After:
![screenshot_2018-07-21 advanced search](https://user-images.githubusercontent.com/1091693/43084744-48ef71da-8e67-11e8-93df-93d65da287df.png)

Resolves #766 Rework the admin enrollments Notes tab