### PR TITLE
Remove colons from service admin view and edit user profile pages

### DIFF
--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_edit_user_profile.template.html
@@ -27,29 +27,24 @@
                 <div class="wholeCol">
                   <div class="row">
                     <label>Username</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="username" name="username" type="hidden" value="{{user.username}}" />
                     <span>{{user.username}}</span>
                   </div>
                   <div class="row">
                     <label>First Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="firstName" name="firstName" class="normalInput" type="text" value="{{user.firstName}}" />
                   </div>
                   <div class="row">
                     <label>Middle Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="middleName" name="middleName" class="normalInput" type="text" value="{{user.middleName}}" />
                     <em class="grey">(optional)</em>
                   </div>
                   <div class="row">
                     <label>Last Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="lastName" name="lastName" class="normalInput" type="text" value="{{user.lastName}}" />
                   </div>
                   <div class="row">
                     <label>Business Phone</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="businessPhonePart1" name="businessPhonePart1" class="smallInput" type="text" value="{{user.businessPhonePart1}}" />
                     <span class="sep">-</span>
                     <input id="businessPhonePart2" name="businessPhonePart2" class="smallInput" type="text" value="{{user.businessPhonePart2}}" />
@@ -60,7 +55,6 @@
                   </div>
                   <div class="row">
                     <label>Email</label>
-                    <span class="floatL"><b>:</b></span>
                     <input id="email" name="email" class="normalInput" type="text" value="{{user.email}}" />
                   </div>
                 </div>

--- a/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
+++ b/psm-app/cms-web/WebContent/templates/admin/service_admin_view_user_profile.template.html
@@ -24,32 +24,26 @@
               <div class="wholeCol">
                 <div class="row">
                   <label>User Name</label>
-                  <span class="floatL"><b>:</b></span>
                   <span>{{user.username}}</span>
                 </div>
                 <div class="row">
                   <label>First Name</label>
-                  <span class="floatL"><b>:</b></span>
                   <span>{{user.firstName}}</span>
                 </div>
                 <div class="row">
                   <label>Middle Name</label>
-                  <span class="floatL"><b>:</b></span>
                   <span>{{user.middleName}}</span>
                 </div>
                 <div class="row">
                   <label>Last Name</label>
-                  <span class="floatL"><b>:</b></span>
                   <span>{{user.lastName}}</span>
                 </div>
                 <div class="row">
                   <label>Business Phone</label>
-                  <span class="floatL"><b>:</b></span>
                   <span>{{user.businessPhonePart1}} - {{user.businessPhonePart2}} - {{user.businessPhonePart3}} <b>ext.</b> {{user.businessPhoneExt}}</span>
                 </div>
                 <div class="row">
                   <label>Email</label>
-                  <span class="floatL"><b>:</b></span>
                   <span>{{user.email}}</span>
                 </div>
               </div>


### PR DESCRIPTION
Before:

![screenshot_2018-08-29 my profile service admin](https://user-images.githubusercontent.com/1091693/44820159-b514ad80-abbd-11e8-8396-329cac7af3c3.png)

![screenshot_2018-08-29 update profile service admin](https://user-images.githubusercontent.com/1091693/44820167-bba32500-abbd-11e8-9a4c-e79f77d0fce2.png)

After:

![screenshot_2018-08-29 my profile service admin 1](https://user-images.githubusercontent.com/1091693/44820177-c2ca3300-abbd-11e8-8fc5-3e7a8c6aa2a7.png)

![screenshot_2018-08-29 update profile service admin 1](https://user-images.githubusercontent.com/1091693/44820181-c6f65080-abbd-11e8-805d-e9df4788aa64.png)

Tested by logging in as a service admin, clicking "MY PROFILE" then "Update Profile" button.

Issue #376: Remove right-justified colons...