### PR TITLE
Improve the Upload File UI in more places

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/adult_day_treatment_application.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/adult_day_treatment_application.jsp
@@ -1,5 +1,7 @@
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <input type="hidden" name="formNames" value="<%= ViewStatics.ADULT_DAY_TREATMENT_APPLICATION_FORM %>">
 <c:set var="selectedMarkup" value='selected="selected"' />
 
@@ -10,16 +12,16 @@
     <div class="section">
         <div class="">
             <div class="row requireField">
-                <label for="applicationFileUpload" class="mediumLbl">Please upload a copy of application*</label>
-                <c:set var="formName" value="_35_application"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <c:if test="${not empty formValue}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="applicationFileUpload" type="file" class="fileUpload" name="${formName}" />
+                <label class="mediumLbl">Please upload a copy of application*</label>
+                <span class="floatL">
+                    <c:set var="formName" value="_35_application" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Adult Day Treatment Application"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download" />
+                </span>
             </div>
         </div>
         <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
@@ -1,5 +1,6 @@
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 
 <c:set var="specialtyTrigger" value="${viewModel.tabModels[viewModel.currentTab].formSettings['Highest Degree Form'].settings['specialtyTrigger']}"></c:set>
 <c:set var="isActivated" value="${true}"></c:set>
@@ -40,26 +41,15 @@
                 </span>
             </div>
             <div class="row">
-                <c:set var="formName" value="_14_copyOfHighestDegree"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="copyOfDegree_${formName}">Copy of Highest Degree Earned</label>
+                <label>Copy of Highest Degree Earned</label>
                 <span class="floatL">
-                    <input
-                      id="copyOfDegree_${formName}"
-                      type="file"
-                      class="fileUpload newEnrollmentPanelButton"
-                      size="10"
-                      name="${formName}"
-                    />
-
-                    <c:if test="${not empty formValue}">
-                        <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                             <c:param name="id" value="${requestScope[formName]}"></c:param>
-                        </c:url>
-                        <div><a href="${downloadLink}">View</a></div>
-                        <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <input type="hidden" name="${formName}" value="${formValue}"/>
-                    </c:if>
+                    <c:set var="formName" value="_14_copyOfHighestDegree" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Copy of Highest Degree Earned"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="View" />
                 </span>
             </div>
             <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
@@ -1,5 +1,7 @@
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <c:set var="formIdPrefix" value="pcpo_insurance"></c:set>
 
 <input type="hidden" name="formNames" value="<%= ViewStatics.PCPO_INSURANCE_FORM %>">
@@ -10,62 +12,65 @@
     <div class="section">
         <div class="wholeCol organizationInfo">
             <div class="row requireField">
-                <c:set var="formName" value="_25_liabilityInsuranceId"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of certificate of liability insurance</label>
+                <label class="mediumLbl">Copy of certificate of liability insurance</label>
                 <span class="floatL"><b>:</b></span>
-                <c:if test="${not empty formValue}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="${formIdPrefix}_${formName}" type="file" class="fileUpload" name="${formName}" />
+                <span class="floatL">
+                    <c:set var="formName" value="_25_liabilityInsuranceId" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Certificate of liability insurance"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download" />
+                </span>
             </div>
             <div class="row">
             </div>
 
             <div class="row">
-                <c:set var="formName" value="_25_compensationInsuranceId"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of Workers' Compensation insurance</label>
+                <label class="mediumLbl">Copy of Workers' Compensation insurance</label>
                 <span class="floatL"><b>:</b></span>
-                <c:if test="${not empty  requestScope[formName]}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="${formIdPrefix}_${formName}" type="file" class="fileUpload" name="${formName}" />
-            </div>
-            <div class="row">
-            </div>
-
-            <div class="row requireField">
-                <c:set var="formName" value="_25_fidelityBondId"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of fidelity bond</label>
-                <span class="floatL"><b>:</b></span>
-                <c:if test="${not empty  requestScope[formName]}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="${formIdPrefix}_${formName}" type="file" class="fileUpload" name="${formName}" />
+                <span class="floatL">
+                    <c:set var="formName" value="_25_compensationInsuranceId" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Workers' Compensation insurance"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download" />
+                </span>
             </div>
             <div class="row">
             </div>
 
             <div class="row requireField">
-                <c:set var="formName" value="_25_suretyBondId"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of surety bond</label>
+                <label class="mediumLbl">Copy of fidelity bond</label>
                 <span class="floatL"><b>:</b></span>
