### PR TITLE
Spring annotations controllers

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -135,11 +135,7 @@
 
   <bean id="OnboardingController"
         class="gov.medicaid.controllers.OnboardingController"
-        parent="BaseController">
-    <property name="onboardingService" ref="OnboardingService"/>
-    <property name="registrationService" ref="RegistrationService"/>
-    <property name="validator" ref="AccountLinkFormValidator"/>
-  </bean>
+        parent="BaseController"/>
 
   <bean id="MyProfileController"
         class="gov.medicaid.controllers.MyProfileController"

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -127,14 +127,7 @@
 
   <bean id="EnrollmentPageFlowController"
         class="gov.medicaid.controllers.EnrollmentPageFlowController"
-        parent="BaseController">
-    <property name="enrollmentWebService" ref="EnrollmentWebService"/>
-    <property name="presentationService" ref="PresentationService"/>
-    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-    <property name="exportService" ref="ExportService"/>
-    <property name="lookupService" ref="LookupService"/>
-    <property name="notificationService" ref="NotificationService"/>
-  </bean>
+        parent="BaseController"/>
 
   <bean id="ProviderDashboardController"
         class="gov.medicaid.controllers.ProviderDashboardController"

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -139,11 +139,7 @@
 
   <bean id="MyProfileController"
         class="gov.medicaid.controllers.MyProfileController"
-        parent="BaseController">
-    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-    <property name="registrationService" ref="RegistrationService"/>
-    <property name="validator" ref="UpdatePasswordFormValidator"/>
-  </bean>
+        parent="BaseController"/>
 
   <context:component-scan
       base-package="gov.medicaid.controllers.admin" />

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -131,10 +131,7 @@
 
   <bean id="ProviderDashboardController"
         class="gov.medicaid.controllers.ProviderDashboardController"
-        parent="BaseController">
-    <property name="enrollmentService" ref="ProviderEnrollmentService"/>
-    <property name="exportService" ref="ExportService"/>
-  </bean>
+        parent="BaseController"/>
 
   <bean id="OnboardingController"
         class="gov.medicaid.controllers.OnboardingController"

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -109,40 +109,8 @@
     </property>
   </bean>
 
-  <bean id="BaseController"
-        class="gov.medicaid.controllers.BaseController"
-        abstract="true">
-  </bean>
-
-  <bean id="SelfRegistrationController"
-        class="gov.medicaid.controllers.SelfRegistrationController"
-        parent="BaseController"/>
-
-  <bean id="ForgotPasswordController"
-        class="gov.medicaid.controllers.ForgotPasswordController"
-        parent="BaseController"/>
-
-  <bean id="LandingController"
-        class="gov.medicaid.controllers.LandingController"/>
-
-  <bean id="EnrollmentPageFlowController"
-        class="gov.medicaid.controllers.EnrollmentPageFlowController"
-        parent="BaseController"/>
-
-  <bean id="ProviderDashboardController"
-        class="gov.medicaid.controllers.ProviderDashboardController"
-        parent="BaseController"/>
-
-  <bean id="OnboardingController"
-        class="gov.medicaid.controllers.OnboardingController"
-        parent="BaseController"/>
-
-  <bean id="MyProfileController"
-        class="gov.medicaid.controllers.MyProfileController"
-        parent="BaseController"/>
-
   <context:component-scan
-      base-package="gov.medicaid.controllers.admin" />
+      base-package="gov.medicaid.controllers" />
 
   <bean id="RegistrationFormValidator" class="gov.medicaid.controllers.validators.RegistrationFormValidator">
     <property name="registrationService" ref="RegistrationService"/>
@@ -212,7 +180,4 @@
   <bean id="UserValidator" class="gov.medicaid.controllers.admin.UserValidator">
     <property name="registrationService" ref="RegistrationService"/>
   </bean>
-
-  <bean id="ErrorController"
-        class="gov.medicaid.controllers.ErrorController"/>
 </beans>

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -116,10 +116,7 @@
 
   <bean id="SelfRegistrationController"
         class="gov.medicaid.controllers.SelfRegistrationController"
-        parent="BaseController">
-    <property name="registrationService" ref="RegistrationService"/>
-    <property name="validator" ref="RegistrationFormValidator"/>
-  </bean>
+        parent="BaseController"/>
 
   <bean id="ForgotPasswordController"
         class="gov.medicaid.controllers.ForgotPasswordController"

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -120,10 +120,7 @@
 
   <bean id="ForgotPasswordController"
         class="gov.medicaid.controllers.ForgotPasswordController"
