### PR TITLE
Remove colons from organization view enrollment pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/member_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/member_information.jsp
@@ -16,25 +16,21 @@
                 <div class="leftCol">
                     <div class="row">
                         <label>NPI</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_16_npi_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label>Individual Provider Type</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_16_providerType_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label>Date of Birth</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_16_dob_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label>Start Date</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_16_startDate_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
@@ -42,13 +38,11 @@
                 <div class="rightCol">
                     <div class="row">
                         <label>Name</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_16_name_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label>Social Security Number</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_16_ssn_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
@@ -56,13 +50,11 @@
                     <c:if test="${not empty formName}">
                         <div class="row">
                             <label>BGS Study ID</label>
-                            <span class="floatL"><b>:</b></span>
                             <c:set var="formName" value="_16_bgsStudyId_${status.index - 1}"></c:set>
                             <span>${requestScope[formName]}</span>
                         </div>
                         <div class="row">
                             <label>BGS Clearance Date</label>
-                            <span class="floatL"><b>:</b></span>
                             <c:set var="formName" value="_16_bgsClearanceDate_${status.index - 1}"></c:set>
                             <span>${requestScope[formName]}</span>
                         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_disclosure.jsp
@@ -13,19 +13,16 @@
 
         <div class="row">
             <label>Been convicted of a criminal offense related to that person's involvement in any program under Medicare, Medicaid, Title XX, or Title XXI in Minnesota or any other state or jurisdiction since the inception of these programs?</label>
-            <span class="floatL"><b>:</b></span>
             <c:if test="${requestScope['_18_empCriminalConvictionInd'] eq 'Y'}"><span>Yes</span></c:if>
             <c:if test="${requestScope['_18_empCriminalConvictionInd'] eq 'N'}"><span>No</span></c:if>
         </div>
         <div class="row">
             <label>Had civil money penalties or assessments imposed under section 1128A of the Social Security Act?</label>
-            <span class="floatL"><b>:</b></span>
             <c:if test="${requestScope['_18_empCivilPenaltyInd'] eq 'Y'}"><span>Yes</span></c:if>
             <c:if test="${requestScope['_18_empCivilPenaltyInd'] eq 'N'}"><span>No</span></c:if>
         </div>
         <div class="row">
             <label>Been excluded from participation in Medicare or any of the State health care programs?</label>
-            <span class="floatL"><b>:</b></span>
             <c:if test="${requestScope['_18_empPreviousExclusionInd'] eq 'Y'}"><span>Yes</span></c:if>
             <c:if test="${requestScope['_18_empPreviousExclusionInd'] eq 'N'}"><span>No</span></c:if>
         </div>
@@ -36,19 +33,16 @@
 
         <div class="row">
             <label>Been convicted of a criminal offense related to that person's involvement in any program under Medicare, Medicaid, Title XX, or Title XXI in Minnesota or any other state or jurisdiction since the inception of these programs?</label>
-            <span class="floatL"><b>:</b></span>
             <c:if test="${requestScope['_18_criminalConvictionInd'] eq 'Y'}"><span>Yes</span></c:if>
             <c:if test="${requestScope['_18_criminalConvictionInd'] eq 'N'}"><span>No</span></c:if>
         </div>
         <div class="row">
             <label>Had civil money penalties or assessments imposed under section 1128A of the Social Security Act?</label>
-            <span class="floatL"><b>:</b></span>
             <c:if test="${requestScope['_18_civilPenaltyInd'] eq 'Y'}"><span>Yes</span></c:if>
             <c:if test="${requestScope['_18_civilPenaltyInd'] eq 'N'}"><span>No</span></c:if>
         </div>
         <div class="row">
             <label>Been excluded from participation in Medicare or any of the State health care programs?</label>
-            <span class="floatL"><b>:</b></span>
             <c:if test="${requestScope['_18_previousExclusionInd'] eq 'Y'}"><span>Yes</span></c:if>
             <c:if test="${requestScope['_18_previousExclusionInd'] eq 'N'}"><span>No</span></c:if>
         </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
@@ -17,17 +17,14 @@
             <div class="wholeCol">
             <div class="row">
                 <label>Name of Facility</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_name']}</span>
             </div>
             <div class="row">
                 <label>NPI</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_npi']}</span>
             </div>
             <div class="row">
                 <label>Street Address</label>
