### PR TITLE
Remove provider statement date

### DIFF
--- a/psm-app/cms-business-model/src/main/resources/Entities.xsd
+++ b/psm-app/cms-business-model/src/main/resources/Entities.xsd
@@ -387,7 +387,6 @@
       <element name="Name" type="string"/>
       <element name="Title" type="string"/>
       <element name="Signature" type="base64Binary"/>
-      <element name="SignDate" type="date"/>
     </sequence>
   </complexType>
   <complexType name="ValidationResultType">

--- a/psm-app/cms-business-process/src/main/resources/cms.validation.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.validation.drl
@@ -2117,63 +2117,6 @@ dialect 'mvel'
 
 end
 
-rule 'Authorized Representative Signature Date Cannot Be In The Future'
-dialect 'mvel'
-    when
-        LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
-        IsOrganization($provider : provider)
-        ProviderStatementType($signDate: signDate, signDate != null) from $provider.providerStatement
-        eval($signDate.after(Calendar.getInstance()))
-        $report: ErrorReporter()
-    then
-        $report.addError(
-            "/ProviderInformation/ProviderStatement/SignDate",
-            "00001",
-            "Authorized representative signature date cannot be a future date."
-        );
-
-end
-
-rule 'Authorized Representative Signature Date Cannot be past date'
-dialect 'mvel'
-    when
-        LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
-        IsOrganization($provider : provider)
-        ProviderStatementType($signDate: signDate, signDate != null) from $provider.providerStatement
-        eval($signDate.before(getNow()))
-        $report: ErrorReporter()
-    then
-        $report.addError(
-            "/ProviderInformation/ProviderStatement/SignDate",
-            "00001",
-            "Authorized representative signature date cannot be a past date."
-        );
-end
-
-
-rule 'Authorized Representative Signature Date Is Required'
-dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
-    when
-        LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
-        IsOrganization($provider : provider)
-        ProviderStatementType(signDate == null) from $provider.providerStatement
-        $report: ErrorReporter()
-    then
-        $report.addError(
-            "/ProviderInformation/ProviderStatement/SignDate",
-            "00001",
-            "Authorized representative signature date is required."
-        );
-
-end
-
 rule 'Authorized Representative Title Is Required'
 dialect 'mvel'
 /*
@@ -11246,63 +11189,6 @@ dialect 'mvel'
             "/ProviderInformation/ProviderStatement/Name",
             "00001",
             "Provider statement name length cannot exceed 100 characters."
-        );
-
-end
-
-rule 'Provider Statement Signature Date Cannot Be In The Future'
-dialect 'mvel'
-    when
-        LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
-        IsIndividual($provider : provider)
-        ProviderStatementType($signDate: signDate, signDate != null) from $provider.providerStatement
-        eval($signDate.after(Calendar.getInstance()))
-        $report: ErrorReporter()
-    then
-        $report.addError(
-            "/ProviderInformation/ProviderStatement/SignDate",
-            "00001",
-            "Provider statement signature date cannot be a future date."
-        );
-
-end
-
-rule 'Provider Statement Signature Date Cannot be past date'
-dialect 'mvel'
-    when
-        LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
-        IsIndividual($provider : provider)
-        ProviderStatementType($signDate: signDate, signDate != null) from $provider.providerStatement
-        eval($signDate.before(getNow()))
-        $report: ErrorReporter()
-    then
-        $report.addError(
-            "/ProviderInformation/ProviderStatement/SignDate",
-            "00001",
-            "Provider statement signature date cannot be a past date."
-        );
-end
-
-
-rule 'Provider Statement Signature Date Is Required'
-dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
-    when
-        LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
-        IsIndividual($provider : provider)
-        ProviderStatementType(signDate == null) from $provider.providerStatement
-        $report: ErrorReporter()
-    then
-        $report.addError(
-            "/ProviderInformation/ProviderStatement/SignDate",
-            "00001",
-            "Provider statement signature date is required."
         );
 
 end

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/print_modal.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/print_modal.jsp
@@ -76,11 +76,6 @@
 	                        <span class="floatL"><b>:</b></span>
 	                        <span></span>
 	                    </div>
-	                    <div class="row">
-	                        <label>Date</label>
-	                        <span class="floatL"><b>:</b></span>
-	                        <span>${requestScope['_08_date']}</span>
-	                    </div>
                     </div>
                     <div class="clear"></div>
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
@@ -212,24 +212,6 @@
             </c:forEach>
             <div class="clearFixed"></div>
         </div>
-        <div class="bottomSection">
-            <div class="row">
-                <label>Date<span
-                    class="required">*</span></label>
-                <span class="dateWrapper">
-                    <c:set var="formName"
-                        value="_08_date"></c:set>
-                    <c:set var="formValue"
-                        value="${requestScope[formName]}"></c:set>
-                    <input
-                        class="date"
-                        type="text"
-                        name="${formName}"
-                        value="${formValue}"/>
-                </span>
-            </div>
-            <div class="clearFixed"></div>
-        </div>
     </div>
     <div class="tl"></div>
     <div class="tr"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
@@ -61,17 +61,6 @@
             </c:forEach>
             <div class="clearFixed"></div>
         </div>
-        <div class="bottomSection">
-            <div class="row">
-                <c:set var="formName" value="_19_date"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">Date <span class="required">*</span></label>
-                <span class="dateWrapper">
-                    <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
-                </span>
-            </div>
-            <div class="clearFixed"></div>
-        </div>
     </div>
     <div class="tl"></div>
     <div class="tr"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_individual_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_individual_disclosure.jsp
@@ -49,11 +49,6 @@
                     <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_08_title']}</span>
                 </div>
-                <div class="row">
-                    <label>Date</label>
-                    <span class="floatL"><b>:</b></span>
-                    <span>${requestScope['_08_date']}</span>
-                </div>
             </div>
         </div>
         <div class="row">&nbsp;</div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_organization_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_organization_disclosure.jsp
@@ -27,11 +27,6 @@
                     <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_19_title']}</span>
                 </div>
-                <div class="row">
-                    <label>Date</label>
-                    <span class="floatL"><b>:</b></span>
-                    <span>${requestScope['_19_date']}</span>
-                </div>
             </div>
         </div>
         <div class="row">&nbsp;</div>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4628,10 +4628,6 @@ input[type=checkbox]{
   line-height: 18px;
   display: block;
 }
-#printModal span.providerPic{
-  padding: 0 10px;
-  display: block;
-}
 
 /* END OF ORGANIZATION PROVIDER TYPE STYLES ------------------------------------- */
 

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -2025,33 +2025,6 @@ input.date{
   margin:0 4px 0 0;
 }
 
