### PR TITLE
Fix #659: Add provider type to provider dashboard table

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_table.jsp
@@ -7,12 +7,13 @@
 <table class="generalTable dashboardTable fixedWidthTable">
 
   <colgroup>
-    <col width="125"/>
-    <col width="125"/>
-    <col width="145"/>
+    <col width="105"/>
     <col width="120"/>
-    <col width="120"/>
-    <col width="120"/>
+    <col width="135"/>
+    <col width="110"/>
+    <col width="85"/>
+    <col width="90"/>
+    <col width="110"/>
     <col width="*"/>
   </colgroup>
 
@@ -33,6 +34,15 @@
           <a href="javascript:changeSort(3);">
             Date Submitted
             <span class="${criteria.sortColumn == '3' ? 'sort' : 'nosort'}"></span>
+          </a>
+          <span class="sep"></span>
+        </div>
+      </th>
+      <th class="tablesorter-header ${sortDirCls}">
+        <div class="tablesorter-header-inner">
+          <a href="javascript:changeSort(8);">
+            Provider Type
+            <span class="${criteria.sortColumn == '8' ? 'sort' : 'nosort'}"></span>
           </a>
           <span class="sep"></span>
         </div>
@@ -102,6 +112,7 @@
         <td>
           <fmt:formatDate value="${item.submissionDate}" pattern="MM/dd/yyyy" />
         </td>
+        <td>${item.providerType}</td>
         <td>
           <c:out value="${item.requestType}" />
         </td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_table.jsp
@@ -1,6 +1,6 @@
 <%--
-    JSP Fragment for provider dashboard results table.
- --%>
+    Provider dashboard table.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
@@ -18,7 +18,10 @@
   </colgroup>
 
   <thead>
-    <c:set var="sortDirCls" value="${criteria.ascending ? 'tablesorter-headerSortDown' : 'tablesorter-headerSortUp' }" />
+    <c:set
+      var="sortDirCls"
+      value="${criteria.ascending ? 'tablesorter-headerSortDown' : 'tablesorter-headerSortUp' }"
+    />
     <tr class="tablesorter-header">
       <th class="tablesorter-header ${sortDirCls}">
         <div class="tablesorter-header-inner">
@@ -102,26 +105,26 @@
       <c:url var="exportTicketLink" value="/provider/enrollment/exportTicket">
         <c:param name="id" value="${item.ticketId}" />
       </c:url>
-      <c:set var="statusCls" value="${item.status == 'Rejected' ? 'red' : item.status == 'Approved' ? 'green' : ''}" />
-      <c:set var="riskCls" value="${item.riskLevel == 'High' ? 'red' : item.riskLevel == 'Limited' ? 'green' : ''}" />
+      <c:set
+        var="statusCls"
+        value="${item.status == 'Rejected' ? 'red' : item.status == 'Approved' ? 'green' : ''}"
+      />
+      <c:set
+        var="riskCls"
+        value="${item.riskLevel == 'High' ? 'red' : item.riskLevel == 'Limited' ? 'green' : ''}"
+      />
 
       <tr>
-        <td class="primary">
-          <c:out value="${item.npi}" />
-        </td>
+        <td class="primary">${item.npi}</td>
         <td>
           <fmt:formatDate value="${item.submissionDate}" pattern="MM/dd/yyyy" />
         </td>
         <td>${item.providerType}</td>
-        <td>
-          <c:out value="${item.requestType}" />
-        </td>
+        <td>${item.requestType}</td>
         <td class="${statusCls}">
-          <c:out value="${item.status == 'Rejected' ? 'Denied' : item.status}" />
+          ${item.status == 'Rejected' ? 'Denied' : item.status}
         </td>
-        <td class="${riskCls}">
-          <c:out value="${item.riskLevel}" />
-        </td>
+        <td class="${riskCls}">${item.riskLevel}</td>
         <td>
           <fmt:formatDate value="${item.statusDate}" pattern="MM/dd/yyyy" />
         </td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
@@ -15,14 +15,15 @@
 
   <colgroup>
     <col width="30"/>
-    <col width="140"/>
-    <col width="140"/>
-    <col width="150"/>
-    <col width="145"/>
+    <col width="120"/>
+    <col width="120"/>
+    <col width="130"/>
+    <col width="120"/>
+    <col width="120"/>
     <c:if test="${statusFilter != 'Draft'}">
-      <col width="145"/>
+      <col width="120"/>
     </c:if>
-    <col width="210"/>
+    <col width="*"/>
   </colgroup>
 
   <thead>