-                <span class="floatL"><b>:</b></span>
                 <span>
                     <c:if test="${not empty requestScope['_15_addressLine1']}"><c:out value="${requestScope['_15_addressLine1']}" /><br /></c:if>
                     <c:out value="${requestScope['_15_addressLine2']}" /><br />
@@ -42,34 +39,28 @@
                   Federal Employer ID
                   (<abbr title="Federal Employer Identification Number">FEIN</abbr>)
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_fein']}</span>
             </div>
             <div class="row">
                 <label>TaxPayer Name</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_legalName']}</span>
             </div>
             <div class="row">
                 <label>State Tax ID</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_stateTaxId']}</span>
             </div>
             <div class="row">
                 <label>Fiscal Year End</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_fye1']}</span>
             </div>
             <div class="row">
                 <label>Office Phone Number</label>
-                <span class="floatL"><b>:</b></span>
                 <span>
                 ${requestScope['_15_phone1']}<c:if test="${requestScope['_15_phone2'] ne ''}"> - </c:if>${requestScope['_15_phone2']}<c:if test="${requestScope['_15_phone3'] ne ''}"> - </c:if>${requestScope['_15_phone3']}<c:if test="${requestScope['_15_phone4'] ne ''}"> ext. </c:if>${requestScope['_15_phone4']}
                 </span>
             </div>
             <div class="row">
                 <label>Office Fax Number</label>
-                <span class="floatL"><b>:</b></span>
                 <span>
                 ${requestScope['_15_fax1']}<c:if test="${requestScope['_15_fax2'] ne ''}"> - </c:if>${requestScope['_15_fax2']}<c:if test="${requestScope['_15_fax3'] ne ''}"> - </c:if>${requestScope['_15_fax3']}
                 </span>
@@ -84,17 +75,14 @@
             <div class="wholeCol">
             <div class="row">
                 <label>Complete Provider Name</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_name']}</span>
             </div>
             <div class="row">
                 <label>NPI</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_npi']}</span>
             </div>
             <div class="row">
                 <label>Actual Street Address</label>
-                <span class="floatL"><b>:</b></span>
                 <span>
                     <c:if test="${not empty requestScope['_15_addressLine1']}"><c:out value="${requestScope['_15_addressLine1']}" /><br /></c:if>
                     <c:out value="${requestScope['_15_addressLine2']}" /><br />
@@ -106,7 +94,6 @@
             </div>
             <div class="row">
                 <label>County</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_orgCountyName']}</span>
             </div>
             <div class="row">
@@ -114,41 +101,34 @@
                   Federal Employer ID
                   (<abbr title="Federal Employer Identification Number">FEIN</abbr>)
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_fein']}</span>
             </div>
             <div class="row">
                 <label>Legal Name According to the IRS</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_legalName']}</span>
             </div>
             <div class="row">
                 <label>State Tax ID</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_stateTaxId']}</span>
             </div>
             <div class="row">
                 <label>Fiscal Year End</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_fye1']}</span>
             </div>
             <div class="row">
                 <label>Phone Number</label>
-                <span class="floatL"><b>:</b></span>
                 <span>
                 ${requestScope['_15_phone1']}<c:if test="${requestScope['_15_phone2'] ne ''}"> - </c:if>${requestScope['_15_phone2']}<c:if test="${requestScope['_15_phone3'] ne ''}"> - </c:if>${requestScope['_15_phone3']}<c:if test="${requestScope['_15_phone4'] ne ''}"> ext. </c:if>${requestScope['_15_phone4']}
                 </span>
             </div>
             <div class="row">
                 <label>Fax Number</label>
-                <span class="floatL"><b>:</b></span>
                 <span>
                 ${requestScope['_15_fax1']}<c:if test="${requestScope['_15_fax2'] ne ''}"> - </c:if>${requestScope['_15_fax2']}<c:if test="${requestScope['_15_fax3'] ne ''}"> - </c:if>${requestScope['_15_fax3']}
                 </span>
             </div>
             <div class="row">
                 <label>Requested Enrollment Date</label>
