### PR TITLE
Update "state" to "state/territory" in user help docs

### DIFF
--- a/psm-app/userhelp/source/account-help.rst
+++ b/psm-app/userhelp/source/account-help.rst
@@ -28,9 +28,9 @@ If you are not a healthcare provider:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You probably want to create an account to be a "service agent" (someone
-who helps get providers enrolled) or a "service admin" (a state employee
-who approves and rejects enrollments). Please speak with the state
-Medicaid office for an account.
+who helps get providers enrolled) or a "service admin" (a state/territory
+employee who approves and rejects enrollments). Please speak with the
+state/territory Medicaid office for an account.
 
 How do I log in?
 ----------------
@@ -48,14 +48,14 @@ website will email you a new password to use to log in.
 I registered using an old email address I don't have access to anymore, and I've forgotten my password. How can I log in?
 -------------------------------------------------------------------------------------------------------------------------
 
-You will need to contact your state Medicaid office directly to get your
-account information changed and to get a new password.
+You will need to contact your state/territory Medicaid office directly to get
+your account information changed and to get a new password.
 
 Someone stole my identity and created an account or took over my existing account. How do I get control of my account back?
 ---------------------------------------------------------------------------------------------------------------------------
 
 To get your account back after identity theft, you will need to contact
-your state Medicaid office directly.
+your state/territory Medicaid office directly.
 
 Can I change my username or password?
 -------------------------------------
@@ -77,4 +77,4 @@ I stopped using the PSM for a while and when I came back I had to log in again. 
 Yes.  For security purposes, the PSM will automatically log you out
 after you haven't interacted with the application for a given amount of
 time.  The default is 30 minutes, but it may be as little as 15 minutes
-depending on the guidelines in your state.
+depending on the guidelines in your state/territory.

--- a/psm-app/userhelp/source/enrollment.rst
+++ b/psm-app/userhelp/source/enrollment.rst
@@ -42,16 +42,16 @@ status is active at |nppes_link| (link opens in a new tab).
 What are the steps in the enrollment process?
 ---------------------------------------------
 
--  A provider, a service agent, or a state Medicaid agency staffer
+-  A provider, a service agent, or a state/territory Medicaid agency staffer
    creates and submits a new enrollment application for a particular
    provider. (A user can save a draft application and come back later to
    finish and submit it.)
 
--  A state Medicaid agency staffer reviews the enrollment, using links
-   provided by the PSM to verify enrollment details, and decides whether
+-  A state/territory Medicaid agency staffer reviews the enrollment, using
+   links provided by the PSM to verify enrollment details, and decides whether
    to approve or reject the submission.
 
--  After an enrollment has been approved, a state Medicaid agency
+-  After an enrollment has been approved, a state/territory Medicaid agency
    staffer can select and renew it.
 
 Who can view enrollments?
@@ -60,7 +60,7 @@ Who can view enrollments?
 A provider can view their own enrollments (including draft, rejected,
 approved, and pending enrollments).
 
-A service agent or state Medicaid agency staffer can view all
+A service agent or state/territory Medicaid agency staffer can view all
 enrollments (including draft, rejected, approved, and pending
 enrollments). (`The PSM may limit this ability in a future
 version. <https://github.com/SolutionGuidance/psm/issues/10>`__)
@@ -70,14 +70,14 @@ currently allows a system admin to view enrollments, but will remove
 that capability in a future
 version. <https://github.com/SolutionGuidance/psm/issues/10>`__
 
-Which enrollment information can a provider, service agent, or state Medicaid agency staffer modify or delete?
---------------------------------------------------------------------------------------------------------------
+Which enrollment information can a provider, service agent, or state/territory Medicaid agency staffer modify or delete?
+------------------------------------------------------------------------------------------------------------------------
 
 A provider can modify a draft enrollment, but can't delete it. A
 provider also cannot delete or modify an enrollment after submitting it
 (once it is "pending", "approved", or "denied").
 
-A service agent or state Medicaid agency staffer can modify a draft or
+A service agent or state/territory Medicaid agency staffer can modify a draft or
 pending enrollment, but cannot delete any enrollments.
 
 How will a provider learn when their enrollment changes status?
@@ -95,7 +95,7 @@ changes. <https://github.com/SolutionGuidance/psm/issues/341>`__)
 Can I create an enrollment for someone else?
 --------------------------------------------
 
-A service agent or a state Medicaid agency staffer can create an
+A service agent or a state/territory Medicaid agency staffer can create an
 enrollment for someone else.
 
 Can I start an enrollment now and finish it later, or do I have to start and submit it all in one session?
@@ -110,10 +110,10 @@ under Enrollments.
 Can I start a draft enrollment and then have someone else finish it for me?
 ---------------------------------------------------------------------------
 
