### PR TITLE
Use the handlebars pagination templates in more places

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -189,7 +189,15 @@
                     <div class="tabFoot">
                       <div class="tabR">
                         <div class="tabM">
-                          <%@ include file="/WEB-INF/pages/admin/includes/page_navigation.jsp" %>
+                          <div class="pagination">
+                            <%@ include file="/WEB-INF/pages/admin/includes/page_left_navigation.jsp" %>
+                            <div class="right">
+                              <h:handlebars
+                                template="includes/pagination_links"
+                                context="${pageContext}"
+                              />
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -142,7 +142,15 @@
                   <div class="tabFoot">
                     <div class="tabR">
                       <div class="tabM">
-                        <%@ include file="/WEB-INF/pages/admin/includes/page_navigation.jsp" %>
+                        <div class="pagination">
+                          <%@ include file="/WEB-INF/pages/admin/includes/page_left_navigation.jsp" %>
+                          <div class="right">
+                            <h:handlebars
+                              template="includes/pagination_links"
+                              context="${pageContext}"
+                            />
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
@@ -45,7 +45,12 @@
             <!-- /.tabHead -->
             <div class="tabContent">
               <div class="pagination">
-                <%@ include file="/WEB-INF/pages/admin/includes/page_left_navigation.jsp" %>
+                <div class="left topPagination">
+                  <h:handlebars
+                    template="includes/pagination_details"
+                    context="${pageContext}"
+                  />
+                </div>
                 <%@ include file="/WEB-INF/pages/admin/includes/enrollment_buttons.jsp" %>
               </div>
               <%@ include file="/WEB-INF/pages/admin/includes/enrollment_search_filter_panel.jsp" %>
@@ -74,7 +79,20 @@
                   <div class="tabFoot">
                     <div class="tabR">
                       <div class="tabM">
-                        <%@ include file="/WEB-INF/pages/admin/includes/page_navigation.jsp" %>
+                        <div class="pagination">
+                          <div class="left topPagination">
+                            <h:handlebars
+                              template="includes/pagination_details"
+                              context="${pageContext}"
+                            />
+                          </div>
+                          <div class="right">
+                            <h:handlebars
+                              template="includes/pagination_links"
+                              context="${pageContext}"
+                            />
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
@@ -153,7 +153,12 @@
             <c:otherwise>
               <div class="tabContent">
                 <div class="pagination">
-                  <%@ include file="/WEB-INF/pages/admin/includes/page_left_navigation.jsp" %>
+                  <div class="left topPagination">
+                    <h:handlebars
+                      template="includes/pagination_details"
+                      context="${pageContext}"
+                    />
+                  </div>
                   <div class="right">
                     <a id="exportEnrollmentsToPDF" href="javascript:;" class="greyBtn iconPdf">Export to PDF</a>
                     <a id="printEnrollments" href="javascript:;" class="greyBtn iconPrint">Print</a>
@@ -169,7 +174,20 @@
                 <div class="tabFoot">
                   <div class="tabR">
                     <div class="tabM">
-                      <%@ include file="/WEB-INF/pages/admin/includes/page_navigation.jsp" %>
+                      <div class="pagination">
+                        <div class="left topPagination">
+                          <h:handlebars
+                            template="includes/pagination_details"
+                            context="${pageContext}"
+                          />
+                        </div>
+                        <div class="right">
+                          <h:handlebars
+                            template="includes/pagination_links"
+                            context="${pageContext}"
+                          />
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
@@ -36,7 +36,12 @@
             </div>
             <div class="tabContent">
               <div class="pagination">
-                <%@ include file="/WEB-INF/pages/admin/includes/page_left_navigation.jsp" %>
+                <div class="left topPagination">
+                  <h:handlebars
+                    template="includes/pagination_details"
+                    context="${pageContext}"
+                  />
+                </div>
                 <%@ include file="/WEB-INF/pages/admin/includes/enrollment_buttons.jsp" %>
               </div>
               <div <c:choose><c:when test="${searchCriteria.showFilterPanel}">style="display: block"</c:when><c:otherwise>style="display: none"</c:otherwise></c:choose> id="quickEnrollmentFilterPanel" class="filterPanel">
