### PR TITLE
Remove "COS" (Categories of Service) links from the UI

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -143,12 +143,6 @@
                 Edit
               </a>
               <span class="sep">|</span>
-              <c:if test="${isServiceAdministrator}">
-                <a class="cosLink" href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
-                  COS
-                </a>
-                <span class="sep">|</span>
-              </c:if>
               <c:forEach var="task" items="${tasks}">
                 <c:if test="${task.processInstanceId == item.processInstanceId}">
                     <a class="reviewLink" href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}">
@@ -163,12 +157,6 @@
                 Edit
               </a>
               <span class="sep">|</span>
-              <c:if test="${isServiceAdministrator}">
-                <a class="cosLink" href="${ctx}/agent/enrollment/pendingcos?id=${item.ticketId}">
-                  COS
-                </a>
-                <span class="sep">|</span>
-              </c:if>
             </c:when>
             <c:when test="${fn:toLowerCase(item.status)=='approved'}">
               <a class="viewLink" href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
@@ -179,12 +167,6 @@
                 Edit
               </a>
               <span class="sep">|</span>
-              <c:if test="${isServiceAdministrator}">
-                <a class="cosLink" href="${ctx}/agent/enrollment/cos?id=${item.profileReferenceId}">
-                  COS
-                </a>
-                <span class="sep">|</span>
-              </c:if>
               <a href="${ctx}/provider/profile/renew?profileId=${item.profileReferenceId}">
                 Renew
               </a>


### PR DESCRIPTION
This obscure feature is incompletely implemented; remove it from the UI until its fate (complete or remove?) is determined.

Tested by logging in as a service admin and confirming that the COS links were gone from the "Action" columns in the tables on the Enrollments pages and Search Results pages.

Before: 

![screenshot_2018-08-03 draft enrollments 2](https://user-images.githubusercontent.com/1091693/43666387-aa199980-9741-11e8-97fc-c220594a6f47.png)

After:

![screenshot_2018-08-03 draft enrollments](https://user-images.githubusercontent.com/1091693/43666220-ec644a8e-9740-11e8-8ea3-92bd4af05606.png)

Issue #711 Remove or complete Categories of Service (COS)