-Service agents and state Medicaid agency staffers can finish draft
+Service agents and state/territory Medicaid agency staffers can finish draft
 enrollments started by other people. A provider can save a draft
 enrollment and then phone or otherwise contact a service agent or the
-state Medicaid agency to ask them to help finish it for you. One
+state/territory Medicaid agency to ask them to help finish it for you. One
 provider cannot access, and therefore cannot finish and submit, a draft
 enrollment started by another provider.
 
@@ -134,15 +134,15 @@ You can only edit an enrollment if its status is still "Draft"
 Can I change something in a pending enrollment after I submit it?
 -----------------------------------------------------------------
 
-You'll need to directly contact the state Medicaid office; once you've
-submitted an enrollment, you can't update it in the PSM.
+You'll need to directly contact the state/territory Medicaid office;
+once you've submitted an enrollment, you can't update it in the PSM.
 
 How will I find out when my enrollment is accepted or rejected?
 ---------------------------------------------------------------
 
 Right now, this site does not notify you via email or paper mail when
-the state accepts or rejects an enrollment you have submitted. `This
-will change in a future version of the Provider Screening
+the state/territory accepts or rejects an enrollment you have submitted.
+`This will change in a future version of the Provider Screening
 Module. <https://github.com/SolutionGuidance/psm/issues/341>`__
 
 When you log into the PSM, you'll see any enrollments you've submitted
@@ -162,7 +162,7 @@ You should:
 -  Check the |nppes_link| (link opens in a new tab) to ensure your NPI
    status is active
 
--  Check the state Medicaid provider guidelines
+-  Check the state/territory Medicaid provider guidelines
 
 .. |nppes_link| raw:: html
 
@@ -275,8 +275,8 @@ enrollment. On the member entry screen, click the link to add an
 additional member. Repeat as necessary to add all the individuals who
 will provide services under the umbrella of the organization.
 
-When an organizational provider owns a number of separately located facilities in the state, does each facility need to enroll separately?
-------------------------------------------------------------------------------------------------------------------------------------------
+When an organizational provider owns a number of separately located facilities in the state/territory, does each facility need to enroll separately?
+----------------------------------------------------------------------------------------------------------------------------------------------------
 
 If the organizational provider (often a corporation) owns multiple
 locations, each one must be enrolled separately.
@@ -284,7 +284,7 @@ locations, each one must be enrolled separately.
 What do I do if none of the provider types seem to describe what I do (what this provider does)?
 ------------------------------------------------------------------------------------------------
 
-Contact your state Medicaid office directly.
+Contact your state/territory Medicaid office directly.
 
 How can I update an existing organizational enrollment to add a new provider (e.g., if a clinic hires a new physician)?
 -----------------------------------------------------------------------------------------------------------------------
