### PR TITLE
Improve Action column link spacing and make tables striped

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -41,7 +41,7 @@
                 <div class="noData">No matched data found.</div>
               </c:when>
               <c:otherwise>
-                <table class="generalTable fixedWidthTable">
+                <table class="generalTable fixedWidthTable linedTable">
                   <colgroup>
                     <col width="100"/>
                     <col width="*"/>
@@ -66,8 +66,9 @@
                     <c:forEach
                       items="${profiles}"
                       var="item"
+                      varStatus="status"
                     >
-                      <tr>
+                      <tr class="${status.index % 2 == 0 ? 'odd' : 'even'}">
                         <td>${item.npi}</td>
                         <td>${item.providerType}</td>
                         <td>${item.providerName}</td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -76,6 +76,7 @@
                         <td>${item.status}</td>
                         <td>
                           <a
+                            class="actionLink"
                             href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
                           >
                             View

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -63,7 +63,10 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <c:forEach items="${profiles}" var="item">
+                    <c:forEach
+                      items="${profiles}"
+                      var="item"
+                    >
                       <tr>
                         <td>${item.npi}</td>
                         <td>${item.providerType}</td>
@@ -72,7 +75,9 @@
                         <td><fmt:formatDate value="${item.statusDate}" pattern="MM/dd/yyyy"/></td>
                         <td>${item.status}</td>
                         <td>
-                          <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+                          <a
+                            href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
+                          >
                             View
                           </a>
                         </td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -139,67 +139,63 @@
           <c:choose>
             <c:when test="${fn:toLowerCase(item.status)=='pending'}">
               <a
-                class="viewLink"
+                class="actionLink viewLink"
                 href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
               >
                 View
               </a>
-              <span class="sep">|</span>
               <a
+                class="actionLink"
                 href="${ctx}/provider/enrollment/reopen?id=${item.ticketId}"
               >
                 Edit
               </a>
-              <span class="sep">|</span>
               <c:forEach var="task" items="${tasks}">
                 <c:if test="${task.processInstanceId == item.processInstanceId}">
                     <a
-                      class="reviewLink"
+                      class="actionLink reviewLink"
                       href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}"
                     >
                       Review
                     </a>
-                    <span class="sep">|</span>
                 </c:if>
               </c:forEach>
             </c:when>
             <c:when test="${fn:toLowerCase(item.status)=='draft'}">
               <a
+                class="actionLink"
                 href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
               >
                 Edit
               </a>
-              <span class="sep">|</span>
             </c:when>
             <c:when test="${fn:toLowerCase(item.status)=='approved'}">
               <a
-                class="viewLink"
+                class="actionLink viewLink"
                 href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
               >
                 View
               </a>
-              <span class="sep">|</span>
               <a
+                class="actionLink"
                 href="${ctx}/provider/profile/edit?profileId=${item.profileReferenceId}"
               >
                 Edit
               </a>
-              <span class="sep">|</span>
               <a
+                class="actionLink
                 href="${ctx}/provider/profile/renew?profileId=${item.profileReferenceId}"
               >
                 Renew
               </a>
-              <span class="sep">|</span>
             </c:when>
             <c:otherwise>
               <a
-                class="viewLink"
+                class="actionLink viewLink"
                 href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
               >
                 View
               </a>
-              <span class="sep">|</span>
             </c:otherwise>
           </c:choose>
 
@@ -207,30 +203,28 @@
             <a
               href="javascript:;"
               rel="${item.ticketId}"
-              class="writeNotes"
+              class="actionLink writeNotes"
             >
               Add Note
             </a>
-            <span class="sep">|</span>
             <a
               href="javascript:;"
               rel="${item.ticketId}"
-              class='viewNotes<c:if test="${!(fn:length(item.notes)>0)}"> hide disabledLink</c:if>'
+              class='actionLink viewNotes <c:if test="${!(fn:length(item.notes)>0)}">hide disabledLink</c:if>'
             >
               View Notes
             </a>
-            <span class="sep <c:if test="${!(fn:length(item.notes)>0)}">hide</c:if>">|</span>
           </c:if>
 
           <a
             rel="${item.ticketId}"
-            class="printEnrollment"
+            class="actionLink printEnrollment"
             href="javascript:;"
           >
             Print
           </a>
-          <span class="sep">|</span>
           <a
+            class="actionLink"
             href="${ctx}/provider/enrollment/exportTicket?id=${item.ticketId}"
           >
             Export

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -1,7 +1,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <table
   id="${searchTableId}"
-  class="generalTable fixedWidthTable"
+  class="generalTable linedTable"
 >
   <colgroup>
     <col width="27"/>
@@ -83,8 +83,9 @@
     <c:forEach
       var="item"
       items="${searchResult.items}"
+      varStatus="status"
     >
-      <tr>
+      <tr class="${status.index % 2 == 0 ? 'odd' : 'even'}">
         <td class="alignCenter tdCheckbox">
           <input
             type="checkbox"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -136,7 +136,7 @@
           <c:otherwise><td>${item.riskLevel}</td></c:otherwise>
         </c:choose>
         <td><fmt:formatDate value="${item.statusDate}" pattern="MM/dd/yyyy"/></td>
