### PR TITLE
Fix regression where invalid username caused an NPE.

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -814,6 +814,9 @@ public class RegistrationServiceBean extends BaseService implements Registration
      */
     public boolean authenticate(String username, String password) throws PortalServiceException {
         CMSUser user = findByUsername(username);
+        if (user == null) {
+            throw new PortalServiceException("User not found");
+        }
         if (user.getStatus() != UserStatus.ACTIVE) {
             throw new PortalServiceException("User is disabled");
         }


### PR DESCRIPTION
Caused when fixing #33.

Issue #33: Complete or remove the ability to suspend user accounts

Test by attempting a login as an unknown user.  Should get the normal messaging.  Used an exception to because of the same idea expressed at https://github.com/SolutionGuidance/psm/pull/943#discussion_r202989696