### PR TITLE
Improve advanced search panel layout and remove colons

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
@@ -35,12 +35,10 @@
                 <div class="leftCol">
                   <div class="row">
                     <label for="npiInput">Enrollment #</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="npiInput" type="text" class="normalInput" value="${searchCriteria.npi}"/>
                   </div>
                   <div class="row">
                     <label>Date Submitted</label>
-                    <span class="floatL"><b>:</b></span>
                     <span class="dateWrapper floatL">
                       <input id="submissionDateStartInput" title="Submission Date Start" value='<fmt:formatDate value="${searchCriteria.submissionDateStart}" pattern="MM/dd/yyyy"/>' class="date" type="text" readonly="readonly"/>
                     </span>
@@ -51,7 +49,6 @@
                   </div>
                   <div class="row">
                     <label for="providerTypeInput">Provider Type</label>
-                    <span class="floatL"><b>:</b></span>
                     <select id="providerTypeInput" class="longSelect">
                       <option value="">All</option>
                       <c:forEach var="item" items="${providerTypesLookup}">
@@ -61,7 +58,6 @@
                   </div>
                   <div class="row">
                     <label for="providerNameInput">Provider Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="providerNameInput" value="${searchCriteria.providerName}" type="text" class="normalInput"/>
                   </div>
                 </div>
@@ -69,7 +65,6 @@
                 <div class="rightCol">
                   <div class="row checkRow">
                     <label>Request Type</label>
-                    <span class="floatL"><b>:</b></span>
                     <div class="checkWrapper">
                       <label class="checkboxLabel">
                         <input type="checkbox" name="requestType" class="checkAll" />
@@ -85,7 +80,6 @@
                   </div>
                   <div class="row checkRow">
                     <label>Status</label>
-                    <span class="floatL"><b>:</b></span>
                     <div class="checkWrapper">
                       <label class="checkboxLabel">
                         <input type="checkbox" name="enrollmentStatus" class="checkAll" />
@@ -101,7 +95,6 @@
                   </div>
                   <div class="row checkRow">
                     <label>Risk Level</label>
-                    <span class="floatL"><b>:</b></span>
                     <div class="checkWrapper">
                       <label class="checkboxLabel">
                         <input type="checkbox" name="riskLevel" class="checkAll" />


### PR DESCRIPTION
The same advanced search panel appears for both provider and service admin logins.

Before (yikes...):

![screenshot_2018-08-29 advanced search 1](https://user-images.githubusercontent.com/1091693/44819277-46822080-abba-11e8-8052-8c9971a5eb34.png)

After:

![screenshot_2018-08-29 advanced search 2](https://user-images.githubusercontent.com/1091693/44819289-513cb580-abba-11e8-9ef5-a2c203bc799c.png)

The CSS changes also slightly affect (in a slightly positive way, IMHO) the system admin advance search panel.  Before:

![screenshot_2018-08-29 advanced search system admin](https://user-images.githubusercontent.com/1091693/44819343-82b58100-abba-11e8-94c8-205efade7b3d.png)

After:

![screenshot_2018-08-29 advanced search system admin 2](https://user-images.githubusercontent.com/1091693/44819346-8812cb80-abba-11e8-8a21-35e68631cb03.png)

Tested by logging in and looking at the advanced search pages for the three logins.

Issue #376: Remove right-justified colons...