### PR TITLE
Remove "COS" links from search results for providers

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -143,10 +143,12 @@
                 Edit
               </a>
               <span class="sep">|</span>
-              <a class="cosLink" href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
-                COS
-              </a>
-              <span class="sep">|</span>
+              <c:if test="${isServiceAdministrator}">
+                <a class="cosLink" href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
+                  COS
+                </a>
+                <span class="sep">|</span>
+              </c:if>
               <c:forEach var="task" items="${tasks}">
                 <c:if test="${task.processInstanceId == item.processInstanceId}">
                     <a class="reviewLink" href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}">
@@ -161,10 +163,12 @@
                 Edit
               </a>
               <span class="sep">|</span>
-              <a class="cosLink" href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
-                COS
-              </a>
-              <span class="sep">|</span>
+              <c:if test="${isServiceAdministrator}">
+                <a class="cosLink" href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
+                  COS
+                </a>
+                <span class="sep">|</span>
+              </c:if>
             </c:when>
             <c:when test="${fn:toLowerCase(item.status)=='approved'}">
               <a class="viewLink" href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
@@ -175,10 +179,12 @@
                 Edit
               </a>
               <span class="sep">|</span>
-              <a class="cosLink" href="${ctx}/agent/enrollment/cos?id=${item.profileReferenceId}">
-                COS
-              </a>
-              <span class="sep">|</span>
+              <c:if test="${isServiceAdministrator}">
+                <a class="cosLink" href="${ctx}/agent/enrollment/cos?id=${item.profileReferenceId}">
+                  COS
+                </a>
+                <span class="sep">|</span>
+              </c:if>
               <a href="${ctx}/provider/profile/renew?profileId=${item.profileReferenceId}">
                 Renew
               </a>


### PR DESCRIPTION
The "COS" links in the actions column are for service admins, not providers, and it is a bug that they are visible for providers in search results. Also these links do not work when logged in as a provider; an error page is shown.

Tested by logging in as a provider and doing a quick search and an advanced search and confirming that there were no "COS" links in the actions column in the search results.  Also did the same as a service admin to confirm that these links still appeared there.

The changes in this PR are on top of those in PR #984, so no review is needed until #984 is merged and this is rebased.

Issue #498 Providers can edit submitted enrollments
Also related: #711 Remove or complete Categories of Service (COS)