### PR TITLE
Use a better approach for role detection in templates

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
@@ -13,7 +13,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set value="Advanced Search (System Admin)" var="title"></c:set>
-  <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/automatic_screening_leie.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/automatic_screening_leie.jsp
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="LEIE Automatic Screening Details"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Dashboard"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Applications by Reviewer"/>
-  <c:set var="adminPage" value="true" />
   <c:set var="includeD3" value="true" />
   <fmt:formatDate value="${startDate}" pattern="MM/dd/yyyy" var="searchStartDate" />
   <fmt:formatDate value="${endDate}" pattern="MM/dd/yyyy" var="searchEndDate" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/draft_applications.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/draft_applications.jsp
@@ -3,7 +3,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Draft Applications"/>
-  <c:set var="adminPage" value="true" />
   <c:set var="reportPage" value="true" />
   <c:set var="includeD3" value="true" />
   <c:set var="pageScripts" value="${[ctx.concat('/js/admin/draftsReport.js')]}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Provider Types"/>
-  <c:set var="adminPage" value="true" />
   <c:set var="reportPage" value="true" />
   <c:set var="includeD3" value="true" />
   <c:set var="pageScripts" value="${[ctx.concat('/js/admin/providerTypesReport.js')]}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reports.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reports.jsp
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Reports"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
@@ -3,7 +3,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Reviewed Documents"/>
-  <c:set var="adminPage" value="true" />
   <c:set var="reportPage" value="true" />
   <c:set var="includeD3" value="true" />
   <c:set var="pageScripts" value="${[ctx.concat('/js/admin/reviewedDocumentsReport.js')]}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
@@ -3,7 +3,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Risk Levels"/>
-  <c:set var="adminPage" value="true" />
   <c:set var="reportPage" value="true" />
   <c:set var="includeD3" value="true" />
   <c:set var="pageScripts" value="${[ctx.concat('/js/admin/riskLevelsReport.js')]}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
@@ -3,7 +3,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Time to Review"/>
-  <c:set var="adminPage" value="true" />
   <c:set var="reportPage" value="true" />
   <c:set var="includeD3" value="true" />
   <c:set var="pageScripts" value="${[ctx.concat('/js/admin/timeToReviewReport.js')]}" />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
@@ -2,7 +2,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Screenings"/>
-  <c:set var="adminPage" value="true" />
   <c:set var="activeTabScreenings" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
@@ -13,7 +13,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set value="Advanced Search (System Admin)" var="title"></c:set>
-  <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Agreements & Addendums - Functions (Service Admin)"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Create Provider Type - Functions (Service Admin)"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Edit Agreement Document - Functions (Service Admin)"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Edit Provider Type - Functions (Service Admin)"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Edit Screening Schedule - Functions (Service Admin)"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Provider Types - Functions (Service Admin)"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="View Agreement Document - Functions (Service Admin)"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="View Provider Type - Functions (Service Admin)"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
@@ -10,7 +10,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Screening Schedules - Functions (Service Admin)"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
@@ -9,7 +9,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Category of Service"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
@@ -19,7 +19,6 @@
     </c:when>
   </c:choose>
   <c:set var="title" value="${listType}"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
@@ -9,7 +9,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Category of Service"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
@@ -9,7 +9,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Status Query"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
@@ -9,7 +9,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Enrollment"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -9,7 +9,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Review Enrollment"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
@@ -9,7 +9,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Advanced Search"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
@@ -9,7 +9,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="Search Results"/>
-  <c:set var="adminPage" value="true" />
   <c:set var="quickSearchNpi" value="${param.npi}" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
@@ -9,7 +9,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set var="title" value="View Enrollment - ${profile.status.description}"/>
-  <c:set var="adminPage" value="true" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
@@ -13,7 +13,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set value="User Account Details (System Admin)" var="title"></c:set>
-  <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
@@ -20,7 +20,6 @@
       <c:set value="Create New User Account (System Admin)" var="title"></c:set>
     </c:otherwise>
   </c:choose>
-  <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
@@ -13,7 +13,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set value="User Account (System Admin)" var="title"></c:set>
-  <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
@@ -14,7 +14,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <c:set value="Advanced Search (System Admin)" var="title"></c:set>
-  <c:set value="true" var="systemPage"></c:set>
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">

--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
-{{> includes/html_head title="Update Profile (Service Admin)" adminPage=true }}
+{{> includes/html_head title="Update Profile (Service Admin)"}}
   <body>
     <div id="wrapper">
       {{> includes/header }}

--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
-{{> includes/html_head title="My Profile (Service Admin)" adminPage=true }}
+{{> includes/html_head title="My Profile (Service Admin)"}}
   <body>
     <div id="wrapper">
       {{> includes/header }}

--- a/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="{{ctx}}/css/reset.css" media="all" />
   <link rel="stylesheet" href="{{ctx}}/css/style.css" media="all" />
   <link rel="stylesheet" href="{{ctx}}/css/jquery.ui.css" media="all" />
