### PR TITLE
Revamp the build process to integrate with eclipse IDE for Hot Deploy

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,7 @@ deployment guide will be part of our 1.0 release. ***
     - [Run automated tests](#run-automated-tests)
     - [Maintain and update environment](#maintain-and-update-environment)
     - [Run Database Migrations](#run-database-migrations)
+	- [Eclipse](#eclipse)
 - **[Production Deployment](#production-deployment)**
     - [NGINX](#nginx)
     - [Continuous Deployment](#continuous-deployment)
@@ -441,6 +442,17 @@ Migration scripts are stored in `psm-app/db/`.
     ```
 
 More material coming soon about how to run individual migrations.
+
+## Eclipse
+
+Eclipse IDE has some requirements on how gradle build is bootstraped
+so that it properly works in Eclipse and prepares the project for development.
+
+Eclipse-WTP is a plugin which is sufficiently adds necessary hooks into 
+the gradle build process to enable hot deployment during development. 
+
+[Eclipse WTP Gradle Plugin Docs](https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.eclipse.model.EclipseWtpComponent.html)
+
 
 # Production Deployment
 

--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -76,6 +76,10 @@ ext.provided_libs = [
 
 allprojects {
     apply plugin: 'checkstyle'
+    
+    repositories {
+        mavenCentral()
+    }
 
     checkstyle {
         toolVersion = '8.2'
@@ -86,20 +90,16 @@ allprojects {
 [
     'cms-business-model',
     'cms-business-process',
-    'cms-portal-services',
     'cms-web',
     'services',
 ].each { name ->
     project(":$name") {
         apply plugin: 'groovy'
         apply plugin: 'com.github.spotbugs'
+        apply plugin: 'eclipse-wtp'        
 
         configurations {
             testCompile.extendsFrom compileOnly
-        }
-
-        repositories {
-            mavenCentral()
         }
 
         dependencies {
@@ -232,6 +232,16 @@ project(':cms-web') {
             into 'js'
         }
     }
+    
+    task copyDeps(type: Copy) {        
+        from(configurations.frontend) 
+        into(file('WebContent/js'))
+    }
+    
+    eclipseWtp.dependsOn copyDeps
+    
+    
+    
 }
 
 project(':cms-business-model') {
@@ -240,6 +250,7 @@ project(':cms-business-model') {
     sourceCompatibility = 1.6
     targetCompatibility = 1.6
     compileJava.dependsOn xjc
+    eclipseWtp.dependsOn xjc
     System.setProperty('javax.xml.accessExternalSchema', 'file')
 
     dependencies {
@@ -279,6 +290,8 @@ project(':cms-business-model') {
 
 project(':cms-portal-services') {
     apply plugin: 'ear'
+    apply plugin: 'eclipse-wtp'
+
     dependencies {
         deploy project(path: ':cms-web', configuration: 'archives')
         deploy project(':cms-business-process')
@@ -310,6 +323,11 @@ project(':cms-portal-services') {
 
     ear {
         appDirName 'EarContent'
+    }
+    
+    eclipse.wtp.facet {
+        facets = []
+        facet name: 'jst.ear', version: '5.0'
     }
 }
 


### PR DESCRIPTION
#767: Improve front-end development feedback cycle

Simply importing the project should build necessary jaxb classes + copy JS dependencies, and build EAR so that the artifacts are deployable within from IDE to Wildfly running within IDE without much of guess work. Secondly, it improves debugging via hot code replacement.

