### PR TITLE
Fix anti-CSRF token on login page

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/psm-app/cms-web/WebContent/WEB-INF/mvc-dispatcher-servlet.xml
@@ -17,7 +17,12 @@
   <mvc:resources location="/help/" mapping="/help/**"/>
   <mvc:resources location="/i/" mapping="/i/**"/>
 
-  <mvc:annotation-driven/>
+  <mvc:annotation-driven>
+    <mvc:argument-resolvers>
+      <bean class="org.springframework.security.web.method.annotation.CsrfTokenArgumentResolver"/>
+    </mvc:argument-resolvers>
+  </mvc:annotation-driven>
+
 
   <context:property-placeholder location="classpath:cms.properties"/>
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/CsrfController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/CsrfController.java
@@ -1,0 +1,13 @@
+package gov.medicaid.controllers;
+
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CsrfController {
+    @RequestMapping("/csrf")
+    public CsrfToken csrf(CsrfToken csrfToken) {
+        return csrfToken;
+    }
+}

--- a/psm-app/frontend/src/main/js/common.js
+++ b/psm-app/frontend/src/main/js/common.js
@@ -202,6 +202,27 @@ function changePageNumber(page) {
   form.submit();
 }
 
+function updateLoginCsrfAndSubmit() {
+  var form = $("#loginform");
+  if (form.attr("submitting") == undefined) {
+    form.attr("submitting", true);
+    $.ajax({
+      url: ctx + "/csrf",
+      cache: false,
+      success: function submitWithNewCsrf(data) {
+        $("#loginForm input[name=_csrf]").val(data.token);
+        $("#loginForm").off().submit();
+      },
+
+      error: function submissionFailed() {
+        form.removeAttr("submitting");
+      }
+    })
+  }
+
+  return false;
+}
+
 /**
  * Submits the form with the given id.
  * @param id the id of the form to be submitted
@@ -254,4 +275,6 @@ $(document).ready(function () {
   $("input.fiscalMonthInput, input.fiscalYearInput").mask("00");
 
   setFileUploadClickHandler();
+
+  $("#loginForm").submit(updateLoginCsrfAndSubmit);
 });


### PR DESCRIPTION
This is a very early and incomplete effort to fix the anti-CSRF tokens expiring on the login page.

From the [Spring docs](https://docs.spring.io/spring-security/site/docs/current/reference/html/csrf.html#csrf-login):

> A common technique to protect the log in form is by using a JavaScript function to obtain a valid CSRF token before the form submission.

This implements the REST endpoint that provides such a token. I have not yet written the client-side JavaScript that overrides the default form behavior, fetches the token, and then includes it in the form submission; that would be necessary to complete this feature.

I open this in the hope that someone will be able to complete it, but I'm afraid it will not be me. If this is too partial to be useful, please close the PR.

Issue #1032 Prevent stale anti-CSRF tokens on login page