@@ -134,7 +139,20 @@
                   <div class="tabFoot">
                     <div class="tabR">
                       <div class="tabM">
-                        <%@ include file="/WEB-INF/pages/admin/includes/page_navigation.jsp" %>
+                        <div class="pagination">
+                          <div class="left topPagination">
+                            <h:handlebars
+                              template="includes/pagination_details"
+                              context="${pageContext}"
+                            />
+                          </div>
+                          <div class="right">
+                            <h:handlebars
+                              template="includes/pagination_links"
+                              context="${pageContext}"
+                            />
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
@@ -17,6 +17,7 @@
 package gov.medicaid.controllers;
 
 import gov.medicaid.entities.CMSUser;
+import gov.medicaid.entities.SearchResult;
 import gov.medicaid.interceptors.FlashMessageInterceptor;
 import gov.medicaid.security.CMSPrincipal;
 
@@ -25,8 +26,14 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpSession;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 
 /**
  * Utility class for front end controllers.
@@ -35,6 +42,9 @@ import javax.servlet.http.HttpSession;
  * @version 1.0
  */
 public class ControllerHelper {
+
+    static final int MAX_PAGE_LINKS_TO_SHOW = 4;
+    private static final int PREVIOUS_PAGES_TO_SHOW = 2;
 
     /**
      * Private constructor.
@@ -117,5 +127,63 @@ public class ControllerHelper {
     public static void addError(String message) {
         ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
         attr.getRequest().setAttribute(FlashMessageInterceptor.FLASH_ERROR, message);
+    }
+
+    public static void addPaginationLinks(SearchResult<?> results, ModelAndView mv) {
+        int pageNumber = results.getPageNumber();
+        int totalPages = results.getTotalPages();
+
+        mv.addObject("thereArePages", totalPages > 0);
+        mv.addObject("currentPage", pageNumber);
+
+        int firstPage = getFirstPage(pageNumber, totalPages);
+        int lastPage = min(firstPage + MAX_PAGE_LINKS_TO_SHOW, totalPages);
+
+        List<Integer> prevPages = new ArrayList<>();
+        List<Integer> nextPages = new ArrayList<>();
+        for (Integer i = firstPage; i <= lastPage; i++) {
+            if (i < pageNumber) {
+                prevPages.add(i);
+            } else if (i > pageNumber) {
+                nextPages.add(i);
+            }
+        }
+        mv.addObject("prevPages", prevPages);
+        mv.addObject("nextPages", nextPages);
+    }
+
+    public static void addPaginationDetails(SearchResult<?> results, ModelAndView mv) {
+        int pageNumber = results.getPageNumber();
+        int pageSize = results.getPageSize();
+        int itemsOnPage = results.getTotalItems();
+        int lastItemOfPreviousPage = (pageNumber - 1) * pageSize;
+
+        mv.addObject(
+                "pageStartItem",
+                itemsOnPage == 0 ? 0 : lastItemOfPreviousPage + 1
+        );
+        mv.addObject(
+                "pageEndItem",
+                lastItemOfPreviousPage + itemsOnPage
+        );
+        mv.addObject(
+                "pageSize" + String.valueOf(pageSize),
+                true
+        );
+    }
+
+    private static int getFirstPage(int pageNumber, int totalPages) {
+        int firstPage;
+        if (nearEndOfPages(pageNumber, totalPages)) {
+            firstPage = totalPages - MAX_PAGE_LINKS_TO_SHOW;
+        } else {
+            firstPage = pageNumber - PREVIOUS_PAGES_TO_SHOW;
+        }
+        return max(1, firstPage);
+    }
+
+    private static boolean nearEndOfPages(int pageNumber, int totalPages) {
+        final int MAX_FIRST_PAGE = totalPages - MAX_PAGE_LINKS_TO_SHOW;
+        return pageNumber > MAX_FIRST_PAGE;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -37,14 +37,9 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
-
-import static java.lang.Math.max;
-import static java.lang.Math.min;
 
 /**
  * Handles dashboard functions.
@@ -341,71 +336,13 @@ public class ProviderDashboardController extends BaseController {
         ModelAndView mv = new ModelAndView(view);
         mv.addObject("results", results);
 
-        addPaginationDetails(results, mv);
-        addPaginationLinks(results, mv);
+        ControllerHelper.addPaginationDetails(results, mv);
+        ControllerHelper.addPaginationLinks(results, mv);
 
         // revert changes to input
         criteria.setEnrollmentNumber(enrollmentNumber);
         mv.addObject("criteria", criteria);
         return mv;
-    }
-
-    void addPaginationLinks(SearchResult<?> results, ModelAndView mv) {
-        int pageNumber = results.getPageNumber();
-        int totalPages = results.getTotalPages();
-
-        mv.addObject("thereArePages", totalPages > 0);
-        mv.addObject("currentPage", pageNumber);
-
-        int firstPage = getFirstPage(pageNumber, totalPages);
-        int lastPage = min(firstPage + MAX_PAGE_LINKS_TO_SHOW, totalPages);
-
-        List<Integer> prevPages = new ArrayList<>();
-        List<Integer> nextPages = new ArrayList<>();
-        for (Integer i = firstPage; i <= lastPage; i++) {
-            if (i < pageNumber) {
-                prevPages.add(i);
-            } else if (i > pageNumber) {
-                nextPages.add(i);
-            }
-        }
-        mv.addObject("prevPages", prevPages);
-        mv.addObject("nextPages", nextPages);
-    }
-
-    void addPaginationDetails(SearchResult<?> results, ModelAndView mv) {
-        int pageNumber = results.getPageNumber();
-        int pageSize = results.getPageSize();
-        int itemsOnPage = results.getTotalItems();
-        int lastItemOfPreviousPage = (pageNumber - 1) * pageSize;
-
-        mv.addObject(
-                "pageStartItem",
-                itemsOnPage == 0 ? 0 : lastItemOfPreviousPage + 1
-        );
-        mv.addObject(
-                "pageEndItem",
-                lastItemOfPreviousPage + itemsOnPage
-        );
-        mv.addObject(
-                "pageSize" + String.valueOf(pageSize),
-                true
-        );
-    }
-
-    private int getFirstPage(int pageNumber, int totalPages) {
-        int firstPage;
-        if (nearEndOfPages(pageNumber, totalPages)) {
-            firstPage = totalPages - MAX_PAGE_LINKS_TO_SHOW;
-        } else {
-            firstPage = pageNumber - PREVIOUS_PAGES_TO_SHOW;
-        }
-        return max(1, firstPage);
-    }
-
-    private boolean nearEndOfPages(int pageNumber, int totalPages) {
-        final int MAX_FIRST_PAGE = totalPages - MAX_PAGE_LINKS_TO_SHOW;
-        return pageNumber > MAX_FIRST_PAGE;
     }
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
@@ -16,6 +16,7 @@
 
 package gov.medicaid.controllers.admin;
 
+import gov.medicaid.controllers.ControllerHelper;
 import gov.medicaid.entities.AgreementDocument;
 import gov.medicaid.entities.AgreementDocumentSearchCriteria;
 import gov.medicaid.entities.AgreementDocumentType;
@@ -98,6 +99,8 @@ public class AgreementDocumentController extends BaseServiceAdminController {
         ModelAndView model = new ModelAndView("admin/service_admin_agreement_documents");
         model.addObject("agreementDocumentsSearchResult", result);
         model.addObject("searchCriteria", criteria);
+        ControllerHelper.addPaginationDetails(result, model);
+        ControllerHelper.addPaginationLinks(result, model);
         return model;
     }
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -685,6 +685,10 @@ public class EnrollmentController extends BaseController {
         }
         mv.addObject("searchCriteria", criteria);
         supplyLookupValues(mv);
+
+        ControllerHelper.addPaginationDetails(results, mv);
+        ControllerHelper.addPaginationLinks(results, mv);
+
         return mv;
     }
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -120,12 +120,7 @@ public class ProviderTypeController extends BaseServiceAdminController {
         criteria.setPageNumber(1);
         criteria.setPageSize(10);
         criteria.setSortColumn("description");
-
-        SearchResult<ProviderType> result = providerTypeService.search(criteria);
-        ModelAndView model = new ModelAndView("admin/service_admin_provider_types");
-        model.addObject("providerTypesSearchResult", result);
-        model.addObject("searchCriteria", criteria);
-        return model;
+        return search(criteria);
     }
 
     /**
@@ -145,6 +140,8 @@ public class ProviderTypeController extends BaseServiceAdminController {
         ModelAndView model = new ModelAndView("admin/service_admin_provider_types");
         model.addObject("providerTypesSearchResult", result);
         model.addObject("searchCriteria", criteria);
+        ControllerHelper.addPaginationDetails(result, model);
+        ControllerHelper.addPaginationLinks(result, model);
         return model;
     }
 

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/ControllerHelperTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/ControllerHelperTest.groovy
@@ -4,9 +4,9 @@ import gov.medicaid.entities.SearchResult
 import org.springframework.web.servlet.ModelAndView
 import spock.lang.Specification
 
-import static gov.medicaid.controllers.ProviderDashboardController.MAX_PAGE_LINKS_TO_SHOW
+import static gov.medicaid.controllers.ControllerHelper.MAX_PAGE_LINKS_TO_SHOW
 
-class ProviderDashboardControllerTest extends Specification {
+class ControllerHelperTest extends Specification {
 
     def "current page details are added to model"(
             int pageNumber,
@@ -19,7 +19,7 @@ class ProviderDashboardControllerTest extends Specification {
         def results = generateResults(pageNumber, pageSize)
         results.setItems([true] * itemsOnPage)
         def mv = new ModelAndView()
-        def controller = new ProviderDashboardController()
+        def controller = new ControllerHelper()
 
         when:
         controller.addPaginationDetails(results, mv)
@@ -52,7 +52,7 @@ class ProviderDashboardControllerTest extends Specification {
         def results = generateResults(pageNumber, pageSize)
         results.setTotal(totalItems)
         def mv = new ModelAndView()
-        def controller = new ProviderDashboardController()
+        def controller = new ControllerHelper()
 
         when:
         controller.addPaginationLinks(results, mv)

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -181,6 +181,27 @@ function postJson(settings) {
   $.ajax(settings);
 }
 
+/**
+* Changes the page size to the given value
+* @param size the new page size
+*/
+function changePageSize(size) {
+  var form = $('#paginationForm, #searchForm');
+  form.find('input[name=pageSize]').val(size);
+  form.find('input[name=pageNumber]').val(1);
+  form.submit();
+}
+
+/**
+* Changes the page number to the given value
+* @param page the new page number
+*/
+function changePageNumber(page) {
+  var form = $('#paginationForm, #searchForm');
+  form.find('input[name=pageNumber]').val(page);
+  form.submit();
+}
+
 $(document).ready(function () {
 
   $('.searchPanel input[type="checkbox"]')

--- a/psm-app/frontend/src/main/js/script.js
+++ b/psm-app/frontend/src/main/js/script.js
@@ -1871,25 +1871,6 @@ function changeSort(idx) {
   $('#paginationForm').submit();
 }
 
-/**
-* Changes the page size to the given value
-* @param size the new page size
-*/
-function changePageSize(size) {
-  $('#paginationForm input[name=pageSize]').val(size);
-  $('#paginationForm input[name=pageNumber]').val(1);
-  $('#paginationForm').submit();
-}
-
-/**
-* Changes the page number to the given value
-* @param page the new page number
-*/
-function changePageNumber(page) {
-  $('#paginationForm input[name=pageNumber]').val(page);
-  $('#paginationForm').submit();
-}
-
 var isPrimaryPracticeLookup = false;
 var isPrivatePracticeForm = false;
 var practiceLookupResults = {};


### PR DESCRIPTION
Fix #1007 by using the handlebars templates for pagination widgets instead of the JSP templates, moving quite close to being able to remove the buggy JSP templates.  This involves both the `1 2 3 4 5 Next >>` widget and the `Showing 1 of 10` widget.

Tested by going to the Enrollments pages and the search results pages for both provider and service admin logins and confirming that all the pagination widgets look and work as expected.  Also by logging in as a service admin and going to Functions > Provider Types and Functions > Agreements... and testing the `1 2 3 4 5 Next >>` widgets on those pages as well.

There is some follow-up work to do to finish the job, but I wanted to go ahead and get this up for review since it gets us to a better place and fixes of the user-visible glitches.

Resolves #1007: Glitches in pagination widget for service admin tables