-        parent="BaseController">
-    <property name="registrationService" ref="RegistrationService"/>
-    <property name="validator" ref="ForgotPasswordFormValidator"/>
-  </bean>
+        parent="BaseController"/>
 
   <bean id="LandingController"
         class="gov.medicaid.controllers.LandingController"/>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
@@ -53,11 +53,6 @@ public abstract class BaseController {
     }
 
     /**
-     * Ensure the object is properly initialized
-     */
-    protected void init() {}
-
-    /**
      * Sets up custom editors.
      *
      * @param binder the current binder registry

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -60,7 +60,6 @@ import gov.medicaid.services.EnrollmentWebService;
 import gov.medicaid.services.ExportService;
 import gov.medicaid.services.LookupService;
 import gov.medicaid.services.NotificationService;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.PortalServiceRuntimeException;
 import gov.medicaid.services.PresentationService;
@@ -80,7 +79,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestWrapper;
 import javax.servlet.http.HttpServletRequest;
@@ -116,82 +114,47 @@ public class EnrollmentPageFlowController extends BaseController {
     @SuppressWarnings("unchecked")
     public static final List<FormError> NO_ERRORS = (List<FormError>) Collections.EMPTY_LIST;
 
-    /**
-     * The enrollment service.
-     */
-    private EnrollmentWebService enrollmentWebService;
-
-    /**
-     * The enrollment service.
-     */
-    private PresentationService presentationService;
-
-    /**
-     * Provider enrollment service.
-     */
-    private ProviderEnrollmentService enrollmentService;
-
-    private NotificationService notificationService;
-
-    /**
-     * Used for exporting PDFs.
-     */
-    private ExportService exportService;
-
-    /**
-     * Used for lookup values.
-     */
-    private LookupService lookupService;
+    private final EnrollmentWebService enrollmentWebService;
+    private final PresentationService presentationService;
+    private final ProviderEnrollmentService enrollmentService;
+    private final NotificationService notificationService;
+    private final ExportService exportService;
+    private final LookupService lookupService;
 
     /**
      * Registry of binders.
      */
-    private Map<String, FormBinder> binderRegistry = null;
+    private final Map<String, FormBinder> binderRegistry;
 
     /**
      * Registry of forms.
      */
-    private Map<String, String> formViewRegistry = null;
+    private final Map<String, String> formViewRegistry;
 
     /**
      * Registry of form displays.
      */
-    private Map<String, String> summaryViewRegistry = null;
+    private final Map<String, String> summaryViewRegistry;
 
     /**
      * Hash key for hidden input security.
      */
-    private String serverHashKey;
+    private final String serverHashKey;
 
