### PR TITLE
Remove colons from system admin view and edit user accounts pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
@@ -39,47 +39,38 @@
                 <div class="wholeCol">
                   <div class="row">
                     <label>Username</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${user.username}</span>
                   </div>
                   <div class="row">
                     <label>Password</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>********</span>
                   </div>
                   <div class="row">
                     <label>First Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${user.firstName}</span>
                   </div>
                   <div class="row">
                     <label>Middle Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${user.middleName}</span>
                   </div>
                   <div class="row">
                     <label>Last Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${user.lastName}</span>
                   </div>
                   <div class="row">
                     <label>Email</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${user.email}</span>
                   </div>
                   <div class="row">
                     <label>API Read Access</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${user.apiRead ? "Yes" : "No"}</span>
                   </div>
                   <div class="row">
                     <label>API Write Access</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${user.apiWrite ? "Yes" : "No"}</span>
                   </div>
                   <div class="row">
                     <label>User Role</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${user.role.description}</span>
                   </div>
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
@@ -81,52 +81,42 @@
                   <div class="wholeCol">
                     <div class="row">
                       <label for="newUsername">Username</label>
-                      <span class="floatL"><b>:</b></span>
                       <form:input id="newUsername" cssClass="normalInput" path="username" />
                     </div>
                     <div class="row">
                       <label for="newPassword">Password</label>
-                      <span class="floatL"><b>:</b></span>
                       <input type="password" id="newPassword" class="passwordNormalInput" value="" name="password" />
                     </div>
                     <div class="row">
                       <label for="newConfirmPassword">Confirm Password</label>
-                      <span class="floatL"><b>:</b></span>
                       <input type="password" id="newConfirmPassword" class="passwordNormalInput" value="" name="password2"/>
                     </div>
                     <div class="row">
                       <label for="firstName">First Name</label>
-                      <span class="floatL"><b>:</b></span>
                       <form:input id="firstName" cssClass="normalInput" path="firstName" />
                     </div>
                     <div class="row">
                       <label for="middleName">Middle Name</label>
-                      <span class="floatL"><b>:</b></span>
                       <form:input id="middleName" cssClass="normalInput" path="middleName" />
                     </div>
                     <div class="row">
                       <label for="lastName">Last Name</label>
-                      <span class="floatL"><b>:</b></span>
                       <form:input id="lastName" cssClass="normalInput" path="lastName" />
                     </div>
                     <div class="row">
                       <label for="email">Email</label>
-                      <span class="floatL"><b>:</b></span>
                       <form:input id="email" cssClass="normalInput" path="email" />
                     </div>
                     <div class="row">
                       <label for="apiRead">API Read Access</label>
-                      <span class="floatL"><b>:</b></span>
                       <form:checkbox id="apiRead" path="apiRead" />
                     </div>
                     <div class="row">
                       <label for="apiWrite">API Write Access</label>
-                      <span class="floatL"><b>:</b></span>
                       <form:checkbox id="apiWrite" path="apiWrite" />
                     </div>
                     <div class="row">
                       <label for="userRole">User Role</label>
-                      <span class="floatL"><b>:</b></span>
                       <form:select id="userRole" cssClass="userRoleSelect" path="role.description">
                         <form:option value="" >Please Select</form:option>
                         <c:forEach items="${availableRoles }" var="r">


### PR DESCRIPTION
Before:
![screenshot_2018-08-29 user account details system admin](https://user-images.githubusercontent.com/1091693/44813927-285ff480-aba9-11e8-953a-348114b869c5.png)
![screenshot_2018-08-29 edit user account system admin](https://user-images.githubusercontent.com/1091693/44813932-2b5ae500-aba9-11e8-970b-7bc536c22fa9.png)


After:
![screenshot_2018-08-29 user account details system admin 1](https://user-images.githubusercontent.com/1091693/44813937-2eee6c00-aba9-11e8-9a19-8d276212d0cf.png)
![screenshot_2018-08-29 edit user account system admin 1](https://user-images.githubusercontent.com/1091693/44813941-31e95c80-aba9-11e8-921a-1c2bbd99b1d4.png)


Tested by logging in as a system admin and clicking 'view' and 'edit' for a user account.

Issue #376: Remove right-justified colons...