### PR TITLE
842 fix show error on personal email address

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
@@ -4,6 +4,8 @@
 
 <%-- BUGR-9673 (optional NPI for some provider types) --%>
 <c:set var="requireNPI" value="${viewModel.tabModels[viewModel.currentTab].formSettings['Personal Information Form'].settings['requireNPI']}"></c:set>
+<c:set var="showEmailRequired" value="${requestScope['_02_showEmailRequired']}"/>
+
 
 <div class="newEnrollmentPanel">
     <div class="section">
@@ -64,10 +66,13 @@
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}" maxlength="10"/>
                 </span>
             </div>
-            <div class="row">
+            <div class="row ${showEmailRequired ? 'requireField' : ''}">
                 <c:set var="formName" value="_02_email"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="emailAddress">Email Address</label>
+                <label for="emailAddress">
+                    Email Address                  
+                    <span id="requireEmailAddressLabel" class="${showEmailRequired ? '' : 'hidden'} required">*</span>                    
+                </label>
                 <input id="emailAddress" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="50"/>
             </div>
             <div class="clearFixed"></div>

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -214,7 +214,7 @@ $(document).ready(function () {
   $('.stepWidget .lastStep').css('width', $('.stepWidget').width() - $('.stepWidget .personal').width() - $('.stepWidget .license').width() - $('.stepWidget .practice').width() - $('.stepWidget .payment').width() - $('.stepWidget .summary').width() - $('.stepWidget .ownership').width() - 2);
 
   //Save As Above
-  $('#sameAsAbove').live('click', function () {
+  $('#sameAsAbove').click(function () {
     contactFormElements = [
       '#contactName',
       '#contactEmail',
@@ -227,10 +227,14 @@ $(document).ready(function () {
       contactFormElements.forEach(function (element) {
         $(element).val('').addClass("disabled").prop('disabled', true);
       });
+
+      $('#requireEmailAddressLabel').removeClass('hidden');
     } else {
       contactFormElements.forEach(function (element) {
         $(element).val('').removeClass("disabled").prop('disabled', false);
       });
+
+      $('#requireEmailAddressLabel').addClass('hidden');
     }
   });
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -433,4 +433,9 @@ public class EnrollmentSteps {
     void closeSubmitModal() {
         enrollmentDetailsPage.closeSubmitModal();
     }
+
+    @Step
+    void enterEmptyEmailAddress() {
+        personalInfoPage.enterEmail("");
+    }
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
@@ -46,6 +46,16 @@ public class ValidationStepDefinitions {
         organizationInfoPage.clickNext();
     }
 
+    @When("^I check 'same as above' on the personal info page$")
+    public void i_check_same_as_above_on_the_personal_info_page() {
+        personalInfoPage.checkSameAsAbove();
+    }
+
+    @When("^I enter an empty email address on the personal info page$")
+    public void i_enter_an_empty_email_address_on_the_personal_info_page() {
+        enrollmentSteps.enterEmptyEmailAddress();
+    }
+
     @Then("^I should get an FEIN error$")
     public void i_should_get_an_fein_error() throws Exception {
         enrollmentSteps.checkForFeinError();
@@ -60,4 +70,14 @@ public class ValidationStepDefinitions {
     public void should_get_a_renewal_date_error() throws Exception {
         enrollmentSteps.checkForRenewalDateError();
     }
+
+    @Then("^I should get a same as above email error$")
+    public void should_get_a_same_as_above_email_error() throws Exception {
+        personalInfoPage.checkForSameAsAboveEmailError();
+    }
+
+    @Then("^I should see email address is required$")
+    public void should_see_email_address_is_required() throws Exception {
+        personalInfoPage.checkEmailAddressDisplaysAsRequired();
+}
 }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
@@ -15,6 +15,9 @@ public class PersonalInfoPage extends PsmPage {
     private static final String PROVIDER_TOO_YOUNG_ERROR_MESSAGE =
             "Provider age should be 18 or above during enrollment.";
 
+    private static final String SAME_AS_ABOVE_EMAIL_ERROR_MESSAGE =
+            "Email Address is required when same as above is checked.";
+
     public void enterDOB(LocalDate dateOfBirth) {
         $("[name=_02_dob]").type(format(dateOfBirth));
     }
@@ -54,5 +57,15 @@ public class PersonalInfoPage extends PsmPage {
     public void checkForTooYoungError() throws Exception {
         assertThat($(".errorInfo > ._02_dob").getText())
                 .contains(PROVIDER_TOO_YOUNG_ERROR_MESSAGE);
+    }
+
+    public void checkForSameAsAboveEmailError() throws Exception {
+        assertThat($(".errorInfo > ._02_email").getText())
+                .contains(SAME_AS_ABOVE_EMAIL_ERROR_MESSAGE);
+    }
+
+    public void checkEmailAddressDisplaysAsRequired() throws Exception {
+        assertThat($("#requireEmailAddressLabel.required") != null);
+        assertThat($("requireEmailAddressLabel.required.hidden") == null);
     }
 }

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/validation.feature
@@ -34,3 +34,21 @@ Feature: Form and Field Validations
     When I enter license info where renewal date is before issue date
     And I click 'next' on the license info page
     Then I should get a renewal date error
+
+  @issue_842
+  Scenario: Validate individual provider email address contact
+    Given I have started an enrollment
+    And I am on the personal info page
+    And I enter valid personal information
+    When I enter an empty email address on the personal info page
+    And I click 'next' on the personal info page
+    Then I should get a same as above email error
+
+  @issue_842
+  Scenario: Validate individual provider email address is required
+    Given I have started an enrollment
+    And I am on the personal info page
+    And I enter valid personal information
+    When I enter an empty email address on the personal info page
+    And I click 'next' on the personal info page
+    Then I should see email address is required

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
@@ -142,6 +142,7 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
         ContactInformationType enrollmentContact = XMLUtility.nsGetContactInformation(enrollment);
         if ("Y".equals(enrollment.getContactSameAsApplicant())) {
             attr(mv, "useProviderAsContact", "Y");
+            attr(mv, "showEmailRequired", Boolean.TRUE);
         } else {
             attr(mv, "contactName", enrollmentContact.getName());
             attr(mv, "contactEmail", enrollmentContact.getEmailAddress());
@@ -150,6 +151,7 @@ public class PersonalInformationFormBinder extends BaseFormBinder implements For
             attr(mv, "contactPhone2", phone[1]);
             attr(mv, "contactPhone3", phone[2]);
             attr(mv, "contactPhone4", phone[3]);
+            attr(mv, "showEmailRequired", Boolean.FALSE);
         }
     }
 


### PR DESCRIPTION
On both the 'Register New' and the edit existing enrollment application pages (for individual providers), > personal info tab. Display the 'Personal Email Address' input field as required when the 'Same as Above' input field is checked.

This pull request also adds serenity tests verifying the 'Personal Email Address' required attribute displays as expected. This pull request tests the 'Personal Email Address is required when same as 
above is checked.' error message displays as expected.

Issue #842 Show error on personal email address