### PR TITLE
Fix dropdown menus being too short and narrow

### DIFF
--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -961,12 +961,8 @@ input.date{
   width:10%;
 }
 
-.firstRegistrant .wholeCol select{
-  width:265px;
-  float:left;
-  margin:4px 7px 0;
-  height:20px;
-  line-height:20px;
+.firstRegistrant .wholeCol select {
+  margin: 0px 7px;
 }
 
 /* buttonBox */
@@ -1244,8 +1240,6 @@ input.date{
   width:212px;
   float:left;
   margin:4px 7px 0;
-  height:20px;
-  line-height:20px;
 }
 
 .newEnrollmentPanel .checkbox{
@@ -1483,7 +1477,7 @@ input.date{
 .practicePanel .inlineBox select,
 .practicePanel .reimbursementAddressRow select{
   width:120px;
-  margin:6px 27px 0px 7px;
+  margin: 0px 27px 0px 7px;
 }
 
 .practicePanel .addPracticeLocations input.normalInput{
@@ -1526,9 +1520,7 @@ input.date{
 .practicePanel select{
   width:212px;
   float:left;
-  margin:4px 7px 0;
-  height:20px;
-  line-height:20px;
+  margin: 0px 7px;
 }
 
 .practicePanel .addPracticeLocations select{


### PR DESCRIPTION
These changes remove the height-setting CSS styles that make drop down menus in the enrollment steps too short.  They also remove the width-setting CSS styles that make the provider type menu too
narrow. (Changing the width of other menus would disrupt the positioning of other items near them, so that remains unchanged.)

Tested by clicking through the enrollment steps for a Durable Medical Equipment application and an Audiologist application to see that the drop down menus are not too short, and that the provider type menu is also not too narrow.

Before:

![screenshot_2018-08-16 provider type page 2](https://user-images.githubusercontent.com/1091693/44224771-714f8c00-a159-11e8-8eef-afa8fb8976fa.png)

After:

![screenshot_2018-08-16 provider type page 1](https://user-images.githubusercontent.com/1091693/44224699-3d746680-a159-11e8-8e88-22bebf275126.png)

Another after (widest option):

![screenshot_2018-08-16 provider type page 3](https://user-images.githubusercontent.com/1091693/44224863-cb505180-a159-11e8-8546-072dd24ac23d.png)

Resolves #163: dropdown menus too short and narrow