-        <td class="alignCenter nopad">
+        <td class="alignCenter">
           <c:choose>
             <c:when test="${fn:toLowerCase(item.status)=='pending'}">
               <a

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -80,7 +80,10 @@
   </thead>
 
   <tbody>
-    <c:forEach var="item" items="${searchResult.items}">
+    <c:forEach
+      var="item"
+      items="${searchResult.items}"
+    >
       <tr>
         <td class="alignCenter tdCheckbox">
           <input
@@ -135,17 +138,25 @@
         <td class="alignCenter nopad">
           <c:choose>
             <c:when test="${fn:toLowerCase(item.status)=='pending'}">
-              <a class="viewLink" href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+              <a
+                class="viewLink"
+                href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
+              >
                 View
               </a>
               <span class="sep">|</span>
-              <a href="${ctx}/provider/enrollment/reopen?id=${item.ticketId}">
+              <a
+                href="${ctx}/provider/enrollment/reopen?id=${item.ticketId}"
+              >
                 Edit
               </a>
               <span class="sep">|</span>
               <c:forEach var="task" items="${tasks}">
                 <c:if test="${task.processInstanceId == item.processInstanceId}">
-                    <a class="reviewLink" href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}">
+                    <a
+                      class="reviewLink"
+                      href="${ctx}/agent/enrollment/screeningReview?id=${item.ticketId}"
+                    >
                       Review
                     </a>
                     <span class="sep">|</span>
@@ -153,27 +164,39 @@
               </c:forEach>
             </c:when>
             <c:when test="${fn:toLowerCase(item.status)=='draft'}">
-              <a href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+              <a
+                href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
+              >
                 Edit
               </a>
               <span class="sep">|</span>
             </c:when>
             <c:when test="${fn:toLowerCase(item.status)=='approved'}">
-              <a class="viewLink" href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+              <a
+                class="viewLink"
+                href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
+              >
                 View
               </a>
               <span class="sep">|</span>
-              <a href="${ctx}/provider/profile/edit?profileId=${item.profileReferenceId}">
+              <a
+                href="${ctx}/provider/profile/edit?profileId=${item.profileReferenceId}"
+              >
                 Edit
               </a>
               <span class="sep">|</span>
-              <a href="${ctx}/provider/profile/renew?profileId=${item.profileReferenceId}">
+              <a
+                href="${ctx}/provider/profile/renew?profileId=${item.profileReferenceId}"
+              >
                 Renew
               </a>
               <span class="sep">|</span>
             </c:when>
             <c:otherwise>
-              <a class="viewLink" href="${ctx}/provider/enrollment/view?id=${item.ticketId}">
+              <a
+                class="viewLink"
+                href="${ctx}/provider/enrollment/view?id=${item.ticketId}"
+              >
                 View
               </a>
               <span class="sep">|</span>
@@ -199,11 +222,17 @@
             <span class="sep <c:if test="${!(fn:length(item.notes)>0)}">hide</c:if>">|</span>
           </c:if>
 
-          <a rel="${item.ticketId}" class="printEnrollment" href="javascript:;">
+          <a
+            rel="${item.ticketId}"
+            class="printEnrollment"
+            href="javascript:;"
+          >
             Print
           </a>
           <span class="sep">|</span>
-          <a href="${ctx}/provider/enrollment/exportTicket?id=${item.ticketId}">
+          <a
+            href="${ctx}/provider/enrollment/exportTicket?id=${item.ticketId}"
+          >
             Export
           </a>
         </td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
@@ -40,7 +40,10 @@
   </thead>
 
   <tbody>
-    <c:forEach var="screening" items="${screenings}">
+    <c:forEach
+      var="screening"
+      items="${screenings}"
+    >
       <tr>
         <td>${screening.date}</td>
         <td>${screening.npi}</td>
@@ -50,9 +53,17 @@
         <td>${screening.reason}</td>
         <td>${screening.result}</td>
         <td class="alignCenter nopad">
-          <a href="#">Auto Screen</a>
+          <a
+            href="#"
+          >
+            Auto Screen
+          </a>
           <span class="sep">|</span>
-          <a href="#">Manual Screen</a>
+          <a
+            href="#"
+          >
+            Manual Screen
+          </a>
         </td>
       </tr>
     </c:forEach>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
@@ -1,7 +1,7 @@
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <table
   id="screeningsTable"
-  class="generalTable"
+  class="generalTable linedTable"
 >
   <thead>
     <tr>
@@ -43,8 +43,9 @@
     <c:forEach
       var="screening"
       items="${screenings}"
+      varStatus="status"
     >
-      <tr>
+      <tr class="${status.index % 2 == 0 ? 'odd' : 'even'}">
         <td>${screening.date}</td>
         <td>${screening.npi}</td>
         <td>${screening.providerName}</td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
@@ -54,12 +54,13 @@
         <td>${screening.result}</td>
         <td class="alignCenter nopad">
           <a
+            class="actionLink"
             href="#"
           >
             Auto Screen
           </a>
-          <span class="sep">|</span>
           <a
