### PR TITLE
Add plugin to generate license reports

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -13,6 +13,7 @@ buildscript {
             exclude group: 'com.google.inject', module:'guice'
         }
         classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.2'
+        classpath 'gradle.plugin.com.github.jk1:gradle-license-report:1.2'
     }
 }
 
@@ -96,6 +97,7 @@ allprojects {
     project(":$name") {
         apply plugin: 'groovy'
         apply plugin: 'com.github.spotbugs'
+        apply plugin: 'com.github.jk1.dependency-license-report'
 
         configurations {
             testCompile.extendsFrom compileOnly
@@ -284,6 +286,7 @@ project(':cms-business-model') {
 
 project(':cms-portal-services') {
     apply plugin: 'ear'
+    apply plugin: 'com.github.jk1.dependency-license-report'
     dependencies {
         deploy project(path: ':cms-web', configuration: 'archives')
         deploy project(':cms-business-process')


### PR DESCRIPTION
Use the ["Gradle License Report"](https://github.com/jk1/Gradle-License-Report) to generate HTML reports of our dependencies.

Generate the reports with:

    ./gradlew generateLicenseReport

Reports live in {project}/build/reports/dependency-license/ .

If the reports this generates are useful, we should probably also delete the surely-out-of-date hand-made reports in [DEPENDENCIES.md](https://github.com/SolutionGuidance/psm/blob/147-license-report-plugin/docs/DEPENDENCIES.md), but I leave that decision to @kfogel or @jvasile.

Note that there may be a new version of the plugin available; this commit was originally authored quite some time ago.

---

If this looks good to you, dear reviewer, please merge it! I will probably not be around to do so. Likewise, if this needs tweaking, please do so! If this is a terrible idea, go ahead and close it; I will not feel slighted.

Issue #147 Review licenses of dependencies