### PR TITLE
Prevent NPE on notification email

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/NotificationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/NotificationServiceBean.java
@@ -146,6 +146,10 @@ public class NotificationServiceBean extends BaseService implements Notification
         String contact_name = enrollment.getContactInformation().getName();
         vars.put("submitter", contact_name);
         String emailAddress = enrollment.getContactInformation().getEmailAddress();
-        sendNotification(emailAddress, emailType, vars);
+        if (emailAddress != null && emailAddress.trim().length() > 0) {
+            sendNotification(emailAddress, emailType, vars);
+        } else {
+            getLogger().warning("Skipping notification as email address was missing");
+        }
     }
 }


### PR DESCRIPTION
We do not collect email addresses in the enrollment application process for every provider type. Check that there is an email address before sending an email so as to avoid throwing a null pointer exception.

@HemKal previously authored this as #1005, but wasn't available to finish polishing before we needed to merge, and #1005 is from @HemKal's fork and so I can't overwrite it and need to, instead, open a new PR.

Resolves #968 NPE on submitting a personal care assistant enrollment application
Resolves #1005 Prevent NPE on notification email