+            class="actionLink"
             href="#"
           >
             Manual Screen

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
@@ -53,7 +53,7 @@
         <td>${screening.screeningType}</td>
         <td>${screening.reason}</td>
         <td>${screening.result}</td>
-        <td class="alignCenter nopad">
+        <td class="alignCenter">
           <a
             class="actionLink"
             href="#"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search_results_section_system_admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search_results_section_system_admin.jsp
@@ -84,14 +84,14 @@
                     <td>${item.role.description}</td>
                     <td class="alignCenter">
                       <a
+                        class="actionLink"
                         href="<c:url value='/admin/user/edit?role=${item.role.description}&userId=${item.userId}' />"
                       >
                         Edit
                       </a>
-                      <span class="sep">|</span>
                       <a
                         href="javascript:;"
-                        class="deleteLink"
+                        class="actionLink deleteLink"
                       >
                         Delete
                       </a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search_results_section_system_admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search_results_section_system_admin.jsp
@@ -77,16 +77,18 @@
                         name="providers"
                       />
                     </td>
-                    <td>
-                      <a href="<c:url value='/admin/user/details?role=${item.role.description}&userId=${item.userId}' />">
-                        ${item.username}
-                      </a>
-                    </td>
+                    <td>${item.username}</td>
                     <td>${item.lastName}</td>
                     <td>${item.firstName}</td>
                     <td>${item.email}</td>
                     <td>${item.role.description}</td>
                     <td class="alignCenter">
+                      <a
+                        class="actionLink"
+                        href="<c:url value='/admin/user/details?role=${item.role.description}&userId=${item.userId}' />"
+                      >
+                        View
+                      </a>
                       <a
                         class="actionLink"
                         href="<c:url value='/admin/user/edit?role=${item.role.description}&userId=${item.userId}' />"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search_results_section_system_admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search_results_section_system_admin.jsp
@@ -60,7 +60,10 @@
                 </tr>
               </thead>
               <tbody>
-                <c:forEach var="item" items="${results.items}">
+                <c:forEach
+                  var="item"
+                  items="${results.items}"
+                >
                   <tr>
                     <td class="alignCenter">
                       <input
@@ -80,7 +83,9 @@
                     <td>${item.email}</td>
                     <td>${item.role.description}</td>
                     <td class="alignCenter">
-                      <a href="<c:url value='/admin/user/edit?role=${item.role.description}&userId=${item.userId}' />">
+                      <a
+                        href="<c:url value='/admin/user/edit?role=${item.role.description}&userId=${item.userId}' />"
+                      >
                         Edit
                       </a>
                       <span class="sep">|</span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search_results_section_system_admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/search_results_section_system_admin.jsp
@@ -24,7 +24,10 @@
       <c:otherwise>
         <div class="tableContainer">
           <div class="tableMain">
-            <table class="generalTable" id="userAccountResultsTable">
+            <table
+              class="generalTable linedTable"
+              id="userAccountResultsTable"
+            >
               <colgroup>
                 <col width="35"/>
                 <col width="125"/>
@@ -63,8 +66,9 @@
                 <c:forEach
                   var="item"
                   items="${results.items}"
+                  varStatus="status"
                 >
-                  <tr>
+                  <tr class="${status.index % 2 == 0 ? 'odd' : 'even'}">
                     <td class="alignCenter">
                       <input
                         type="checkbox"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/user_accounts_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/user_accounts_table.jsp
@@ -70,15 +70,17 @@
                   name="providers"
                 />
               </td>
-              <td>
-                <a href="<c:url value='/system/user/details?role=${role}&userId=${item.userId}' />">
-                  ${item.username}
-                </a>
-              </td>
+              <td>${item.username}</td>
               <td>${item.lastName}</td>
               <td>${item.firstName}</td>
               <td>${item.email}</td>
               <td class="alignCenter">
+                <a
+                  class="actionLink"
+                  href="<c:url value='/system/user/details?role=${role}&userId=${item.userId}' />"
+                >
+                  View
+                </a>
                 <a
                   class="actionLink"
                   href="<c:url value='/system/user/edit?role=${role}&userId=${item.userId}' />"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/user_accounts_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/user_accounts_table.jsp
@@ -14,7 +14,7 @@
   </c:when>
   <c:otherwise>
     <div class="tableContainer">
-      <table class="generalTable">
+      <table class="generalTable linedTable">
         <colgroup>
           <col width="30"/>
           <col width="145"/>
@@ -48,17 +48,20 @@
           <c:forEach
             var="item"
             items="${results.items}"
+            varStatus="status"
           >
-            <tr
-              <c:choose>
-                <c:when test="${item.status == 'DISABLED'}">
-                  class="disabledUser"
-                </c:when>
-                <c:when test="${item.status == 'ACTIVE'}">
-                  class="enabledUser"
-                </c:when>
-              </c:choose>
-            >
+            <c:choose>
+              <c:when test="${item.status == 'DISABLED'}">
+                <c:set var="userStatusClass" value="disabledUser" />
+              </c:when>
+              <c:when test="${item.status == 'ACTIVE'}">
+                <c:set var="userStatusClass" value="enabledUser" />
+              </c:when>
+              <c:otherwise>
+                <c:set var="userStatusClass" value="" />
+              </c:otherwise>
+            </c:choose>
+            <tr class="${userStatusClass} ${status.index % 2 == 0 ? 'odd' : 'even'}">
               <td class="alignCenter">
                 <input
                   type="checkbox"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/user_accounts_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/user_accounts_table.jsp
