### PR TITLE
Fix #708: Rendering issues in Facility Credentials screen

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
@@ -67,7 +67,7 @@
                 <tr>
                     <th class="firstTheader">#<span class="sep"></span></th>
                     <th class="alignCenter"><span class="multi">Type of License<br/>/Certification</span> <span class="required-dark-background">*</span><span class="sep"></span></th>
-                    <th class="alignCenter"><span class="multi">License/Certification Number</span> <span class="required-dark-background">*</span><span class="sep"></span></th>
+                    <th class="alignCenter"><span class="multi">License/Certification<br/> Number</span> <span class="required-dark-background">*</span><span class="sep"></span></th>
                     <th class="alignCenter"><span class="multi">Original Issue Date<br/> (MM/DD/YYYY)</span> <span class="required-dark-background">*</span><span class="sep"></span></th>
                     <th class="alignCenter"><span class="multi">Renewal End Date<br/> (MM/DD/YYYY)</span> <span class="required-dark-background">*</span><span class="sep"></span></th>
                     <th class="alignCenter">Issuing State <span class="required-dark-background">*</span><span class="sep"></span></th>


### PR DESCRIPTION
Before:

![screenshot_2018-08-20 facility credentials](https://user-images.githubusercontent.com/1091693/44347830-e0cdc000-a466-11e8-87ea-a9f0263d894d.png)


After:

![screenshot_2018-08-20 facility credentials 1](https://user-images.githubusercontent.com/1091693/44347835-e3c8b080-a466-11e8-8c1c-19835a0e10e2.png)


Tested by logging in as a provider and starting to fill out a "Head Start" application, and seeing that the table header formatting was indeed fixed as shown above.

Resolves #708 Rendering issues in Facility Credentials screen