### PR TITLE
Remove PDF export button from provider All page

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -78,9 +78,11 @@
                     <span class="text">${param.filterViewState eq 'visible' ? 'Hide Filter' : 'Filter'}</span>
                     <span class="arrow"></span>
                   </a>
-                  <a href="javascript:submitFormById('paginationForm','${exportResultsURL}')" class="greyBtn iconPdf">
-                    Export to PDF
-                  </a>
+                  <c:if test="${statusFilter != 'All'}">
+                    <a href="javascript:submitFormById('paginationForm','${exportResultsURL}')" class="greyBtn iconPdf">
+                      Export to PDF
+                    </a>
+                  </c:if>
                 </div>
               </div>
               <!-- /.pagination -->


### PR DESCRIPTION
We don't support this functionality yet, so just remove the button for now.  When this lands I'll open a new issue for adding it back and making it work.  Currently it causes a server error. (An overlooked side-effect of PR #998)

Tested by logging in as a provider and confirming that the "Export PDF" button did not appear on the Enrollments > All tab page, but did appear on the Draft, Pending, etc. tab pages.

Issue #668 Rearrange the provider dashboard pages