@@ -45,7 +45,10 @@
           </tr>
         </thead>
         <tbody>
-          <c:forEach var="item" items="${results.items}">
+          <c:forEach
+            var="item"
+            items="${results.items}"
+          >
             <tr
               <c:choose>
                 <c:when test="${item.status == 'DISABLED'}">
@@ -73,7 +76,9 @@
               <td>${item.firstName}</td>
               <td>${item.email}</td>
               <td class="alignCenter">
-                <a href="<c:url value='/system/user/edit?role=${role}&userId=${item.userId}' />">
+                <a
+                  href="<c:url value='/system/user/edit?role=${role}&userId=${item.userId}' />"
+                >
                   Edit
                 </a>
                 <span class="sep">|</span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/user_accounts_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/user_accounts_table.jsp
@@ -77,27 +77,26 @@
               <td>${item.email}</td>
               <td class="alignCenter">
                 <a
+                  class="actionLink"
                   href="<c:url value='/system/user/edit?role=${role}&userId=${item.userId}' />"
                 >
                   Edit
                 </a>
-                <span class="sep">|</span>
                 <a
                   href="<c:url value='/system/user/reinstate?userId=${item.userId}' />"
-                  class="reinstateLink"
+                  class="actionLink reinstateLink"
                 >
                   Reinstate
                 </a>
                 <a
                   href="<c:url value='/system/user/suspend?userId=${item.userId}' />"
-                  class="suspendLink"
+                  class="actionLink suspendLink"
                 >
                   Suspend
                 </a>
-                <span class="sep">|</span>
                 <a
                   href="javascript:;"
-                  class="deleteLink"
+                  class="actionLink deleteLink"
                 >
                   Delete
                 </a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
@@ -75,7 +75,7 @@
             <c:when test="${fn:length(enrollments) gt 0}">
               <div class="reportTable tableData">
                 <div class="tableData">
-                  <table class="generalTable">
+                  <table class="generalTable linedTable">
                     <thead>
                       <tr>
                         <th>Application ID</th>
@@ -90,8 +90,9 @@
                     <c:forEach
                       var="enrollment"
                       items="${enrollments}"
+                      varStatus="status"
                     >
-                      <tr class="reportRow">
+                      <tr class="reportRow ${status.index % 2 == 0 ? 'odd' : 'even'}">
                         <td>
                           <a href="${ctx}/provider/enrollment/view?id=${enrollment.ticketId}">
                             ${enrollment.ticketId}

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
@@ -87,7 +87,10 @@
                         <th>Status</th>
                       </tr>
                     </thead>
-                    <c:forEach var="enrollment" items="${enrollments}">
+                    <c:forEach
+                      var="enrollment"
+                      items="${enrollments}"
+                    >
                       <tr class="reportRow">
                         <td>
                           <a href="${ctx}/provider/enrollment/view?id=${enrollment.ticketId}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/draft_applications.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/draft_applications.jsp
@@ -39,7 +39,7 @@
                 <div class="tableTitle">
                   <h2>${enrollmentMonth.month}</h2>
                 </div>
-                <table class="generalTable">
+                <table class="generalTable linedTable">
                   <thead>
                     <tr>
                       <th>Application ID</th>
@@ -53,8 +53,9 @@
                   <c:forEach
                     var="enrollment"
                     items="${enrollmentMonth.enrollments}"
+                    varStatus="status"
                   >
-                  <tr class="reportRow">
+                  <tr class="reportRow ${status.index % 2 == 0 ? 'odd' : 'even'}">
                     <td class="reportDatum nonedisplay" reportField="month" reportValue="${enrollmentMonth.month}"></td>
                     <td class="reportDatum" reportField="ticketId" reportValue="${enrollment.ticketId}">
                       <a href="${ctx}/provider/enrollment/view?id=${enrollment.ticketId}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/draft_applications.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/draft_applications.jsp
@@ -50,7 +50,10 @@
                       <th>Submission Date</th>
                     </tr>
                   </thead>
-                  <c:forEach var="enrollment" items="${enrollmentMonth.enrollments}">
+                  <c:forEach
+                    var="enrollment"
+                    items="${enrollmentMonth.enrollments}"
+                  >
                   <tr class="reportRow">
                     <td class="reportDatum nonedisplay" reportField="month" reportValue="${enrollmentMonth.month}"></td>
                     <td class="reportDatum" reportField="ticketId" reportValue="${enrollment.ticketId}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
@@ -72,7 +72,10 @@
                           <th class="providerTypesNum">Applications Reviewed</th>
                         </tr>
                       </thead>
-                      <c:forEach var="providerType" items="${month.providerTypes}">
+                      <c:forEach
+                        var="providerType"
+                        items="${month.providerTypes}"
+                      >
                         <tr class="reportRow">
                           <td
                             class="reportDatum"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
