### PR TITLE
Add Action column with View link on service admin Dashboard page

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -42,6 +42,15 @@
               </c:when>
               <c:otherwise>
                 <table class="generalTable fixedWidthTable">
+                  <colgroup>
+                    <col width="100"/>
+                    <col width="*"/>
+                    <col width="100"/>
+                    <col width="95"/>
+                    <col width="85"/>
+                    <col width="75"/>
+                    <col width="60"/>
+                  </colgroup>
                   <thead>
                     <tr>
                       <th class="alignCenter">NPI / UMPI<span class="sep"></span></th>
@@ -50,19 +59,23 @@
                       <th class="alignCenter">Request Type<span class="sep"></span></th>
                       <th class="alignCenter">Date<span class="sep"></span></th>
                       <th class="alignCenter">Status<span class="sep"></span></th>
+                      <th class="alignCenter">Action<span class="sep"></span></th>
                     </tr>
                   </thead>
                   <tbody>
                     <c:forEach items="${profiles}" var="item">
                       <tr>
-                        <td>
-                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">${item.npi}</a>
-                        </td>
+                        <td>${item.npi}</td>
                         <td>${item.providerType}</td>
                         <td>${item.providerName}</td>
                         <td>${item.requestType}</td>
                         <td><fmt:formatDate value="${item.statusDate}" pattern="MM/dd/yyyy"/></td>
                         <td>${item.status}</td>
+                        <td>
+                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+                            View
+                          </a>
+                        </td>
                       </tr>
                     </c:forEach>
                   </tbody>


### PR DESCRIPTION
Add an Action column with View links on service admin Dashboard page, and remove the link from the NPI numbers because some providers' applications don't have NPI numbers.

Tested by logging in as a system admin and clicking the View links in the Action column.

Before:

![screenshot_2018-08-16 dashboard 1](https://user-images.githubusercontent.com/1091693/44218196-2e84b880-a147-11e8-963e-306ed0cb1654.png)

After:

![screenshot_2018-08-16 dashboard](https://user-images.githubusercontent.com/1091693/44218203-33496c80-a147-11e8-9391-8df11c71992b.png)

Resolves #672 Empty link text for providers with no NPI