@@ -305,7 +305,7 @@ If an enrollment is a draft (you haven't submitted it yet), then yes,
 you can click on the draft enrollment and edit the member list. If you
 have already submitted the enrollment, then it is not possible to remove
 an individual member via the PSM, and you will need to directly contact
-your state Medicaid office.
+your state/territory Medicaid office.
 
 How do I view license/certification files?
 ------------------------------------------
@@ -325,7 +325,7 @@ probably automatically open a program to view the file, such as:
 What if I know from past experience that someone else with the same name, address, or NPI has previously been excluded from Medicaid and that automatic checks are likely to flag this enrollment as a result?
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-Contact your state Medicaid office directly.
+Contact your state/territory Medicaid office directly.
 
 How do I end (terminate) my own active enrollment?
 --------------------------------------------------
@@ -333,4 +333,5 @@ How do I end (terminate) my own active enrollment?
 Currently the PSM does not give you a way to terminate an approved
 enrollment, but `a future version of the PSM
 will <https://github.com/SolutionGuidance/psm/issues/407>`__. Please
-contact the state Medicaid office directly to terminate an enrollment.
+contact the state/territory Medicaid office directly to terminate an
+enrollment.

--- a/psm-app/userhelp/source/process-purpose.rst
+++ b/psm-app/userhelp/source/process-purpose.rst
@@ -1,9 +1,9 @@
 Why do we have this enrollment process?
 =======================================
 
-Under Medicaid and similar programs, federal and state governments pay
-doctors, pharmacists, and other medical service providers for treating
-patients. State and federal regulations require providers to meet
+Under Medicaid and similar programs, federal and state/territory governments
+pay doctors, pharmacists, and other medical service providers for treating
+patients. State/territory and federal regulations require providers to meet
 eligibility standards. The enrollment process is where we verify that
 eligibility. The Provider Screening Module (PSM) helps states manage the
 enrollment process so that eligible providers can serve Medicaid

--- a/psm-app/userhelp/source/provider-help.rst
+++ b/psm-app/userhelp/source/provider-help.rst
@@ -23,7 +23,7 @@ If an `enrollment <enrollment.html>`__ is a draft (you haven't submitted
 it yet), then yes, you can click on the draft enrollment and edit your
 name. If you have already submitted the enrollment, then it is not
 possible to edit your name as associated with that enrollment; you'll
-need to contact the state Medicaid office directly.
+need to contact the state/territory Medicaid office directly.
 
 Currently it is not possible for you to change your name for your
 account; you will need to contact a system administrator at your state
@@ -39,7 +39,7 @@ Once an enrollment has been approved, you cannot change the contact
 information in it via this system (although `a future version of the PSM
 will allow you to do
 this <https://github.com/SolutionGuidance/psm/issues/416>`__); please
-contact the state Medicaid office directly.
+contact the state/territory Medicaid office directly.
 
 How do I update my license/certification information for an approved enrollment (e.g., if I have renewed my license)?
 ---------------------------------------------------------------------------------------------------------------------
@@ -48,4 +48,4 @@ Once an enrollment has been approved, you cannot change the license and
 certification information in it via this system (although `a future
 version of the PSM will allow you to do
 this <https://github.com/SolutionGuidance/psm/issues/416>`__); please
-contact the state Medicaid office directly.
+contact the state/territory Medicaid office directly.

--- a/psm-app/userhelp/source/service-admin-help.rst
+++ b/psm-app/userhelp/source/service-admin-help.rst
@@ -2,12 +2,12 @@ Application reviewer help documentation
 =======================================
 
 This is documentation for service administrators for the Provider
-Screening Module. Usually these are state Medicaid agency staffers.
+Screening Module. Usually these are state/territory Medicaid agency staffers.
 
 How do I use the enrollment verification process?
 -------------------------------------------------
 
-Verification is checking an enrollment with federal or state data
+Verification is checking an enrollment with federal or state/territory data
 sources and visually inspecting the license(s) or certification(s) in a
 submitted enrollment.
 

--- a/psm-app/userhelp/source/service-agent-help.rst
+++ b/psm-app/userhelp/source/service-agent-help.rst
@@ -7,19 +7,19 @@ Module.
 Who is allowed to be a service agent?
 -------------------------------------
 
-The state Medicaid office decides on criteria for service agents.
+The state/territory Medicaid office decides on criteria for service agents.
 
 Is it acceptable for me to fill out and sign the Provider Statement on the provider's behalf?
 ---------------------------------------------------------------------------------------------
 
-Please confer with the state Medicaid office.
+Please confer with the state/territory Medicaid office.
 
-When the state accepts or rejects an enrollment I've submitted, how do I find out? Is it my responsibility to notify the provider?
-----------------------------------------------------------------------------------------------------------------------------------
+When the state/territory accepts or rejects an enrollment I've submitted, how do I find out? Is it my responsibility to notify the provider?
+--------------------------------------------------------------------------------------------------------------------------------------------
 
 Right now, this site does not notify you via email or paper mail when
-the state accepts or rejects an enrollment you have submitted. `This
-will change in a future version of the Provider Screening
+the state/territory accepts or rejects an enrollment you have submitted.
+`This will change in a future version of the Provider Screening
 Module. <https://github.com/SolutionGuidance/psm/issues/341>`__
 
 When you log into the PSM, you'll see any enrollments you've submitted
@@ -59,8 +59,8 @@ How do I update the license/certification information for an approved enrollment
 -----------------------------------------------------------------------------------------------------------------------------------
 
 Currently, the PSM does not allow you to update information for an
-approved enrollment. You'll need to contact the state Medicaid office
-directly. `A future version of the PSM will let you do
+approved enrollment. You'll need to contact the state/territory Medicaid
+office directly. `A future version of the PSM will let you do
 this. <https://github.com/SolutionGuidance/psm/issues/416>`__
 
 How do I terminate an enrollment (e.g., if a provider retires or dies)?
@@ -68,5 +68,5 @@ How do I terminate an enrollment (e.g., if a provider retires or dies)?
 
 Currently the PSM does not give you a way to terminate an approved
 enrollment, but `a future version of the PSM
-will <https://github.com/SolutionGuidance/psm/issues/407>`__. Please
-contact the state Medicaid office directly to terminate an enrollment.
+will <https://github.com/SolutionGuidance/psm/issues/407>`__. Please contact
+the state/territory Medicaid office directly to terminate an enrollment.


### PR DESCRIPTION
As in PR #1059, we are adding U.S. territories in addition to states, and are updating the UI accordingly.  This PR covers the wording in the user help docs.

Issue #62 Include territories in list of states?