@@ -65,7 +65,7 @@
                 </div>
                 <c:choose>
                   <c:when test="${month.providerTypes.size() > 0}">
-                    <table class="generalTable">
+                    <table class="generalTable linedTable">
                       <thead>
                         <tr>
                           <th>Provider Type</th>
@@ -75,8 +75,9 @@
                       <c:forEach
                         var="providerType"
                         items="${month.providerTypes}"
+                        varStatus="status"
                       >
-                        <tr class="reportRow">
+                        <tr class="reportRow ${status.index % 2 == 0 ? 'odd' : 'even'}">
                           <td
                             class="reportDatum"
                             reportField="providerType"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
@@ -45,7 +45,10 @@
                     <th>Number of Documents</th>
                   </tr>
                 </thead>
-                <c:forEach var="month" items="${months}">
+                <c:forEach
+                  var="month"
+                  items="${months}"
+                >
                   <tr class="reportRow">
                     <td
                       class="reportDatum"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
@@ -38,7 +38,7 @@
               <div class="tableTitle">
                 <h2>Reviewed Documents</h2>
               </div>
-              <table class="generalTable">
+              <table class="generalTable linedTable">
                 <thead>
                   <tr>
                     <th>Month</th>
@@ -48,8 +48,9 @@
                 <c:forEach
                   var="month"
                   items="${months}"
+                  varStatus="status"
                 >
-                  <tr class="reportRow">
+                  <tr class="reportRow ${status.index % 2 == 0 ? 'odd' : 'even'}">
                     <td
                       class="reportDatum"
                       reportField="month"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
@@ -52,7 +52,10 @@
                     </c:forEach>
                   </tr>
                 </thead>
-                <c:forEach var="month" items="${months}">
+                <c:forEach
+                  var="month"
+                  items="${months}"
+                >
                   <tr class="reportRow">
                     <td
                       class="reportDatum"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
@@ -43,7 +43,7 @@
               <div class="tableTitle">
                 <h2>Risk Levels</h2>
               </div>
-              <table class="generalTable">
+              <table class="generalTable linedTable">
                 <thead>
                   <tr>
                     <th>Month</th>
@@ -55,8 +55,9 @@
                 <c:forEach
                   var="month"
                   items="${months}"
+                  varStatus="status"
                 >
-                  <tr class="reportRow">
+                  <tr class="reportRow ${status.index % 2 == 0 ? 'odd' : 'even'}">
                     <td
                       class="reportDatum"
                       reportField="month"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
@@ -53,7 +53,10 @@
                     <th>Median Review Time</th>
                   </tr>
                 </thead>
-                <c:forEach var="month" items="${months}">
+                <c:forEach
+                  var="month"
+                  items="${months}"
+                >
                   <tr class="reportRow">
                     <td
                       class="reportDatum"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
@@ -44,7 +44,7 @@
               <div class="tableTitle">
                 <h2>Time to Review</h2>
               </div>
-              <table class="generalTable">
+              <table class="generalTable linedTable">
                 <thead>
                   <tr>
                     <th>Month</th>
@@ -56,8 +56,9 @@
                 <c:forEach
                   var="month"
                   items="${months}"
+                  varStatus="status"
                 >
-                  <tr class="reportRow">
+                  <tr class="reportRow ${status.index % 2 == 0 ? 'odd' : 'even'}">
                     <td
                       class="reportDatum"
                       reportField="month"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -172,18 +172,42 @@
                           </tr>
                         </thead>
                         <tbody>
-                          <c:forEach var="item" items="${searchResult.items}">
+                          <c:forEach
+                            var="item"
+                            items="${searchResult.items}"
+                          >
                             <tr>
                               <td class="alignCenter">
                                 <input id="agreement_type_${item.id}" <c:if test="${!item.canDelete}">disabled="disabled"</c:if> class="agreementDocumentCheckBox" value="${item.id}" type="checkbox" name="agreementType"/>
                               </td>
                               <td><a href="${ctx}/admin/getAgreementDocument?agreementId=${item.id}" class="viewAgreementLink">${item.title}</a></td>
                               <td><label for="agreement_type_${item.id}">${item.type}</label></td>
-                              <td class="alignCenter"><a href="${ctx}/admin/editAgreementDocument?agreementId=${item.id}" class="editAgreementLink">Edit</a>
+                              <td class="alignCenter">
+                                <a
+                                  href="${ctx}/admin/editAgreementDocument?agreementId=${item.id}"
+                                  class="editAgreementLink"
+                                >
+                                  Edit
+                                </a>
                                 <span class="sep">|</span>
                                 <c:choose>