-                <c:if test="${not empty  requestScope[formName]}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="${formIdPrefix}_${formName}" type="file" class="fileUpload" name="${formName}" />
+                <span class="floatL">
+                    <c:set var="formName" value="_25_fidelityBondId" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Fidelity bond"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download" />
+                </span>
+            </div>
+            <div class="row">
+            </div>
+
+            <div class="row requireField">
+                <label class="mediumLbl">Copy of surety bond</label>
+                <span class="floatL"><b>:</b></span>
+                <span class="floatL">
+                    <c:set var="formName" value="_25_suretyBondId" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Surety bond"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download" />
+                </span>
             </div>
 
             <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/phn_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/phn_agency.jsp
@@ -1,5 +1,7 @@
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <c:set var="formIdPrefix" value="phn_agency"></c:set>
 
 <input type="hidden" name="formNames" value="<%= ViewStatics.PHN_AGENCY_FORM %>">
@@ -42,15 +44,13 @@
                                     </label>
                                 </td>
                                 <td>
-                                    <c:set var="formName" value="_26_contractAttachment"></c:set>
-                                    <input type="file" title="Contract File" class="fileUpload" name="${formName}" />
-                                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                                    <c:if test="${not empty formValue}">
-                                        <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                                             <c:param name="id" value="${formValue}"></c:param>
-                                        </c:url>
-                                        <div><a href="${downloadLink}">Download</a></div>
-                                    </c:if>
+                                    <c:set var="formName" value="_26_contractAttachment" />
+                                    <h:attachment
+                                        name="${formName}"
+                                        title="Contract File"
+                                        attachmentId="${requestScope[formName]}"
+                                        attachmentIdName="_26_contractAttachmentId"
+                                        filename="Download" />
                                 </td>
                             </tr>
                             </tbody>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/physician_clinic_facility_qualification.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/physician_clinic_facility_qualification.jsp
@@ -7,6 +7,8 @@
 
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <c:set var="formIdPrefix" value="physician_clinic_facility_qualification"></c:set>
 <input type="hidden" name="formNames" value="<%= ViewStatics.PHYSICIAN_CLINIC_FACILITY_QUALIFICATION_FORM %>">
 <c:set var="selectedMarkup" value='selected="selected"' />
@@ -29,15 +31,13 @@
                             </label>
                         </td>
                         <td>
-                           <c:set var="formName" value="_40_designationApproval"></c:set>
-                           <input type="file" title="Approval Letter File" class="fileUpload" name="${formName}" />
-                           <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                           <c:if test="${not empty formValue}">
-                               <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                                    <c:param name="id" value="${formValue}"></c:param>
-                               </c:url>
-                               <div><a href="${downloadLink}">Download</a></div>
-                           </c:if>
+                           <c:set var="formName" value="_40_designationApproval" />
+                           <h:attachment
+                               name="${formName}"
+                               title="Approval Letter File"
+                               attachmentId="${requestScope[formName]}"
+                               attachmentIdName="${formName}"
+                               filename="Download" />
                         </td>
                     </tr>
                     </tbody>

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
@@ -76,8 +76,10 @@ public class PHNAgencyFormBinder extends BaseFormBinder {
         if ("Y".equals(countyInfo.getCountyInd())) {
             countyInfo.setCountyName(param(request, "countyName"));
         } else if ("N".equals(countyInfo.getCountyInd())) {
-            String attachmentId = (String) request.getAttribute(NAMESPACE + "contractAttachment");
-            if (attachmentId != null) {
+            String attachmentId = (String) request.getAttribute(name("contractAttachment"));
+            if (attachmentId == null) {
+                attachmentId = param(request, "contractAttachmentId");
+            } else {
                 replaceDocument(XMLUtility.nsGetAttachments(provider), attachmentId, CONTRACT_WITH_COUNTY);
             }
 


### PR DESCRIPTION
When we were working on #158, I had some work partially completed to implement the new upload file UI in more places. Then that work got deprioritized, and it sat on a branch, alone and unloved.

I haven't yet tested these, and they might be quite broken! The first step is to figure out which forms, exactly, I'm updating; hopefully the commit titles make that clear. Then you need to figure out how to get to each form...

I open this PR in the hope that they aren't broken, and that someone has time to test them. Please merge, tweak, rewrite, or close as you see fit, dear reviewer; I'm afraid I likely won't have the time to.

Issue #158 "No file selected" is confusing when a file is uploaded
Issue #734 Moving backward in PHN enrollment loses county contract