-/* .bottomSection */
-.providerPanel .bottomSection{
-  min-height:10px;
-  margin:0 10px;
-  padding:10px 0 4px 0;
-  border-top:#d2d2d2 solid 1px;
-}
-
-.providerPanel .bottomSection .providerPic{
-  width:auto;
-  height:76px;
-  float:left;
-  display:inline;
-  margin:0 7px;
-}
-
-.providerPanel .bottomSection input.date{
-  width:95px;
-  height:20px;
-  padding-left:5px;
-  line-height:20px;
-  float:left;
-  margin:4px 7px 0;
-  border:1px solid #7ea5c8;
-  background:url(../i/input-bg.png) repeat-x left top;
-}
-
 /* radioPanel */
 .radioPanel{
   width:100%;

--- a/psm-app/db/changelog/db-changelog-1.0.xml
+++ b/psm-app/db/changelog/db-changelog-1.0.xml
@@ -2021,4 +2021,12 @@
     <rollback changeSetId="issue254-seed-service-categories" changeSetAuthor="" />
   </changeSet>
 
+  <changeSet author="" id="issue1021-remove-sign-date">
+    <dropColumn tableName="provider_statements" columnName="date"/>
+    <rollback>
+      <addColumn tableName="provider_statements">
+        <column name="date" type="date"/>
+      </addColumn>
+    </rollback>
+  </changeSet>
 </databaseChangeLog>

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -105,12 +105,12 @@ public class EnrollmentStepDefinitions {
     @When("^I enter my individual provider statement$")
     public void i_enter_my_provider_statement() {
         enrollmentSteps.checkNoOnProviderDisclosureQuestions();
-        enrollmentSteps.signAndDateProviderStatement();
+        enrollmentSteps.signProviderStatement();
     }
 
     @When("^I enter my organization provider statement$")
     public void i_enter_my_organization_provider_statement() {
-        enrollmentSteps.signAndDateProviderStatement();
+        enrollmentSteps.signProviderStatement();
     }
 
     @When("^I submit the enrollment$")

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -470,10 +470,9 @@ public class EnrollmentSteps {
     }
 
     @Step
-    void signAndDateProviderStatement() {
+    void signProviderStatement() {
         providerStatementPage.enterProviderName(LAST_NAME);
         providerStatementPage.enterProviderTitle("Title");
-        providerStatementPage.enterValidDate();
     }
 
     @Step

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/ProviderStatementPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/ProviderStatementPage.java
@@ -2,8 +2,6 @@ package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;
 
-import java.time.LocalDate;
-
 public class ProviderStatementPage extends PsmPage {
     public void checkNoCriminalConviction() {
         click($("[name=_08_criminalConvictionInd][value='N']"));
@@ -35,11 +33,6 @@ public class ProviderStatementPage extends PsmPage {
 
     public void enterProviderTitle(String providerTitle) {
         $("[name=_08_title], [name=_19_title]").type(providerTitle);
-    }
-
-    public void enterValidDate() {
-        String currentDate = LocalDate.now().format(DATE_FORMATTER);
-        $("[name=_08_date], [name=_19_date]").type(currentDate);
     }
 
     public void clickSubmitButton() {

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
@@ -110,12 +110,6 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
         ProviderStatementType statement = XMLUtility.nsGetProviderStatement(enrollment);
         statement.setName(param(request, "name"));
         statement.setTitle(param(request, "title"));
-        try {
-            statement.setSignDate(BinderUtils.getAsCalendar(param(request, "date")));
-        } catch (BinderException e) {
-            e.setAttribute(name("date"), param(request, "date"));
-            exceptions.add(e);
-        }
 
         ProviderType pt = getLookupService().getProviderTypeWithAgreementDocuments(
                 provider
@@ -192,7 +186,6 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
             ProviderStatementType statement = XMLUtility.nsGetProviderStatement(enrollment);
             attr(mv, "name", statement.getName());
             attr(mv, "title", statement.getTitle());
-            attr(mv, "date", statement.getSignDate());
 
             AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
 
@@ -261,8 +254,6 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
                     errors.add(createError("name", ruleError.getMessage()));
                 } else if (path.equals(STATEMENT + "Title")) {
                     errors.add(createError("title", ruleError.getMessage()));
-                } else if (path.equals(STATEMENT + "SignDate")) {
-                    errors.add(createError("date", ruleError.getMessage()));
                 }
 
                 if (errors.size() > count) { // caught
@@ -332,7 +323,6 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
 
         hStatement.setName(xStatement.getName());
         hStatement.setTitle(xStatement.getTitle());
-        hStatement.setDate(BinderUtils.toDate(xStatement.getSignDate()));
     }
 
     /**
@@ -434,7 +424,6 @@ public class IndividualDisclosureFormBinder extends BaseFormBinder {
             ProviderStatementType xStatement = XMLUtility.nsGetProviderStatement(enrollment);
             xStatement.setName(hStatement.getName());
             xStatement.setTitle(hStatement.getTitle());
-            xStatement.setSignDate(BinderUtils.toCalendar(hStatement.getDate()));
         }
     }
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
@@ -90,12 +90,6 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
         ProviderStatementType statement = XMLUtility.nsGetProviderStatement(enrollment);
         statement.setName(param(request, "name"));
         statement.setTitle(param(request, "title"));
-        try {
-            statement.setSignDate(BinderUtils.getAsCalendar(param(request, "date")));
-        } catch (BinderException e) {
-            e.setAttribute(name("date"), param(request, "date"));
-            exceptions.add(e);
-        }
 
         List<AgreementDocument> docs = getLookupService().getProviderTypeWithAgreementDocuments(
                 provider
@@ -170,7 +164,6 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
             ProviderStatementType statement = XMLUtility.nsGetProviderStatement(enrollment);
             attr(mv, "name", statement.getName());
             attr(mv, "title", statement.getTitle());
-            attr(mv, "date", statement.getSignDate());
 
             AcceptedAgreementsType acceptedAgreements = provider.getAcceptedAgreements();
 
@@ -233,8 +226,6 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
                     errors.add(createError("name", ruleError.getMessage()));
                 } else if (path.equals(STATEMENT + "Title")) {
                     errors.add(createError("title", ruleError.getMessage()));
-                } else if (path.equals(STATEMENT + "SignDate")) {
-                    errors.add(createError("date", ruleError.getMessage()));
                 }
 
                 if (errors.size() > count) { // caught
@@ -299,7 +290,6 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
 
         hStatement.setName(xStatement.getName());
         hStatement.setTitle(xStatement.getTitle());
-        hStatement.setDate(BinderUtils.toDate(xStatement.getSignDate()));
     }
 
     /**
@@ -398,7 +388,6 @@ public class OrganizationStatementFormBinder extends BaseFormBinder {
             ProviderStatementType xStatement = XMLUtility.nsGetProviderStatement(enrollment);
             xStatement.setName(hStatement.getName());
             xStatement.setTitle(hStatement.getTitle());
-            xStatement.setSignDate(BinderUtils.toCalendar(hStatement.getDate()));
         }
     }
 }

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
@@ -22,7 +22,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import java.io.Serializable;
-import java.util.Date;
 
 @javax.persistence.Entity
 @Table(name = "provider_statements")
@@ -44,8 +43,6 @@ public class ProviderStatement implements Serializable {
     private String name;
 
     private String title;
-
-    private Date date;
 
     public long getId() {
         return id;
@@ -69,14 +66,6 @@ public class ProviderStatement implements Serializable {
 
     public void setTitle(String title) {
         this.title = title;
-    }
-
-    public Date getDate() {
-        return date;
-    }
-
-    public void setDate(Date date) {
-        this.date = date;
     }
 
     public long getProfileId() {


### PR DESCRIPTION
The last page of the enrollment application process is for the user to sign a provider statement. Previously, we included the date on that page, and required the user to type in today's date.

It turns out this is neither necessary nor useful. We don't require it for legal reasons. It's bad UX, because there's only one acceptable answer, and the system knows what it is.  Additionally, if an admin needs to later edit the application, they were sometimes forced to update the signature date, which is both annoying and incorrect.

Remove the signing date entirely: do not ask for it, do not test that it is a valid value, do not record it, and do not display it. Instead, we can rely upon the application submission date.

---

Here's how it looks after this change.

An individual provider statement page:

![individual-provider-statement](https://user-images.githubusercontent.com/1494855/44061404-359b4224-9f26-11e8-8fb5-61d8a8078f40.png)

An organization provider statement page:

![ctcc-provider-statement](https://user-images.githubusercontent.com/1494855/44061411-3c577a06-9f26-11e8-84fa-90dd62c90e0b.png)

---

To test this, I created enrollments as an individual and an organization, and verified that the last page did not contain a date field and that I could successfully submit the enrollment application.

Issue #162 Provider enrollment: "Provider Statement" UI improvements
Issue #301 When service admin edits pending enrollment, PSM inappropriately checks provider statement date
Resolves #1021 Remove date field from provider disclosure forms