### PR TITLE
Use Spring annotations to find and initialize form validators

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -176,7 +176,6 @@
     </property>
   </bean>
 
-  <bean id="UserValidator" class="gov.medicaid.controllers.admin.UserValidator">
-    <property name="registrationService" ref="RegistrationService"/>
-  </bean>
+  <bean id="UserValidator"
+        class="gov.medicaid.controllers.admin.UserValidator"/>
 </beans>

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -112,16 +112,6 @@
   <context:component-scan
       base-package="gov.medicaid.controllers" />
 
-  <bean id="RegistrationFormValidator"
-        class="gov.medicaid.controllers.validators.RegistrationFormValidator"/>
-
-  <bean id="AccountLinkFormValidator"
-        class="gov.medicaid.controllers.validators.AccountLinkFormValidator"/>
-  <bean id="ForgotPasswordFormValidator"
-        class="gov.medicaid.controllers.validators.ForgotPasswordFormValidator"/>
-  <bean id="UpdatePasswordFormValidator"
-        class="gov.medicaid.controllers.validators.UpdatePasswordFormValidator"/>
-
   <bean class="org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter"/>
 
   <bean id="JSPController"
@@ -175,7 +165,4 @@
       <value>${jndi.ProviderTypeService}</value>
     </property>
   </bean>
-
-  <bean id="UserValidator"
-        class="gov.medicaid.controllers.admin.UserValidator"/>
 </beans>

--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -112,9 +112,8 @@
   <context:component-scan
       base-package="gov.medicaid.controllers" />
 
-  <bean id="RegistrationFormValidator" class="gov.medicaid.controllers.validators.RegistrationFormValidator">
-    <property name="registrationService" ref="RegistrationService"/>
-  </bean>
+  <bean id="RegistrationFormValidator"
+        class="gov.medicaid.controllers.validators.RegistrationFormValidator"/>
 
   <bean id="AccountLinkFormValidator"
         class="gov.medicaid.controllers.validators.AccountLinkFormValidator"/>

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
@@ -20,6 +20,7 @@ import gov.medicaid.controllers.validators.BaseValidator;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.entities.dto.ViewStatics;
 import gov.medicaid.services.RegistrationService;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
@@ -36,6 +37,7 @@ import java.util.List;
  * @author argolite, TCSASSEMBLER
  * @version 1.0
  */
+@Component
 public class UserValidator extends BaseValidator implements Validator {
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
@@ -19,13 +19,9 @@ package gov.medicaid.controllers.admin;
 import gov.medicaid.controllers.validators.BaseValidator;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.entities.dto.ViewStatics;
-import gov.medicaid.services.PortalServiceConfigurationException;
 import gov.medicaid.services.RegistrationService;
-
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
-
-import javax.annotation.PostConstruct;
 
 import java.util.Arrays;
 import java.util.List;
@@ -78,24 +74,10 @@ public class UserValidator extends BaseValidator implements Validator {
     /**
      * Represents the user service used for validation.
      */
-    private RegistrationService registrationService;
+    private final RegistrationService registrationService;
 
-    /**
-     * Empty constructor.
-     */
-    public UserValidator() {
-    }
-
-    /**
-     * This method checks that all required injection fields are in fact provided.
-     *
-     * @throws PortalServiceConfigurationException - If there are required injection fields that are not injected
-     */
-    @PostConstruct
-    protected void init() {
-        if (registrationService == null) {
-            throw new PortalServiceConfigurationException("registrationService must be configured.");
-        }
+    public UserValidator(RegistrationService registrationService) {
+        this.registrationService = registrationService;
     }
 
     /**
@@ -164,21 +146,5 @@ public class UserValidator extends BaseValidator implements Validator {
                 errors.rejectValue("username", "duplicate.username", "The requested username is already in use.");
             }
         }
-    }
-
-    /**
-     * Gets the value of the field <code>registrationService</code>.
-     * @return the registrationService
-     */
-    public RegistrationService getRegistrationService() {
-        return registrationService;
-    }
-
-    /**
-     * Sets the value of the field <code>registrationService</code>.
-     * @param registrationService the registrationService to set
-     */
-    public void setRegistrationService(RegistrationService registrationService) {
-        this.registrationService = registrationService;
     }
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/AccountLinkFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/AccountLinkFormValidator.java
@@ -18,6 +18,7 @@ package gov.medicaid.controllers.validators;
 
 import gov.medicaid.controllers.forms.AccountLinkForm;
 
+import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
 /**
@@ -26,6 +27,7 @@ import org.springframework.validation.Errors;
  * @author TCSASSEMBLER
  * @version 1.0
  */
+@Component
 public class AccountLinkFormValidator extends BaseValidator {
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
@@ -18,6 +18,7 @@ package gov.medicaid.controllers.validators;
 
 import gov.medicaid.controllers.forms.UpdatePasswordForm;
 
+import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
 /**
@@ -26,6 +27,7 @@ import org.springframework.validation.Errors;
  * @author TCSASSEMBLER
  * @version 1.0
  */
+@Component
 public class ForgotPasswordFormValidator extends BaseValidator {
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
@@ -53,12 +53,10 @@ public class RegistrationFormValidator extends BaseValidator {
     /**
      * The registration service used for data checks.
      */
-    private RegistrationService registrationService;
+    private final RegistrationService registrationService;
 
-    /**
-     * Empty constructor.
-     */
-    public RegistrationFormValidator() {
+    public RegistrationFormValidator(RegistrationService registrationService) {
+        this.registrationService = registrationService;
     }
 
     /**
@@ -119,14 +117,4 @@ public class RegistrationFormValidator extends BaseValidator {
             }
         }
     }
-
-    /**
-     * Sets the value of the field <code>registrationService</code>.
-     *
-     * @param registrationService the registrationService to set
-     */
-    public void setRegistrationService(RegistrationService registrationService) {
-        this.registrationService = registrationService;
-    }
-
 }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
@@ -20,6 +20,7 @@ import gov.medicaid.controllers.forms.RegistrationForm;
 import gov.medicaid.entities.CMSUser;
 import gov.medicaid.services.RegistrationService;
 
+import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.validation.Errors;
  * @author TCSASSEMBLER
  * @version 1.0
  */
+@Component
 public class RegistrationFormValidator extends BaseValidator {
 
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/UpdatePasswordFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/UpdatePasswordFormValidator.java
@@ -18,6 +18,7 @@ package gov.medicaid.controllers.validators;
 
 import gov.medicaid.controllers.forms.UpdatePasswordForm;
 
+import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
 /**
@@ -26,6 +27,7 @@ import org.springframework.validation.Errors;
  * @author TCSASSEMBLER
  * @version 1.0
  */
+@Component
 public class UpdatePasswordFormValidator extends BaseValidator {
 
     /**


### PR DESCRIPTION
Spring initialization is used for more than just controllers, and the same simplifications we made for controllers can be made for our form validators, too. And, now that #1044 is merged, we are already telling Spring to scan these class files; all we need to do is add the `@Component` annotation to let Spring find them and configure them.

This is the last of the Spring annotation experiments I have; I looked briefly into similarly streamlining the JNDI components, but those are a bridge out of Spring and into Java EE, which behaves a bit differently. It might be worthwhile to reconsider that decision someday, but that's much bigger than these annotation changes, and is not worthwhile at the moment.

---

I tested this by:

- self registering with an already-existing username
- going through the forgot password flow without filling in the email address
- logging in as `p1` and updating my password with a mismatched confirmation password
- ignoring the disabled external provider account linking form
- updating an existing user as `system` to remove the email address

and I saw the expected error on each form.