### PR TITLE
Fix print and export

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_buttons.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_buttons.jsp
@@ -17,7 +17,7 @@
     </c:choose>
     <a id="exportEnrollmentsToPDF" href="javascript:;" class="greyBtn iconPdf">Export to PDF</a>
     <a id="printEnrollments" href="javascript:;" class="greyBtn iconPrint">Print</a>
-    <c:if test="${active_enrollment_tab=='approved'||active_enrollment_tab=='notes'}">
+    <c:if test="${active_enrollment_tab=='approved'}">
         <a href="javascript:renewSelections('${ctx}/provider/enrollment/bulkRenewTickets');" class="greyBtn">Renew Selected Enrollments</a>
     </c:if>
 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -4,7 +4,9 @@
   class="generalTable linedTable"
 >
   <colgroup>
-    <col width="27"/>
+    <c:if test="${active_enrollment_tab=='approved'}">
+      <col width="27"/>
+    </c:if>
     <col width="90"/>
     <col width="85"/>
     <col width="100"/>
@@ -15,28 +17,23 @@
     </c:if>
     <col width="80"/>
     <col width="85"/>
-    <c:choose>
-      <c:when test="${addStatusColumn=='yes'}">
-        <col width="214"/>
-      </c:when>
-      <c:otherwise>
-        <col width="284"/>
-      </c:otherwise>
-    </c:choose>
+    <col width="*"/>
   </colgroup>
 
   <thead>
     <tr>
-      <th class="alignCenter">
-        <input
-          type="checkbox"
-          title="Select All Enrollments"
-          id="enrollmentSelectAll"
-          name="enrollmentRowCheckBox"
-          class="selectAll"
-          />
-        <span class="sep"></span>
-      </th>
+      <c:if test="${active_enrollment_tab=='approved'}">
+        <th class="alignCenter">
+          <input
+            type="checkbox"
+            title="Select All Enrollments"
+            id="enrollmentSelectAll"
+            name="enrollmentRowCheckBox"
+            class="selectAll"
+            />
+          <span class="sep"></span>
+        </th>
+      </c:if>
       <c:set var="sortFieldOfEntity" value="2"/>
       <c:set var="sortColumnTitle" value="NPI/UMPI"/>
       <%@ include file="/WEB-INF/pages/admin/includes/sort_column_header.jsp"%>
@@ -86,14 +83,16 @@
       varStatus="status"
     >
       <tr class="${status.index % 2 == 0 ? 'odd' : 'even'}">
-        <td class="alignCenter tdCheckbox">
-          <input
-            type="checkbox"
-            title="Enrollment ${item.ticketId}"
-            class="enrollmentRowCheckBox"
-            value="${item.ticketId}"
-            />
-        </td>
+        <c:if test="${active_enrollment_tab=='approved'}">
+          <td class="alignCenter tdCheckbox">
+            <input
+              type="checkbox"
+              title="Enrollment ${item.ticketId}"
+              class="enrollmentRowCheckBox"
+              value="${item.ticketId}"
+              />
+          </td>
+        </c:if>
         <td>
           ${item.npi}
         </td>

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -63,13 +63,18 @@ $(document).ready(function () {
     if ($("#enrollmentFilterPanel").size() > 0 || $("#quickEnrollmentFilterPanel").size() > 0) {
       $(".requestTypeValue").remove();
       $(".riskLevelValue").remove();
+      $("#npiSearchField").val($.trim($("#enrollmentSearchFilterNpiInput").val()));
+      $("#submissionDateStartSearchField").val($("#enrollmentSearchFilterSubmissionDateStartInput").val());
+      $("#submissionDateEndSearchField").val($("#enrollmentSearchFilterSubmissionDateEndInput").val());
+      $("#providerTypeSearchField").val($("#enrollmentSearchFilterProviderTypeInput").val());
+      $("#providerNameSearchField").val($.trim($("#enrollmentSearchFilterProviderNameInput").val()));
 
-      if ($("#requestTypeInput").val() != '') {
-        $('#searchForm').append('<input name="requestTypes[0]" value="' + $("#requestTypeInput").val() + '" type="hidden" />');
+      if ($("#enrollmentSearchFilterRequestTypeInput").val() != '') {
+        $('#searchForm').append('<input name="requestTypes[0]" value="' + $("#enrollmentSearchFilterRequestTypeInput").val() + '" type="hidden" />');
       }
 
-      if ($("#riskLevelInput").val() != '') {
-        $('#searchForm').append('<input name="riskLevels[0]" value="' + $("#riskLevelInput").val() + '" type="hidden" />');
+      if ($("#enrollmentSearchFilterRiskLevelInput").val() != '') {
+        $('#searchForm').append('<input name="riskLevels[0]" value="' + $("#enrollmentSearchFilterRiskLevelInput").val() + '" type="hidden" />');
       }
     }
 


### PR DESCRIPTION
This PR reflects fixes to the secondary features on the enrollments page.  Specifically:

1. It removes the checkboxes from all tabs except the tab that leverages them
2. It corrects the issue where the print and PDF export buttons did not actually work
3. It corrects a related issue where the filter form does not actually filter results

I tested this by logging in, going to the enrollments page and using the buttons.
You can see the check boxes if you click on the "Approved" sub tab of the enrollments page.

Resolves #1014 
I believe this also Resolves #914 