-                <span class="floatL"><b>:</b></span>
                 <span>${requestScope['_15_effectiveDate']}</span>
             </div>
             </div>
@@ -161,12 +141,10 @@
             <div class="leftCol">
                 <div class="row">
                     <label>Type</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_subType']}</span>
                 </div>
                 <div class="row">
                     <label>Organization Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_name']}</span>
                 </div>
                 <div class="row">
@@ -174,22 +152,18 @@
                     Federal Employer ID
                     (<abbr title="Federal Employer Identification Number">FEIN</abbr>)
                   </label>
-                  <span class="floatL"><b>:</b></span>
                   <span>${requestScope['_15_fein']}</span>
                 </div>
                 <div class="row">
                     <label>State Tax Id</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_stateTaxId']}</span>
                 </div>
                 <div class="row">
                     <label>Legal Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_legalName']}</span>
                 </div>
                 <div class="row">
                     <label>Address</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>
                         <c:if test="${not empty requestScope['_15_addressLine1']}"><c:out value="${requestScope['_15_addressLine1']}" /><br /></c:if>
                         <c:out value="${requestScope['_15_addressLine2']}" /><br />
@@ -201,7 +175,6 @@
                 </div>
                 <div class="row">
                     <label>Phone Number</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>
                         ${requestScope['_15_phone1']}<c:if test="${requestScope['_15_phone2'] ne ''}"> - </c:if>${requestScope['_15_phone2']}<c:if test="${requestScope['_15_phone3'] ne ''}"> - </c:if>${requestScope['_15_phone3']}<c:if test="${requestScope['_15_phone4'] ne ''}"> ext. </c:if>${requestScope['_15_phone4']}
                     </span>
@@ -215,25 +188,21 @@
                 </div>
                 <div class="row">
                     <label>Legal Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_legalName']}</span>
                 </div>
                 <div class="row">
                     <label>Fax Number</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>
                     ${requestScope['_15_fax1']}<c:if test="${requestScope['_15_fax2'] ne ''}"> - </c:if>${requestScope['_15_fax2']}<c:if test="${requestScope['_15_fax3'] ne ''}"> - </c:if>${requestScope['_15_fax3']}
                     </span>
                 </div>
                 <div class="row">
                     <label>UMPI</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_npi']}</span>
                 </div>
                 <c:if test="${showNameOfPersonFillingTheForm}">
                     <div class="row">
                         <label>Name of person completing this form</label>
-                        <span class="floatL"><b>:</b></span>
                         <span>${requestScope['_15_personCompletingForm']}</span>
                     </div>
                 </c:if>
@@ -253,17 +222,14 @@
                             <label>NPI</label>
                         </c:otherwise>
                     </c:choose>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_npi']}</span>
                 </div>
                 <div class="row">
                     <label>${askDBAName ? 'DBA Name' : 'Doing Business As'}</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_name']}</span>
                 </div>
                 <div class="row">
                     <label>Practice Address</label>
-                    <span class="floatL"><b>:</b></span>
                     <h:address name="practice"
                         streetAddress="${requestScope['_15_addressLine1']}"
                         extendedAddress="${requestScope['_15_addressLine2']}"
@@ -274,7 +240,6 @@
                 </div>
                 <div class="row">
                     <label>Office Phone Number</label>
-                    <span class="floatL"><b>:</b></span>
 
                     <span>
                         ${requestScope['_15_phone1']}<c:if test="${requestScope['_15_phone2'] ne ''}"> - </c:if>${requestScope['_15_phone2']}<c:if test="${requestScope['_15_phone3'] ne ''}"> - </c:if>${requestScope['_15_phone3']}<c:if test="${requestScope['_15_phone4'] ne ''}"> ext. </c:if>${requestScope['_15_phone4']}
@@ -285,13 +250,11 @@
                     Federal Employer ID
                     (<abbr title="Federal Employer Identification Number">FEIN</abbr>)
                   </label>
-                  <span class="floatL"><b>:</b></span>
                   <span>${requestScope['_15_fein']}</span>
                 </div>
                 <c:if test="${askFiscalYear}">
                     <div class="row">
                         <label>Fiscal Year End</label>
-                        <span class="floatL"><b>:</b></span>
                         <span>${requestScope['_15_fye1']}</span>
                     </div>
                 </c:if>
