### PR TITLE
Remove "COS" page accessibility integration test

### DIFF
--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -49,12 +49,6 @@ public class AdminStepDefinitions {
         adminSteps.openWriteNoteModal();
     }
 
-    @When("^I am on the COS page$")
-    public void i_am_on_the_cos_page() {
-        adminSteps.goToAdminDraftPage();
-        generalSteps.clickLinkAssertTitle(".cosLink", "Category of Service");
-    }
-
     @When("^I am on the Print Enrollment page$")
     public void i_am_on_the_print_enrollment_page() {
         adminSteps.goToAdminAllEnrollmentsPage();

--- a/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
+++ b/psm-app/integration-tests/src/test/resources/features/service_admin/accessibility.feature
@@ -46,13 +46,6 @@ Feature: General Accessibility Checks for Admins
     Then I should have no accessibility issues
     And I should see enrollments
 
-  # fails: COS input field needs label or title
-  @ignore
-  Scenario: Admin COS Page
-    Given I am logged in as an admin
-    And I am on the COS page
-    Then I should have no accessibility issues
-
   # fails: print page is opened in a new window
   @ignore
   Scenario: Admin Print Enrollment Page


### PR DESCRIPTION
A follow-up to PR #1002 (remove COS links from UI). No need to test UI that is no longer there.

This test was `@ignore`'d because of accessibility issues on the COS page, so it wasn't being run before anyway.

Issue #711: Remove or complete Categories of Service (COS)