-                                <c:when test="${item.canDelete}"><a rel="${item.id}" href="javascript:;" class="deleteAgreementDocumentBtn">Delete</a></c:when>
-                                <c:otherwise><a href="javascript:;" class="disabledBtn">Delete</a></c:otherwise>
+                                  <c:when test="${item.canDelete}">
+                                    <a
+                                      rel="${item.id}"
+                                      href="javascript:;"
+                                      class="deleteAgreementDocumentBtn"
+                                    >
+                                      Delete
+                                    </a>
+                                  </c:when>
+                                  <c:otherwise>
+                                    <a
+                                      href="javascript:;"
+                                      class="disabledBtn"
+                                    >
+                                      Delete
+                                    </a>
+                                  </c:otherwise>
                                 </c:choose>
                               </td>
                             </tr>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -121,7 +121,10 @@
                 <c:otherwise>
                   <div class="tableWrapper">
                     <div class="tableContainer">
-                      <table class="generalTable" id="agreementTable">
+                      <table
+                        class="generalTable linedTable"
+                        id="agreementTable"
+                      >
                         <thead>
                           <tr>
                             <th class="alignCenter">
@@ -175,8 +178,9 @@
                           <c:forEach
                             var="item"
                             items="${searchResult.items}"
+                            varStatus="status"
                           >
-                            <tr>
+                            <tr class="${status.index % 2 == 0 ? 'odd' : 'even'}">
                               <td class="alignCenter">
                                 <input id="agreement_type_${item.id}" <c:if test="${!item.canDelete}">disabled="disabled"</c:if> class="agreementDocumentCheckBox" value="${item.id}" type="checkbox" name="agreementType"/>
                               </td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -184,9 +184,15 @@
                               <td class="alignCenter">
                                 <input id="agreement_type_${item.id}" <c:if test="${!item.canDelete}">disabled="disabled"</c:if> class="agreementDocumentCheckBox" value="${item.id}" type="checkbox" name="agreementType"/>
                               </td>
-                              <td><a href="${ctx}/admin/getAgreementDocument?agreementId=${item.id}" class="viewAgreementLink">${item.title}</a></td>
+                              <td>${item.title}</td>
                               <td><label for="agreement_type_${item.id}">${item.type}</label></td>
                               <td class="alignCenter">
+                                <a
+                                  href="${ctx}/admin/getAgreementDocument?agreementId=${item.id}"
+                                  class="actionLink viewAgreementLink"
+                                >
+                                  View
+                                </a>
                                 <a
                                   href="${ctx}/admin/editAgreementDocument?agreementId=${item.id}"
                                   class="actionLink editAgreementLink"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -185,17 +185,16 @@
                               <td class="alignCenter">
                                 <a
                                   href="${ctx}/admin/editAgreementDocument?agreementId=${item.id}"
-                                  class="editAgreementLink"
+                                  class="actionLink editAgreementLink"
                                 >
                                   Edit
                                 </a>
-                                <span class="sep">|</span>
                                 <c:choose>
                                   <c:when test="${item.canDelete}">
                                     <a
                                       rel="${item.id}"
                                       href="javascript:;"
-                                      class="deleteAgreementDocumentBtn"
+                                      class="actionLink deleteAgreementDocumentBtn"
                                     >
                                       Delete
                                     </a>
@@ -203,7 +202,7 @@
                                   <c:otherwise>
                                     <a
                                       href="javascript:;"
-                                      class="disabledBtn"
+                                      class="actionLink disabledBtn"
                                     >
                                       Delete
                                     </a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -138,24 +138,22 @@
                             <td class="alignCenter">
                               <a
                                 href="${ctx}/admin/getProviderType?providerTypeId=${item.code}"
-                                class="viewProviderLink"
+                                class="actionLink viewProviderLink"
                               >
                                 View
                               </a>
-                              <span class="sep">|</span>
                               <a
                                 href="${ctx}/admin/beginEditProviderType?providerTypeId=${item.code}"
-                                class="editProviderLink"
+                                class="actionLink editProviderLink"
                               >
                                 Edit
                               </a>
-                              <span class="sep">|</span>
                               <c:choose>
                                 <c:when test="${item.canDelete}">
                                   <a
                                     rel="${item.code}"
                                     href="javascript:;"
-                                    class="deleteProviderTypeBtn"
+                                    class="actionLink deleteProviderTypeBtn"
                                   >
                                     Delete
                                   </a>
@@ -163,7 +161,7 @@
                                 <c:otherwise>
                                   <a
                                     href="javascript:;"
-                                    class="disabledBtn"
+                                    class="actionLink disabledBtn"
                                   >
                                     Delete
                                   </a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -126,17 +126,48 @@
                         </tr>
                       </thead>
                       <tbody>
-                        <c:forEach var="item" items="${searchResult.items}">
+                        <c:forEach
+                          var="item"
+                          items="${searchResult.items}"
+                        >
                           <tr>
                             <td class="alignCenter">
                               <input id="providerType_${item.code}" <c:if test="${!item.canDelete}">disabled="disabled"</c:if> class="providerTypeCheckBox" value="${item.code}" type="checkbox" name="providerType"/>
                             </td>
                             <td><label for="providerType_${item.code}">${item.description}</label></td>
