### PR TITLE
Rename user docs to "user help" rather than "user manual"

### DIFF
--- a/psm-app/userhelp/source/conf.py
+++ b/psm-app/userhelp/source/conf.py
@@ -49,7 +49,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Provider Screening Module user manual'
+project = u'Provider Screening Module user help'
 copyright = u'2017, (TBD)'
 author = u'Solution Guidance Corporation'
 
@@ -166,7 +166,7 @@ latex_toplevel_sectioning = 'chapter'
 # -- Options for Epub output ----------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = "Provider Service Module user manual"
+epub_title = "Provider Service Module user help"
 epub_author = "Solution Guidance Corporation"
 epub_publisher = "Solution Guidance Corporation https://github.com/SolutionGuidance/psm/"
 epub_copyright = copyright


### PR DESCRIPTION
Tested by logging in as a provider, clicking the "Help" link at the top left to view the user help documentation pages, and confirming that the title was changed as expected.

Before: 

![screenshot-2018-2-21 welcome to provider screening module s documentation provider screening module user manual 1 0 docum](https://user-images.githubusercontent.com/1497818/36499379-a934e058-1706-11e8-88b9-225c8abc836e.png)

After:

![screenshot_2018-08-20 welcome to provider screening module s documentation provider screening module user help 1 0 docume](https://user-images.githubusercontent.com/1091693/44348383-43738b80-a468-11e8-9dcd-15485eee7ded.png)

Resolves #681: Rename built user docs to "user help" or "user FAQ"