@@ -301,13 +264,11 @@
                 <c:if test="${askEffectiveDate}">
                     <div class="row">
                         <label>Effective Date</label>
-                        <span class="floatL"><b>:</b></span>
                         <span>${requestScope['_15_effectiveDate']}</span>
                     </div>
                 </c:if>
                 <div class="row">
                     <label>${askTaxPayerName ? 'Taxpayer Name' : 'Legal Name'}</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_legalName']}</span>
                 </div>
                 <div class="row">
@@ -316,14 +277,12 @@
                 </div>
                 <div class="row">
                     <label>Office Fax Number</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>
                         ${requestScope['_15_fax1']}<c:if test="${requestScope['_15_fax2'] ne ''}"> - </c:if>${requestScope['_15_fax2']}<c:if test="${requestScope['_15_fax3'] ne ''}"> - </c:if>${requestScope['_15_fax3']}
                     </span>
                 </div>
                 <div class="row">
                     <label>State Tax ID</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_15_stateTaxId']}</span>
                 </div>
             </div>
@@ -336,7 +295,6 @@
     <div class="leftCol">
         <div class="row">
             <label>Billing Address</label>
-            <span class="floatL"><b>:</b></span>
             <c:if test="${requestScope['_15_billingSameAsPrimary'] eq 'Y'}">Same As Above</c:if>
             <c:if test="${requestScope['_15_billingSameAsPrimary'] ne 'Y'}">
                 <span>
@@ -351,7 +309,6 @@
         </div>
         <div class="row">
             <label>1099 Address</label>
-            <span class="floatL"><b>:</b></span>
             <c:if test="${requestScope['_15_ten99SameAsPrimary'] eq 'Y'}">Same As Above</c:if>
             <c:if test="${requestScope['_15_ten99SameAsPrimary'] ne 'Y'}">
                 <span>
@@ -372,26 +329,22 @@
     <div class="leftCol">
         <div class="row">
             <label>Contact Name</label>
-            <span class="floatL"><b>:</b></span>
             <span class="address">${requestScope['_15_contactName']}</span>
         </div>
         <div class="row">
             <label>Contact Phone Number</label>
-            <span class="floatL"><b>:</b></span>
             <span>
             ${requestScope['_15_contactPhone1']}<c:if test="${requestScope['_15_contactPhone2'] ne ''}"> - </c:if>${requestScope['_15_contactPhone2']}<c:if test="${requestScope['_15_contactPhone3'] ne ''}"> - </c:if>${requestScope['_15_contactPhone3']}<c:if test="${requestScope['_15_contactPhone4'] ne ''}"> ext. </c:if>${requestScope['_15_contactPhone4']}
             </span>
         </div>
         <div class="row">
             <label>Contact Fax Number</label>
-            <span class="floatL"><b>:</b></span>
             <span>
             ${requestScope['_15_contactFax1']}<c:if test="${requestScope['_15_contactFax2'] ne ''}"> - </c:if>${requestScope['_15_contactFax2']}<c:if test="${requestScope['_15_contactFax3'] ne ''}"> - </c:if>${requestScope['_15_contactFax3']}
             </span>
         </div>
         <div class="row">
             <label>Contact Email Address</label>
-            <span class="floatL"><b>:</b></span>
             <span>${requestScope['_15_contactEmail']}</span>
         </div>
     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ownership_information.jsp
@@ -22,25 +22,21 @@
                 <div class="leftCol">
                     <div class="row">
                         <label>Type</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_17_iboType_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label>Date of Birth</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_17_iboDOB_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label>Social Security Number</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_17_iboSSN_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label>Home Residence Address</label>
-                        <span class="floatL"><b>:</b></span>
 
                         <c:set var="streetAddress" value="_17_iboAddressLine1_${status.index - 1}" />
                         <c:set var="extendedAddress" value="_17_iboAddressLine2_${status.index - 1}" />
@@ -60,7 +56,6 @@
                 <div class="rightCol">
                     <div class="row">
                         <label>Name</label>
