### PR TITLE
Use "Limited" instead of "Low" for consistent UI risk levels

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -121,7 +121,7 @@
         <c:choose>
           <c:when test="${fn:toLowerCase(item.riskLevel)=='limited'}">
             <td class="green">
-              Low
+              Limited
             </td>
           </c:when>
           <c:when test="${fn:toLowerCase(item.riskLevel)=='high'}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
@@ -64,7 +64,7 @@
                               </c:choose>
                             </td>
                             <c:choose>
-                            <c:when test="${fn:toLowerCase(item.riskLevel)=='limited'}"><td class="green">Low</td></c:when>
+                            <c:when test="${fn:toLowerCase(item.riskLevel)=='limited'}"><td class="green">Limited</td></c:when>
                             <c:when test="${fn:toLowerCase(item.riskLevel)=='high'}"><td class="red">High</td></c:when>
                             <c:otherwise><td style="text-align: center;">${item.riskLevel}</td></c:otherwise>
                             </c:choose>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
@@ -50,25 +50,44 @@
                       <tbody>
                         <c:forEach var="item" items="${searchResult.items}">
                           <tr>
-                            <td style="text-align: center;">${item.npi}
+                            <td class="alignCenter">${item.npi}</td>
+                            <td class="alignCenter">
+                              <fmt:formatDate
+                                value="${item.submissionDate}"
+                                pattern="MM/dd/yyyy"
+                              />
                             </td>
-                            <td style="text-align: center;"><fmt:formatDate value="${item.submissionDate}" pattern="MM/dd/yyyy"/></td>
-                            <td style="text-align: center;">${item.providerType}</td>
-                            <td style="text-align: center;">${item.providerName}</td>
-                            <td style="text-align: center;">${item.requestType}</td>
-                            <td style="text-align: center;">
-                              <c:choose>
-                              <c:when test="${fn:toLowerCase(item.status)=='approved'}"><span class="green">Approved</span></c:when>
-                              <c:when test="${fn:toLowerCase(item.status)=='rejected'}"><span class="red">Denied</span></c:when>
-                              <c:otherwise>${item.status}</c:otherwise>
-                              </c:choose>
-                            </td>
+                            <td class="alignCenter">${item.providerType}</td>
+                            <td class="alignCenter">${item.providerName}</td>
+                            <td class="alignCenter">${item.requestType}</td>
                             <c:choose>
-                            <c:when test="${fn:toLowerCase(item.riskLevel)=='limited'}"><td class="green">Limited</td></c:when>
-                            <c:when test="${fn:toLowerCase(item.riskLevel)=='high'}"><td class="red">High</td></c:when>
-                            <c:otherwise><td style="text-align: center;">${item.riskLevel}</td></c:otherwise>
+                              <c:when test="${fn:toLowerCase(item.status)=='approved'}">
+                                <td class="green alignCenter">Approved</td>
+                              </c:when>
+                              <c:when test="${fn:toLowerCase(item.status)=='rejected'}">
+                                <td class="red alignCenter">Denied</td>
+                              </c:when>
+                              <c:otherwise>
+                                <td class="alignCenter">${item.status}</td>
+                              </c:otherwise>
                             </c:choose>
-                            <td style="text-align: center;"><fmt:formatDate value="${item.statusDate}" pattern="MM/dd/yyyy"/></td>
+                            <c:choose>
+                              <c:when test="${fn:toLowerCase(item.riskLevel)=='limited'}">
+                                <td class="green alignCenter">Limited</td>
+                              </c:when>
+                              <c:when test="${fn:toLowerCase(item.riskLevel)=='high'}">
+                                <td class="red alignCenter">High</td>
+                              </c:when>
+                              <c:otherwise>
+                                <td class="alignCenter">${item.riskLevel}</td>
+                              </c:otherwise>
+                            </c:choose>
+                            <td class="alignCenter">
+                              <fmt:formatDate
+                                value="${item.statusDate}"
+                                pattern="MM/dd/yyyy"
+                              />
+                            </td>
                           </tr>
                         </c:forEach>
                       </tbody>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
@@ -56,7 +56,7 @@
                 <form:select id="dashboardFilterRiskLevel" path="riskLevel" cssClass="longSelect">
                     <form:option value="">All</form:option>
                     <form:option value="NULL">Not screened yet</form:option>
