### PR TITLE
Add test data to mock out DMF API

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -436,6 +436,21 @@ Migration scripts are stored in `psm-app/db/`.
 
 More material coming soon about how to run individual migrations.
 
+## Set up external data sources
+
+See the [Credentialing and Verification: Extract, Translate, and Load
+repository](https://github.com/SolutionGuidance/cavetl) for information on
+using the API wrappers around the various external data sources the PSM
+integrates with.
+
+### Death Master File test data
+
+As the Social Security Administration limits access to the Death Master file,
+we have a substitute for the sake of development and testing. See the [README
+for the mock
+wrapper](psm-app/cms-business-process/src/test/resources/dmf-api-mock/README.md)
+for more information.
+
 # Production Deployment
 
 If you want to deploy this in earnest, there will be additional steps

--- a/psm-app/cms-business-process/src/test/resources/dmf-api-mock/README.md
+++ b/psm-app/cms-business-process/src/test/resources/dmf-api-mock/README.md
@@ -1,0 +1,36 @@
+# Death Master File test data
+
+This directory contains test data for mocking the [Death Master File
+API](https://github.com/SolutionGuidance/cavetl/tree/master/dmf), as setting
+it up is non-trivial and requires access to restricted data.
+
+## Running the mock DMF API
+
+To use this data in demonstrating the PSM, simply run the following command
+from this directory:
+
+```shell-session
+$ python3 -m http.server 5001
+```
+
+This will start the [Python HTTP
+server](https://docs.python.org/3.7/library/http.server.html) on port 5001 (the
+default DMF API port the PSM expects; this can be overridden in
+`cms.properties`), and will serve the files in the `dmf` subdirectory in the
+same way the DMF API would respond.
+
+## Test SSNs
+
+The Veris Test API has three special testing social security numbers, which we match:
+
+- `001-01-0001` will return a result with both a name and a matching DMF
+  record, indicating that the person holding that SSN has died, and the PSM
+  will record a **failure**
+- `123-45-6789` will return a result with a name but without a matching DMF
+  record, indicating that this is a recognized SSN and that the person holding
+  that SSN is still alive, and the PSM will record a **success**
+- `987-65-4321` will return a result without a name or a matching DMF record,
+  indicating that this is not a recognized SSN and so there are no matching
+  death records, and the PSM will record a **success**
+- any other social security number will not return a result, and the PSM will
+  record an **error**

--- a/psm-app/cms-business-process/src/test/resources/dmf-api-mock/dmf/001010001
+++ b/psm-app/cms-business-process/src/test/resources/dmf-api-mock/dmf/001010001
@@ -1,0 +1,5 @@
+{
+  "ssn": "001010001",
+  "full_name": "Grace Muzzey",
+  "dmf_record_present": true
+}

--- a/psm-app/cms-business-process/src/test/resources/dmf-api-mock/dmf/123456789
+++ b/psm-app/cms-business-process/src/test/resources/dmf-api-mock/dmf/123456789
@@ -1,0 +1,5 @@
+{
+  "ssn": "987654321",
+  "full_name": null,
+  "dmf_record_present": false
+}

--- a/psm-app/cms-business-process/src/test/resources/dmf-api-mock/dmf/987654321
+++ b/psm-app/cms-business-process/src/test/resources/dmf-api-mock/dmf/987654321
@@ -1,0 +1,5 @@
+{
+  "ssn": "987654321",
+  "full_name": null,
+  "dmf_record_present": false
+}


### PR DESCRIPTION
The DMF API in the cavetl repo is difficult to set up, mostly because it requires special access and permissions and so on. For the sake of demos, and to ease testing the PSM side of the DMF integration, add some test data and document how to use it.

We want this mock data in the PSM repository and not in the CAVETL repository for a few reasons:

- this is, like the code that consumes the DMF API, documentation of what the PSM expects
- these mocks are useful for testing and demonstrating the PSM
- these mocks are useful for writing integration tests
- the PSM's dependency on CAVETL does not include explicit version numbers or commit hashes, and if the DMF API implementation in the CAVETL repo changes, the PSM should be able to fall back to these mocks until it is updated to consume the new API (and these mocks should be updated to match)
- as a side effect of the previous point, it may be useful to be able to go back in time to previous versions of the PSM, and having these mocks eases that

(See also [discussion on Zulip](https://chat.opentechstrategies.com/#narrow/stream/6-Provider-Screening/subject/DMF/near/52613))

Thanks to @frankduncan for sharing the special SSNs and names returned by the Veris Test API.

Once this is merged, we can set up our CI to run this mock API before running the integration tests, and we can write integration tests around the PSM's DMF integration for #877!

Issue #759 Automatically check SSN against the Death Master File
PR #877 Issue #759. Add DMF check for individuals
Issue #1050 Add more integration tests