-    /**
-     * Empty constructor.
-     */
-    public EnrollmentPageFlowController() {
-    }
-
-    /**
-     * This method checks that all required injection fields are in fact
-     * provided.
-     *
-     * @throws PortalServiceConfigurationException If there are required
-     *                                             injection fields that are not
-     *                                             injected
-     */
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (enrollmentWebService == null) {
-            throw new PortalServiceConfigurationException("enrollmentWebService is not configured correctly.");
-        }
-        if (presentationService == null) {
-            throw new PortalServiceConfigurationException("presentationService is not configured correctly.");
-        }
-        if (exportService == null) {
-            throw new PortalServiceConfigurationException("exportService is not configured correctly.");
-        }
-        if (notificationService == null) {
-          throw new PortalServiceConfigurationException("notificationService is not configured correctly.");
-        }
+    public EnrollmentPageFlowController(
+        EnrollmentWebService enrollmentWebService,
+        PresentationService presentationService,
+        ProviderEnrollmentService enrollmentService,
+        NotificationService notificationService,
+        ExportService exportService,
+        LookupService lookupService
+    ) {
+        this.enrollmentWebService = enrollmentWebService;
+        this.presentationService = presentationService;
+        this.enrollmentService = enrollmentService;
+        this.notificationService = notificationService;
+        this.exportService = exportService;
+        this.lookupService = lookupService;
 
         CMSConfigurator config = new CMSConfigurator();
         binderRegistry = config.getBinderRegistry();
@@ -730,7 +693,7 @@ public class EnrollmentPageFlowController extends BaseController {
             PracticeSearchCriteria criteria
     ) {
         CMSUser user = ControllerHelper.getCurrentUser();
-        SearchResult<PracticeLookup> results = getEnrollmentService().searchPractice(user, criteria);
+        SearchResult<PracticeLookup> results = enrollmentService.searchPractice(user, criteria);
         List<PracticeLookup> items = results.getItems();
         if (items != null) {
             for (PracticeLookup item : items) {
@@ -754,7 +717,7 @@ public class EnrollmentPageFlowController extends BaseController {
     public List<ProviderLookup> lookupProvider(
             @RequestParam("npi") String npi
     ) {
-        List<ProviderLookup> results = getEnrollmentService().lookupProvider(npi);
+        List<ProviderLookup> results = enrollmentService.lookupProvider(npi);
         if (results != null) {
             for (ProviderLookup item : results) {
                 String hash = Util.hash("" + item.getProfileId(), serverHashKey);
@@ -1276,7 +1239,7 @@ public class EnrollmentPageFlowController extends BaseController {
             long ticketId = BinderUtils.getAsLong(enrollment.getObjectId());
             if (ticketId > 0) {
                 long profileId = BinderUtils.getAsLong(enrollment.getProviderInformation().getObjectId());
-                Validity validity = getEnrollmentService().getSubmissionValidity(ticketId, profileId);
+                Validity validity = enrollmentService.getSubmissionValidity(ticketId, profileId);
                 if (validity == Validity.STALE) {
                     ControllerHelper.popup("staleTicket");
                 }
@@ -1565,72 +1528,5 @@ public class EnrollmentPageFlowController extends BaseController {
         } else {
             return Optional.empty();
         }
-    }
-
-    /**
-     * Sets the value of the field <code>enrollmentWebService</code>.
-     *
-     * @param enrollmentWebService the enrollmentWebService to set
-     */
-    public void setEnrollmentWebService(EnrollmentWebService enrollmentWebService) {
-        this.enrollmentWebService = enrollmentWebService;
-    }
-
-    /**
-     * Sets the value of the field <code>presentationService</code>.
-     *
-     * @param presentationService the presentationService to set
-     */
-    public void setPresentationService(PresentationService presentationService) {
-        this.presentationService = presentationService;
-    }
-
-    /**
-     * Sets the value of the field <code>binderRegistry</code>.
-     *
-     * @param binderRegistry the binderRegistry to set
-     */
-    public void setBinderRegistry(Map<String, FormBinder> binderRegistry) {
-        this.binderRegistry = binderRegistry;
-    }
-
-    /**
-     * Gets the value of the field <code>enrollmentService</code>.
-     *
-     * @return the enrollmentService
-     */
-    public ProviderEnrollmentService getEnrollmentService() {
-        return enrollmentService;
-    }
-
-    /**
-     * Sets the value of the field <code>enrollmentService</code>.
-     *
-     * @param enrollmentService the enrollmentService to set
-     */
-    public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
-        this.enrollmentService = enrollmentService;
-    }
-
-    /**
-     * Sets the value of the field <code>exportService</code>.
-     *
-     * @param exportService the exportService to set
-     */
-    public void setExportService(ExportService exportService) {
-        this.exportService = exportService;
-    }
-
-    /**
-     * Sets the value of the field <code>lookupService</code>.
-     *
-     * @param lookupService the lookupService to set
-     */
-    public void setLookupService(LookupService lookupService) {
-        this.lookupService = lookupService;
-    }
-
-    public void setNotificationService(NotificationService notificationService) {
-        this.notificationService = notificationService;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
@@ -18,7 +18,6 @@ package gov.medicaid.controllers;
 
 import gov.medicaid.controllers.forms.ForgotPasswordForm;
 import gov.medicaid.controllers.validators.ForgotPasswordFormValidator;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.RegistrationService;
 
@@ -28,8 +27,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
-
-import javax.annotation.PostConstruct;
 
 /**
  * Handles requests to regenerated passwords.
@@ -41,37 +38,15 @@ import javax.annotation.PostConstruct;
 @Controller
 @RequestMapping("/forgotpassword")
 public class ForgotPasswordController extends BaseController {
+    private final RegistrationService registrationService;
+    private final ForgotPasswordFormValidator validator;
 
-    /**
-     * The registration service.
-     */
-    private RegistrationService registrationService;
-
-    /**
-     * The request validator.
-     */
-    private ForgotPasswordFormValidator validator;
-
-    /**
-     * Empty constructor.
-     */
-    public ForgotPasswordController() {
-    }
-
-    /**
-     * This method checks that all required injection fields are in fact provided.
-     *
-     * @throws PortalServiceConfigurationException - If there are required injection fields that are not injected
-     */
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (registrationService == null) {
-            throw new PortalServiceConfigurationException("registrationService is not configured correctly.");
-        }
-        if (validator == null) {
-            throw new PortalServiceConfigurationException("validator is not configured correctly.");
-        }
+    public ForgotPasswordController(
+        RegistrationService registrationService,
+        ForgotPasswordFormValidator validator
+    ) {
+        this.registrationService = registrationService;
+        this.validator = validator;
     }
 
     /**
@@ -127,23 +102,4 @@ public class ForgotPasswordController extends BaseController {
             return new ModelAndView("redirect:/login");
         }
     }
-
-    /**
-     * Sets the value of the field <code>registrationService</code>.
-     *
-     * @param registrationService the registrationService to set
-     */
-    public void setRegistrationService(RegistrationService registrationService) {
-        this.registrationService = registrationService;
-    }
-
-    /**
-     * Sets the value of the field <code>validator</code>.
-     *
-     * @param validator the validator to set
-     */
-    public void setValidator(ForgotPasswordFormValidator validator) {
-        this.validator = validator;
-    }
-
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
@@ -26,7 +26,6 @@ import gov.medicaid.entities.UserRequest;
 import gov.medicaid.entities.Validity;
 import gov.medicaid.entities.dto.ViewStatics;
 import gov.medicaid.security.CMSPrincipal;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 import gov.medicaid.services.RegistrationService;
@@ -38,8 +37,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
-
-import javax.annotation.PostConstruct;
 
 import java.util.Arrays;
 import java.util.List;
@@ -54,45 +51,18 @@ import java.util.List;
 @Controller
 @RequestMapping("/provider/profile/*")
 public class MyProfileController extends BaseController {
+    private final ProviderEnrollmentService enrollmentService;
+    private final RegistrationService registrationService;
+    private final UpdatePasswordFormValidator validator;
 
-    /**
-     * Enrollment service.
-     */
-    private ProviderEnrollmentService enrollmentService;
-
-    /**
-     * Registration service.
-     */
-    private RegistrationService registrationService;
-
-    /**
-     * Request validator.
-     */
-    private UpdatePasswordFormValidator validator;
-
-    /**
-     * Empty constructor.
-     */
-    public MyProfileController() {
-    }
-
-    /**
-     * This method checks that all required injection fields are in fact provided.
-     *
-     * @throws PortalServiceConfigurationException - If there are required injection fields that are not injected
-     */
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (enrollmentService == null) {
-            throw new PortalServiceConfigurationException("enrollmentService is not configured correctly.");
-        }
-        if (registrationService == null) {
-            throw new PortalServiceConfigurationException("registrationService is not configured correctly.");
-        }
-        if (validator == null) {
-            throw new PortalServiceConfigurationException("validator is not configured correctly.");
-        }
+    public MyProfileController(
+        ProviderEnrollmentService enrollmentService,
+        RegistrationService registrationService,
+        UpdatePasswordFormValidator validator
+    ) {
+        this.enrollmentService = enrollmentService;
+        this.registrationService = registrationService;
+        this.validator = validator;
     }
 
     /**
@@ -254,32 +224,5 @@ public class MyProfileController extends BaseController {
             mv.addObject("profileId", profileId);
             return mv;
         }
-    }
-
-    /**
-     * Sets the value of the field <code>enrollmentService</code>.
-     *
-     * @param enrollmentService the enrollmentService to set
-     */
-    public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
-        this.enrollmentService = enrollmentService;
-    }
-
-    /**
-     * Sets the value of the field <code>registrationService</code>.
-     *
-     * @param registrationService the registrationService to set
-     */
-    public void setRegistrationService(RegistrationService registrationService) {
-        this.registrationService = registrationService;
-    }
-
-    /**
-     * Sets the value of the field <code>validator</code>.
-     *
-     * @param validator the validator to set
-     */
-    public void setValidator(UpdatePasswordFormValidator validator) {
-        this.validator = validator;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
@@ -24,7 +24,6 @@ import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.SystemId;
 import gov.medicaid.security.CMSPrincipal;
 import gov.medicaid.services.OnboardingService;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.RegistrationService;
 import gov.medicaid.services.util.Util;
@@ -36,8 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
-
-import javax.annotation.PostConstruct;
 
 import java.util.List;
 
@@ -51,45 +48,18 @@ import java.util.List;
 @Controller
 @RequestMapping("/provider/onboarding/*")
 public class OnboardingController extends BaseController {
+    private final OnboardingService onboardingService;
+    private final RegistrationService registrationService;
+    private final AccountLinkFormValidator validator;
 
-    /**
-     * Onboarding data service.
-     */
-    private OnboardingService onboardingService;
-
-    /**
-     * Registration service.
-     */
-    private RegistrationService registrationService;
-
-    /**
-     * Account link validator.
-     */
-    private AccountLinkFormValidator validator;
-
-    /**
-     * Empty constructor.
-     */
-    public OnboardingController() {
-    }
-
-    /**
-     * This method checks that all required injection fields are in fact provided.
-     *
-     * @throws PortalServiceConfigurationException - If there are required injection fields that are not injected
-     */
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (onboardingService == null) {
-            throw new PortalServiceConfigurationException("onboardingService is not configured correctly.");
-        }
-        if (registrationService == null) {
-            throw new PortalServiceConfigurationException("registrationService is not configured correctly.");
-        }
-        if (validator == null) {
-            throw new PortalServiceConfigurationException("validator is not configured correctly.");
-        }
+    public OnboardingController(
+        OnboardingService onboardingService,
+        RegistrationService registrationService,
+        AccountLinkFormValidator validator
+    ) {
+        this.onboardingService = onboardingService;
+        this.registrationService = registrationService;
+        this.validator = validator;
     }
 
     /**
@@ -269,32 +239,5 @@ public class OnboardingController extends BaseController {
         link.setExternalUserId(accountLinkForm.getAccountId());
         link.setSystemId(SystemId.valueOf(accountLinkForm.getSystemId()));
         return link;
-    }
-
-    /**
-     * Sets the value of the field <code>onboardingService</code>.
-     *
-     * @param onboardingService the onboardingService to set
-     */
-    public void setOnboardingService(OnboardingService onboardingService) {
-        this.onboardingService = onboardingService;
-    }
-
-    /**
-     * Sets the value of the field <code>registrationService</code>.
-     *
-     * @param registrationService the registrationService to set
-     */
-    public void setRegistrationService(RegistrationService registrationService) {
-        this.registrationService = registrationService;
-    }
-
-    /**
-     * Sets the value of the field <code>validator</code>.
-     *
-     * @param validator the validator to set
-     */
-    public void setValidator(AccountLinkFormValidator validator) {
-        this.validator = validator;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -66,8 +66,6 @@ public class ProviderDashboardController extends BaseController {
      * Used to export results to PDF.
      */
     private ExportService exportService;
-    static final int MAX_PAGE_LINKS_TO_SHOW = 4;
-    private static final int PREVIOUS_PAGES_TO_SHOW = 2;
 
     /**
      * Empty constructor.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -24,7 +24,6 @@ import gov.medicaid.entities.UserRequest;
 import gov.medicaid.entities.dto.ViewStatics;
 import gov.medicaid.security.CMSPrincipal;
 import gov.medicaid.services.ExportService;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.ProviderEnrollmentService;
 import gov.medicaid.services.util.Util;
@@ -34,7 +33,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
@@ -57,33 +55,15 @@ public class ProviderDashboardController extends BaseController {
      */
     private static final int DEFAULT_PAGE_SIZE = 10;
 
-    /**
-     * Service used to perform operations.
-     */
-    private ProviderEnrollmentService enrollmentService;
+    private final ProviderEnrollmentService enrollmentService;
+    private final ExportService exportService;
 
-    /**
-     * Used to export results to PDF.
-     */
-    private ExportService exportService;
-
-    /**
-     * Empty constructor.
-     */
-    public ProviderDashboardController() {
-    }
-
-    /**
-     * This method checks that all required injection fields are in fact provided.
-     *
-     * @throws PortalServiceConfigurationException - If there are required injection fields that are not injected
-     */
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (enrollmentService == null) {
-            throw new PortalServiceConfigurationException("enrollmentService is not configured correctly.");
-        }
+    public ProviderDashboardController(
+        ProviderEnrollmentService enrollmentService,
+        ExportService exportService
+    ) {
+        this.enrollmentService = enrollmentService;
+        this.exportService = exportService;
     }
 
     /**
@@ -342,22 +322,4 @@ public class ProviderDashboardController extends BaseController {
         mv.addObject("criteria", criteria);
         return mv;
     }
-
-    /**
-     * Sets the value of the field <code>enrollmentService</code>.
-     *
-     * @param enrollmentService the enrollmentService to set
-     */
-    public void setEnrollmentService(ProviderEnrollmentService enrollmentService) {
-        this.enrollmentService = enrollmentService;
-    }
-
-    /**
-     * Sets the value of the field <code>exportService</code>.
-     * @param exportService the exportService to set
-     */
-    public void setExportService(ExportService exportService) {
-        this.exportService = exportService;
-    }
-
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
@@ -19,7 +19,6 @@ package gov.medicaid.controllers;
 import gov.medicaid.controllers.forms.RegistrationForm;
 import gov.medicaid.controllers.validators.RegistrationFormValidator;
 import gov.medicaid.entities.CMSUser;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.PortalServiceException;
 import gov.medicaid.services.RegistrationService;
 import gov.medicaid.services.util.Util;
@@ -31,8 +30,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
-
-import javax.annotation.PostConstruct;
 
 import java.io.UnsupportedEncodingException;
 
@@ -46,38 +43,15 @@ import java.io.UnsupportedEncodingException;
 @Controller
 @RequestMapping("/accounts/*")
 public class SelfRegistrationController extends BaseController {
+    private final RegistrationService registrationService;
+    private final RegistrationFormValidator validator;
 
-    /**
-     * Registration service.
-     */
-    private RegistrationService registrationService;
-
-    /**
-     * Validator.
-     */
-    private RegistrationFormValidator validator;
-
-    /**
-     * Empty constructor.
-     */
-    public SelfRegistrationController() {
-    }
-
-    /**
-     * This method checks that all required injection fields are in fact provided.
-     *
-     * @throws PortalServiceConfigurationException - If there are required injection fields that are not injected
-     */
-    @PostConstruct
-    protected void init() {
-        super.init();
-        if (registrationService == null) {
-            throw new PortalServiceConfigurationException("registrationService is not configured correctly.");
-        }
-
-        if (validator == null) {
-            throw new PortalServiceConfigurationException("validator is not configured correctly.");
-        }
+    public SelfRegistrationController(
+        RegistrationService registrationService,
+        RegistrationFormValidator validator
+    ) {
+        this.registrationService = registrationService;
+        this.validator = validator;
     }
 
     /**
@@ -176,23 +150,5 @@ public class SelfRegistrationController extends BaseController {
         user.setUsername(registrant.getUsername());
         user.setEmail(registrant.getEmail());
         return user;
-    }
-
-    /**
-     * Sets the value of the field <code>registrationService</code>.
-     *
-     * @param registrationService the registrationService to set
-     */
-    public void setRegistrationService(RegistrationService registrationService) {
-        this.registrationService = registrationService;
-    }
-
-    /**
-     * Sets the value of the field <code>validator</code>.
-     *
-     * @param validator the validator to set
-     */
-    public void setValidator(RegistrationFormValidator validator) {
-        this.validator = validator;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/FlashMessageInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/FlashMessageInterceptor.java
@@ -16,7 +16,6 @@
 
 package gov.medicaid.interceptors;
 
-import org.springframework.stereotype.Controller;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -29,7 +28,6 @@ import javax.servlet.http.HttpServletResponse;
  * @author TCSASSEMBLER
  * @version 1.0
  */
-@Controller
 public class FlashMessageInterceptor implements HandlerInterceptor {
 
     /**


### PR DESCRIPTION
As promised in #1042, this is the continuation of configuring controllers via Spring annotations instead of XML:

> When a project is set up to support it, Spring is able to automatically discover new controllers (and other components) by looking for the proper annotation. This makes configuration much simpler, and makes it easier to, for example, add new controllers.
> 
> Spring is also able to automatically determine a component's dependencies if they are declared as constructor arguments. In addition to simplifying configuration, this allows us to reduce Java boilerplate code by removing getters and setters.

Again, I open this as a PR now both in the interest of getting experiments merged as part of winding down my contributions to the PSM, and because it will make solving #1032 a bit easier.

---

To test this, I created a new provider through the self-registration form, went through the forgot password flow, relied on the integration tests to create a new enrollment, made sure the provider dashboard works, ignored the disabled onboarding endpoints, verified that I could view my profile as `p1`, and reset my password from the link on the my profile page.