@@ -48,6 +49,15 @@
           <a href="javascript:changeSort(10);">
             Date Created
             <span class="${criteria.sortColumn == '10' ? 'sort' : 'nosort'}"></span>
+          </a>
+          <span class="sep"></span>
+        </div>
+      </th>
+      <th class="tablesorter-header ${sortDirCls}">
+        <div class="tablesorter-header-inner">
+          <a href="javascript:changeSort(8);">
+            Provider Type
+            <span class="${criteria.sortColumn == '8' ? 'sort' : 'nosort'}"></span>
           </a>
           <span class="sep"></span>
         </div>
@@ -116,6 +126,7 @@
         <td>
           <fmt:formatDate value="${item.createDate}" pattern="MM/dd/yyyy" />
         </td>
+        <td>${item.providerType}</td>
         <td>
           <c:out value="${item.requestType}" />
         </td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
@@ -1,6 +1,6 @@
 <%--
-    JSP Fragment for provider status list results table.
- --%>
+    Provider status list results table (Draft, Pending, etc.).
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
@@ -27,11 +27,19 @@
   </colgroup>
 
   <thead>
-    <c:set var="sortDirCls" value="${criteria.ascending ? 'tablesorter-headerSortDown' : 'tablesorter-headerSortUp' }" />
+    <c:set
+      var="sortDirCls"
+      value="${criteria.ascending ? 'tablesorter-headerSortDown' : 'tablesorter-headerSortUp' }"
+    />
     <tr class="tablesorter-header">
       <th class="alignCenter">
         <div class="tablesorter-header-inner">
-          <input type="checkbox" title="Select All" class="selectAll" name="providerIds">
+          <input
+            type="checkbox"
+            title="Select All"
+            class="selectAll"
+            name="providerIds"
+          >
           <span class="sep"></span>
         </div>
       </th>
@@ -113,28 +121,33 @@
       <c:url var="exportTicketLink" value="/provider/enrollment/exportTicket">
         <c:param name="id" value="${item.ticketId}" />
       </c:url>
-      <c:set var="statusCls" value="${item.status == 'Rejected' ? 'red' : item.status == 'Approved' ? 'green' : ''}" />
-      <c:set var="riskCls" value="${item.riskLevel == 'High' ? 'red' : item.riskLevel == 'Limited' ? 'green' : ''}" />
+      <c:set
+        var="statusCls"
+        value="${item.status == 'Rejected' ? 'red' : item.status == 'Approved' ? 'green' : ''}"
+      />
+      <c:set
+        var="riskCls"
+        value="${item.riskLevel == 'High' ? 'red' : item.riskLevel == 'Limited' ? 'green' : ''}"
+      />
 
       <tr class="${status.index % 2 == 0 ? 'even' : 'odd'}">
         <td class="alignCenter">
-          <input type="checkbox" title="Provider ${item.ticketId}" name="providerIds" value="${item.ticketId}" />
+          <input
+            type="checkbox"
+            title="Provider ${item.ticketId}"
+            name="providerIds"
+            value="${item.ticketId}"
+          />
         </td>
-        <td>
-          <c:out value="${item.npi}" />
-        </td>
+        <td>${item.npi}</td>
         <td>
           <fmt:formatDate value="${item.createDate}" pattern="MM/dd/yyyy" />
         </td>
         <td>${item.providerType}</td>
-        <td>
-          <c:out value="${item.requestType}" />
-        </td>
+        <td>${item.requestType}</td>
 
         <c:if test="${statusFilter != 'Draft'}">
-          <td class="${riskCls}">
-            <c:out value="${item.riskLevel}" />
-          </td>
+          <td class="${riskCls}">${item.riskLevel}</td>
         </c:if>
 
         <td>


### PR DESCRIPTION
Tested by logging in as a provider and viewing the tables under Dashboard and Enrollments.

Before:

![screenshot_2018-07-25 dashboard 1](https://user-images.githubusercontent.com/1091693/43232820-ca4a9900-9040-11e8-9f20-461e410fe70b.png)

After:

![screenshot_2018-07-25 dashboard](https://user-images.githubusercontent.com/1091693/43232825-cfba6b40-9040-11e8-9cc8-2a87488658a5.png)

Before:

![screenshot_2018-07-25 approved enrollments 1](https://user-images.githubusercontent.com/1091693/43233451-f7df7a0e-9043-11e8-8232-4c6ccefeaf53.png)

After:

![screenshot_2018-07-25 approved enrollments](https://user-images.githubusercontent.com/1091693/43233447-f56473ba-9043-11e8-83e1-889640a95de9.png)

Resolves #659 Add provider type to provider dashboard table