### PR TITLE
Increase input field width on edit and create provider type pages

### DIFF
--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -3739,6 +3739,7 @@ input.text{
   line-height: 20px;
   margin: 4px 7px 0;
   padding-left: 5px;
+  width: 700px;
 }
 .rightBoxes{
   float:left;


### PR DESCRIPTION
Before it was too narrow to show the full provider type text:

![screenshot_2018-08-29 edit provider type - functions service admin 1](https://user-images.githubusercontent.com/1091693/44812597-af12d280-aba5-11e8-95f6-a165f9016e12.png)


After:

![screenshot_2018-08-29 edit provider type - functions service admin](https://user-images.githubusercontent.com/1091693/44812604-b33ef000-aba5-11e8-9d9b-9d1b44467740.png)

Tested by logging in as a service admin and going to functions > provider types > edit (and also add provider type).