-  {{#if adminPage}}
+  {{#if isServiceAdministrator}}
     <link rel="stylesheet" href="{{ctx}}/js/chosen/chosen.css" media="all"/>
     <link rel="stylesheet" href="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.css"/>
   {{else if systemPage}}
@@ -21,7 +21,7 @@
   <script src="{{ctx}}/js/jquery.ui.widget.js"></script>
   <script src="{{ctx}}/js/jquery.ui.datepicker.js"></script>
   <script src="{{ctx}}/js/jquery.mask.min.js"></script>
-  {{#if adminPage}}
+  {{#if isServiceAdministrator}}
     <script src="{{ctx}}/js/jquery.validate.min.js"></script>
     <script src="{{ctx}}/js/chosen/chosen.jquery.min.js"></script>
     <script src="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.js"></script>
@@ -50,7 +50,7 @@
 
   <script src="{{ctx}}/js/common.js"></script>
 
-  {{#if adminPage}}
+  {{#if isServiceAdministrator}}
     <script src="{{ctx}}/js/admin/script.js"></script>
   {{else if systemPage}}
     <script src="{{ctx}}/js/system/script.js"></script>

--- a/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/html_head.template.html
@@ -11,7 +11,7 @@
   {{#if isServiceAdministrator}}
     <link rel="stylesheet" href="{{ctx}}/js/chosen/chosen.css" media="all"/>
     <link rel="stylesheet" href="{{ctx}}/js/jwysiwyg/jquery.wysiwyg.css"/>
-  {{else if systemPage}}
+  {{else if isSystemAdministrator}}
     <link rel="stylesheet" href="{{ctx}}/js/chosen/chosen.css" media="all"/>
   {{/if}}
   <script src="{{ctx}}/js/jquery-1.7.1.min.js"></script>
@@ -29,7 +29,7 @@
     <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.image.js"></script>
     <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.link.js" ></script>
     <script src="{{ctx}}/js/jwysiwyg/controls/wysiwyg.table.js" ></script>
-  {{else if systemPage}}
+  {{else if isSystemAdministrator}}
     <script src="{{ctx}}/js/chosen/chosen.jquery.min.js"></script>
   {{else}}
     <script src="{{ctx}}/js/jquery.compare.js"></script>
@@ -41,7 +41,7 @@
 
   <script>
     var ctx = "{{ctx}}";
-    {{#if systemPage}}
+    {{#if isSystemAdministrator}}
       var roles = "{{role}}";
       var searchedResult = "{{searchedResult}}";
       var searchFirstName = "{{searchFirstName}}";
@@ -52,7 +52,7 @@
 
   {{#if isServiceAdministrator}}
     <script src="{{ctx}}/js/admin/script.js"></script>
-  {{else if systemPage}}
+  {{else if isSystemAdministrator}}
     <script src="{{ctx}}/js/system/script.js"></script>
   {{else}}
     <script src="{{ctx}}/js/script.js"></script>

--- a/psm-app/cms-web/WebContent/templates/includes/nav.template.html
+++ b/psm-app/cms-web/WebContent/templates/includes/nav.template.html
@@ -2,7 +2,7 @@
   <div class="navR">
     <div class="navM">
       <ul>
-        {{#if systemPage}}
+        {{#if isSystemAdministrator}}
           <li class="active">
             <a href="{{ctx}}/system/user/list">USER ACCOUNTS</a>
             {{#if hasArrow}}<span class="arrow"></span>{{/if}}
@@ -49,7 +49,7 @@
         {{/if}}
       </ul>
 
-      {{#if systemPage}}
+      {{#if isSystemAdministrator}}
         <div class="searchWidget">
           <a class="advancedSearchLink" href="{{ctx}}/system/advanced-search-system-admin">Advanced Search</a>
           <form id="searchBoxForm" class="inputContainer" action="{{ctx}}/system/user/search?role=Provider"  method="post">

--- a/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
@@ -44,10 +44,17 @@ public class HandlebarsInterceptor extends HandlerInterceptorAdapter {
             CMSUser principalUser = principal.getUser();
             modelAndView.addObject("principalUser", principalUser);
 
+            String roleDescription = principalUser.getRole().getDescription();
+
             // <c:if test="${requestPrincipal.user.role.description eq 'Service Administrator'}">
-            if ("Service Administrator".equals(principalUser.getRole().getDescription())) {
+            if ("Service Administrator".equals(roleDescription)) {
                 modelAndView.addObject(
                         "isServiceAdministrator",
+                        true
+                );
+            } else if ("System Administrator".equals(roleDescription)) {
+                modelAndView.addObject(
+                        "isSystemAdministrator",
                         true
                 );
             }


### PR DESCRIPTION
We had two ways of indicating to the templates that the current user role was a service administrator or a system administrator. Consolidate these and only use the better approach.

Tested by logging in as both kinds of administrator and as a provider and checking that the main navigation menu was unchanged and that the appropriate script.js file was in the page source (`admin/script.js` for service admins, `system/script.js` for system admins, `js/script.js` for providers).

The changes in this PR are on top of those in PR #984, so no review is needed until #984 is merged and this is rebased.