-                    <form:option value="Low">Low</form:option>
+                    <form:option value="Limited">Limited</form:option>
                     <form:option value="Moderate">Moderate</form:option>
                     <form:option value="High">High</form:option>
                 </form:select>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 @Controller
 public class RiskLevelsReportController extends gov.medicaid.controllers.BaseController {
     private static final List<String> RISK_LEVELS = ImmutableList.of(
-        ViewStatics.LOW_RISK,
+        ViewStatics.LIMITED_RISK,
         ViewStatics.MODERATE_RISK,
         ViewStatics.HIGH_RISK
     );

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/RiskLevelsReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/RiskLevelsReportControllerTest.groovy
@@ -62,13 +62,13 @@ class RiskLevelsReportControllerTest extends Specification {
     }
 
     private setupTestProviders() {
-        enrollmentService.getProviderDetailsByTicket(1, false) >> makeProvider(ViewStatics.LOW_RISK)
-        enrollmentService.getProviderDetailsByTicket(2, false) >> makeProvider(ViewStatics.LOW_RISK)
+        enrollmentService.getProviderDetailsByTicket(1, false) >> makeProvider(ViewStatics.LIMITED_RISK)
+        enrollmentService.getProviderDetailsByTicket(2, false) >> makeProvider(ViewStatics.LIMITED_RISK)
         enrollmentService.getProviderDetailsByTicket(3, false) >> makeProvider(ViewStatics.MODERATE_RISK)
         enrollmentService.getProviderDetailsByTicket(4, false) >> makeProvider(ViewStatics.HIGH_RISK)
         enrollmentService.getProviderDetailsByTicket(5, false) >> makeProvider(ViewStatics.HIGH_RISK)
         enrollmentService.getProviderDetailsByTicket(6, false) >> makeProvider(ViewStatics.MODERATE_RISK)
-        enrollmentService.getProviderDetailsByTicket(7, false) >> makeProvider(ViewStatics.LOW_RISK)
+        enrollmentService.getProviderDetailsByTicket(7, false) >> makeProvider(ViewStatics.LIMITED_RISK)
     }
 
     def "csv with no enrollments - header"() {
@@ -87,7 +87,7 @@ class RiskLevelsReportControllerTest extends Specification {
         records.size == 1
         records[0].size() == 4
         records[0][0] == "Month"
-        records[0][1] == ViewStatics.LOW_RISK
+        records[0][1] == ViewStatics.LIMITED_RISK
         records[0][2] == ViewStatics.MODERATE_RISK
         records[0][3] == ViewStatics.HIGH_RISK
     }
@@ -135,7 +135,7 @@ class RiskLevelsReportControllerTest extends Specification {
         then:
         mv["months"].size == 4
         mv["months"][0].month == noonMiddleThisMonth.withDayOfMonth(1).toLocalDate()
-        mv["months"][0].getNum(ViewStatics.LOW_RISK) == 2
+        mv["months"][0].getNum(ViewStatics.LIMITED_RISK) == 2
         mv["months"][0].getNum(ViewStatics.HIGH_RISK) == 0
         mv["months"][2].month == noonMiddleThisMonth.minusMonths(2).withDayOfMonth(1).toLocalDate()
         mv["months"][2].getNum(ViewStatics.MODERATE_RISK) == 1
@@ -157,7 +157,7 @@ class RiskLevelsReportControllerTest extends Specification {
         then:
         mv["months"].size == 1
         mv["months"][0].month == noonMiddleThisMonth.withDayOfMonth(1).toLocalDate()
-        mv["months"][0].getNum(ViewStatics.LOW_RISK) == 0
+        mv["months"][0].getNum(ViewStatics.LIMITED_RISK) == 0
         mv["months"][0].getNum(ViewStatics.MODERATE_RISK) == 0
         mv["months"][0].getNum(ViewStatics.HIGH_RISK) == 0
     }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
@@ -186,7 +186,7 @@ public class ViewStatics {
     /**
      * Low risk.
      */
-    public static final String LOW_RISK = "Limited";
+    public static final String LIMITED_RISK = "Limited";
 
     /**
      * High risk.


### PR DESCRIPTION
"Limited" was used in more places in the UI, is the language in the requirements docs, and is used in the underlying code.  This also fixes a bug: filtering for "Low" (with provider login) was not working, but filtering for "Limited" does work.

Tested by logging in as an admin and seeing "Limited" instead of "Low" the enrollment tables in the "Risk Levels" column.  And by logging in as a provider and seeing "Limited" instead of "Low" when filtering the enrollments tables, and checking that this filter option works as expected.  

I checked the change in the `service_agent_print_enrollments.jsp` by going to the search results page (quick or admin) and clicking the Print button at the top of the table, then seeing "Limited" in the table on the printable page that opens in a new tab.

Resolves #862 Standardize on 'Low' vs 'Limited' risk level