-                        <span class="floatL"><b>:</b></span>
                         <span>
                             <c:set var="formName" value="_17_iboFirstName_${status.index - 1}"></c:set>
                             ${requestScope[formName]}&nbsp;<c:set var="formName" value="_17_iboMiddleName_${status.index - 1}"></c:set><c:if test="${not empty requestScope[formName]}"><c:out value="${requestScope[formName]}"></c:out></c:if>
@@ -69,13 +64,11 @@
                     </div>
                     <div class="row">
                         <label>Hire Date</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_17_iboHireDate_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label class="multiLine">Relationship to any other listed person</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_17_iboRelationship_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
@@ -99,19 +92,16 @@
                 <div class="leftCol">
                     <div class="row">
                         <label>Type</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_17_cboType_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label>Full Legal Name</label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_17_cboLegalName_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>
                     <div class="row">
                         <label>Business Address</label>
-                        <span class="floatL"><b>:</b></span>
 
                         <c:set var="streetAddress" value="_17_cboAddressLine1_${status.index - 1}" />
                         <c:set var="extendedAddress" value="_17_cboAddressLine2_${status.index - 1}" />
@@ -133,7 +123,6 @@
                         <label>
                           <abbr title="Federal Employer Identification Number">FEIN</abbr>
                         </label>
-                        <span class="floatL"><b>:</b></span>
                         <c:set var="formName" value="_17_cboFEIN_${status.index - 1}"></c:set>
                         <span>${requestScope[formName]}</span>
                     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_organization_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_organization_disclosure.jsp
@@ -19,12 +19,10 @@
             <div class="leftCol">
                 <div class="row">
                     <label>Provider Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_19_name']}</span>
                 </div>
                 <div class="row">
                     <label>Provider Title</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_19_title']}</span>
                 </div>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
@@ -46,38 +46,26 @@
                 <div class="col1">
                   <div class="row">
                     <label>Request Type</label>
-                    <span class="floatL">
-                      <b>:</b>
-                    </span>
                     <span>${requestScope['_99_requestType']}</span>
                   </div>
                   <div class="row">
                     <label>Status</label>
-                    <span class="floatL">
-                      <b>:</b>
-                    </span>
                     <span>${requestScope['_99_requestStatus'] eq 'Rejected' ? 'Denied' : requestScope['_99_requestStatus']}</span>
                   </div>
                 </div>
                 <div class="col2">
                   <div class="row">
                     <label>Submitted On</label>
-                    <span class="floatL">
-                      <b>:</b>
-                    </span>
                     <span>${requestScope['_99_submittedOn']}</span>
                   </div>
                   <div class="row">
                     <label>Status Date</label>
-                    <span class="floatL">
-                      <b>:</b>
-                    </span>
                     <span>${requestScope['_99_statusDate']}</span>
                   </div>
                 </div>
                 <div class="col3">
                   <div class="row">
-                    <label>Risk Level &nbsp;&nbsp;&nbsp;&nbsp;:</label>
+                    <label>Risk Level</label>
                     <span>${requestScope['_99_riskLevel']}</span>
                   </div>
                 </div>


### PR DESCRIPTION
Before:

![screenshot_2018-08-29 organization information](https://user-images.githubusercontent.com/1091693/44815735-598ef380-abae-11e8-8753-6a0d030980f6.png)
![screenshot_2018-08-29 ownership information](https://user-images.githubusercontent.com/1091693/44815742-5e53a780-abae-11e8-99b9-0d25850abcea.png)
![screenshot_2018-08-29 provider statement](https://user-images.githubusercontent.com/1091693/44815744-60b60180-abae-11e8-8f9a-062446718fa5.png)

After:

![screenshot_2018-08-29 organization information 1](https://user-images.githubusercontent.com/1091693/44815750-64498880-abae-11e8-9a1d-1dee30fd00a3.png)
![screenshot_2018-08-29 ownership information 1](https://user-images.githubusercontent.com/1091693/44815752-66134c00-abae-11e8-84b9-cf74eede9451.png)
![screenshot_2018-08-29 provider statement 1](https://user-images.githubusercontent.com/1091693/44815755-67447900-abae-11e8-87ef-bad2bc5b862a.png)

Tested by logging in as a provider and clicking 'view' for an organization application, and looking at the three different tabs on the view page.

Issue #376: Remove right-justified colons...