-                            <td class="alignCenter"><a href="${ctx}/admin/getProviderType?providerTypeId=${item.code}" class="viewProviderLink">View</a><span class="sep">|</span><a href="${ctx}/admin/beginEditProviderType?providerTypeId=${item.code}" class="editProviderLink">Edit</a>
+                            <td class="alignCenter">
+                              <a
+                                href="${ctx}/admin/getProviderType?providerTypeId=${item.code}"
+                                class="viewProviderLink"
+                              >
+                                View
+                              </a>
+                              <span class="sep">|</span>
+                              <a
+                                href="${ctx}/admin/beginEditProviderType?providerTypeId=${item.code}"
+                                class="editProviderLink"
+                              >
+                                Edit
+                              </a>
                               <span class="sep">|</span>
                               <c:choose>
-                              <c:when test="${item.canDelete}"><a rel="${item.code}" href="javascript:;" class="deleteProviderTypeBtn">Delete</a></c:when>
-                              <c:otherwise><a href="javascript:;" class="disabledBtn">Delete</a></c:otherwise>
+                                <c:when test="${item.canDelete}">
+                                  <a
+                                    rel="${item.code}"
+                                    href="javascript:;"
+                                    class="deleteProviderTypeBtn"
+                                  >
+                                    Delete
+                                  </a>
+                                </c:when>
+                                <c:otherwise>
+                                  <a
+                                    href="javascript:;"
+                                    class="disabledBtn"
+                                  >
+                                    Delete
+                                  </a>
+                                </c:otherwise>
                               </c:choose>
                             </td>
                           </tr>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -95,7 +95,10 @@
               <c:otherwise>
                 <div class="tableWrapper">
                   <div class="tableContainer">
-                    <table class="generalTable" id="draftEnrollmentTable">
+                    <table
+                      class="generalTable linedTable"
+                      id="draftEnrollmentTable"
+                    >
                       <thead>
                         <tr>
                           <th class="alignCenter">
@@ -129,8 +132,9 @@
                         <c:forEach
                           var="item"
                           items="${searchResult.items}"
+                          varStatus="status"
                         >
-                          <tr>
+                          <tr class="${status.index % 2 == 0 ? 'odd' : 'even'}">
                             <td class="alignCenter">
                               <input id="providerType_${item.code}" <c:if test="${!item.canDelete}">disabled="disabled"</c:if> class="providerTypeCheckBox" value="${item.code}" type="checkbox" name="providerType"/>
                             </td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
@@ -6,13 +6,13 @@
 
 <c:choose>
   <c:when test="${statusFilter == 'All'}">
-    <table class="generalTable dashboardTable fixedWidthTable">
+    <table class="generalTable linedTable dashboardTable fixedWidthTable">
   </c:when>
   <c:when test="${statusFilter != 'Draft'}">
-    <table class="generalTable table-sort">
+    <table class="generalTable linedTable table-sort">
   </c:when>
   <c:otherwise>
-    <table class="generalTable" id="draftTable">
+    <table class="generalTable linedTable" id="draftTable">
   </c:otherwise>
 </c:choose>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
@@ -185,22 +185,31 @@
         <td class="alignCenter">
           <c:choose>
             <c:when test="${item.status == 'Draft'}">
-              <a href="${viewTicketLink}">
+              <a
+                href="${viewTicketLink}"
+              >
                 Edit
               </a>
             </c:when>
             <c:otherwise>
-              <a href="${viewTicketLink}">
+              <a
+                href="${viewTicketLink}"
+              >
                 View
               </a>
             </c:otherwise>
           </c:choose>
           <span class="sep">|</span>
-          <a href="${previewTicketLink}" class="printModalBtn printMe">
+          <a
+            href="${previewTicketLink}"
+            class="printModalBtn printMe"
+          >
             Print
           </a>
           <span class="sep">|</span>
-          <a href="${exportTicketLink}">
+          <a
+            href="${exportTicketLink}"
+          >
             Export to PDF
           </a>
         </td>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
@@ -186,6 +186,7 @@
           <c:choose>
             <c:when test="${item.status == 'Draft'}">
               <a
+                class="actionLink"
                 href="${viewTicketLink}"
               >
                 Edit
@@ -193,21 +194,21 @@
             </c:when>
             <c:otherwise>
               <a
+                class="actionLink"
                 href="${viewTicketLink}"
               >
                 View
               </a>
             </c:otherwise>
           </c:choose>
-          <span class="sep">|</span>
           <a
             href="${previewTicketLink}"
-            class="printModalBtn printMe"
+            class="actionLink printModalBtn printMe"
           >
             Print
           </a>
-          <span class="sep">|</span>
           <a
+            class="actionLink"
             href="${exportTicketLink}"
           >
             Export to PDF

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -59,18 +59,19 @@
                       <td><fmt:formatDate value="${profile.lastModifiedDate}" pattern="MM/dd/yyyy"/></td>
                       <td class="alignCenter">
                         <a
+                          class="actionLink"
                           href="${viewProfileLink}"
                         >
                           View
                         </a>
-                        <span class="sep">|</span>
                         <a
+                          class="actionLink"
                           href="${editProfileLink}"
                         >
                           Edit
                         </a>
-                        <span class="sep">|</span>
                         <a
