### PR TITLE
Don't include right-aligned colons when exporting PDFs

### DIFF
--- a/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
@@ -121,7 +121,7 @@ public class PDFHelper {
      * @param value the value text
      */
     public static void addCell(PdfPTable table, String value) {
-        PdfPCell val = new PdfPCell(new Phrase(": " + Util.defaultString(value), FontFactory.getFont(
+        PdfPCell val = new PdfPCell(new Phrase(Util.defaultString(value), FontFactory.getFont(
             FontFactory.HELVETICA, 7)));
         val.setBorder(Rectangle.NO_BORDER);
         val.setHorizontalAlignment(PdfPCell.ALIGN_LEFT);


### PR DESCRIPTION
See the following PDF, which has no colons, unlike the one in issue #1045.

[no-more-colons.pdf](https://github.com/SolutionGuidance/psm/files/2319994/no-more-colons.pdf)

Tested by logging in as a service admin and clicking the "Export" link in the Action column to download the PDF.

Issue #1045 Exported PDF of an enrollment has confusingly-aligned colons