+                          class="actionLink"
                           href="${renewProfileLink}"
                         >
                           Renew

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/list.jsp
@@ -58,9 +58,23 @@
                       <td><c:out value="${profile.providerType}"/></td>
                       <td><fmt:formatDate value="${profile.lastModifiedDate}" pattern="MM/dd/yyyy"/></td>
                       <td class="alignCenter">
-                        <a href="${viewProfileLink}">View</a><span class="sep">|</span>
-                        <a href="${editProfileLink}">Edit</a><span class="sep">|</span>
-                        <a href="${renewProfileLink}">Renew</a>
+                        <a
+                          href="${viewProfileLink}"
+                        >
+                          View
+                        </a>
+                        <span class="sep">|</span>
+                        <a
+                          href="${editProfileLink}"
+                        >
+                          Edit
+                        </a>
+                        <span class="sep">|</span>
+                        <a
+                          href="${renewProfileLink}"
+                        >
+                          Renew
+                        </a>
                       </td>
                     </tr>
                   </c:forEach>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -498,7 +498,7 @@ input.date{
 }
 .generalTable tr td {
   padding: 5px 0px 5px 10px;
-  vertical-align:middle;
+  vertical-align: middle;
 }
 .generalTable tr.even td{
   background:#ecf2f3;
@@ -512,6 +512,10 @@ input.date{
 .generalTable .sep {
   color: #6e6e6e;
   margin:0 5px;
+}
+.linedTable tr td {
+  line-height: 1.1em;
+  border-top: 1px solid #ddd;
 }
 .actionLink {
   display: inline-block;
@@ -2184,7 +2188,7 @@ input.date{
   width:66%;
   float:left;
   display:inline;
-  padding:0 0 8px 0;
+  padding: 0px;
 }
 
 .dashboardPanel .wideTableData{
@@ -3852,7 +3856,7 @@ input.text{
 }
 .disabledBtn,
 .disabledBtn:hover {
-  color: #707070;
+  color: #696969;
   cursor: default;
   text-decoration: none;
 }

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -12,9 +12,6 @@ a {
 a:hover{
   text-decoration:none;
 }
-.hide{
-  display:none;
-}
 input,select,textarea{
   font-family:Arial, Helvetica, sans-serif;
 }
@@ -515,6 +512,15 @@ input.date{
 .generalTable .sep {
   color: #6e6e6e;
   margin:0 5px;
+}
+.actionLink {
+  display: inline-block;
+  padding: 0px 4px;
+  margin: 2px 1px;
+  text-decoration: none;
+}
+.actionLink:hover {
+  text-decoration: underline;
 }
 .red{
   color: #d00;
@@ -3844,7 +3850,8 @@ input.text{
   padding: 3px;
   color: #d00;
 }
-.disabledBtn{
+.disabledBtn,
+.disabledBtn:hover {
   color: #707070;
   cursor: default;
   text-decoration: none;
@@ -4862,4 +4869,8 @@ select.stateSelect, select.stateSelectFor {
 .radioLabel {
   width: auto !important;
   float: none !important;
+}
+
+.hide {
+  display:none;
 }

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -4787,11 +4787,6 @@ div.row > .h-adr > .p-postal-code {
   width: auto;
 }
 
-td.nopad {
-  padding: 0px !important;
-}
-
-
 .row.addressline1 {
   padding-bottom : 0px;
 }


### PR DESCRIPTION
Improve the spacing and styling of the links in Action columns in tables.  Make table rows striped to make tables easier to read and make it easier to visually group Action column links.  While we're at it, use a "View" link in the Action column rather than linking the text from another column, for system admin tables, and for Agreements and Addendums table.

Tested by looking at:
- For provider login:
  - enrollment tables (all, draft, etc.)
  - my profile table
- For service admin login:
  - dashboard table
  - enrollments tables (all, draft, etc.)
  - search results tables (same JSPs as for provider login)
  - the tables on all the reports pages
  - the functions > provider types table, 
  - the functions > agreements and addendums table
- For system admin login: 
  - user accounts table
  - search results table

Before:

![screenshot_2018-08-23 all enrollments 2](https://user-images.githubusercontent.com/1091693/44563397-27077580-a72c-11e8-94e7-4e0050fd9bd6.png)

After:

![screenshot_2018-08-23 all enrollments](https://user-images.githubusercontent.com/1091693/44563403-2b339300-a72c-11e8-9431-c964f2731d58.png)

Before:

![screenshot_2018-08-23 agreements addendums - functions service admin 2](https://user-images.githubusercontent.com/1091693/44563694-5a96cf80-a72d-11e8-928a-a0b8092bbc30.png)

After:

![screenshot_2018-08-23 agreements addendums - functions service admin](https://user-images.githubusercontent.com/1091693/44563699-61254700-a72d-11e8-9726-fcd8dc221f2a.png)

Before:

![screenshot_2018-08-23 user account system admin 1](https://user-images.githubusercontent.com/1091693/44563705-671b2800-a72d-11e8-87c3-f675fcdb0f8a.png)

After:

![screenshot_2018-08-23 user account system admin](https://user-images.githubusercontent.com/1091693/44563716-6f736300-a72d-11e8-8385-d19a0567c2c8.png)

Resolves #692: Action column may wrap to two lines