### PR TITLE
WIP: Add groovy linter

### DIFF
--- a/psm-app/build.gradle
+++ b/psm-app/build.gradle
@@ -96,6 +96,12 @@ allprojects {
     project(":$name") {
         apply plugin: 'groovy'
         apply plugin: 'com.github.spotbugs'
+        apply plugin: 'codenarc'
+
+        codenarc {
+            toolVersion = '1.1'
+            configFile = rootProject.file("codenarc.groovy")
+        }
 
         configurations {
             testCompile.extendsFrom compileOnly

--- a/psm-app/cms-business-model/src/test/groovy/HelloSpec.groovy
+++ b/psm-app/cms-business-model/src/test/groovy/HelloSpec.groovy
@@ -1,15 +1,16 @@
-import spock.lang.*
+import spock.lang.Specification
+import spock.lang.Unroll
 
 @Unroll
 class HelloSpec extends Specification {
-  def "tests run properly (#a == #b)"(int a, int b) {
-    expect:
-    a == b
+    void "tests run properly (#a == #b)"(int a, int b) {
+        expect:
+        a == b
 
-    where:
-    a | b
-    1 | 1
-    2 | 2
-    3 | 3
-  }
+        where:
+        a | b
+        1 | 1
+        2 | 2
+        3 | 3
+    }
 }

--- a/psm-app/codenarc.groovy
+++ b/psm-app/codenarc.groovy
@@ -1,0 +1,382 @@
+ruleset {
+
+    description '''
+        A Sample Groovy RuleSet containing all CodeNarc Rules, grouped by category.
+        You can use this as a template for your own custom RuleSet.
+        Just delete the rules that you don't want to include.
+        '''
+
+    // rulesets/basic.xml
+    AssertWithinFinallyBlock
+    AssignmentInConditional
+    BigDecimalInstantiation
+    BitwiseOperatorInConditional
+    BooleanGetBoolean
+    BrokenNullCheck
+    BrokenOddnessCheck
+    ClassForName
+    ComparisonOfTwoConstants
+    ComparisonWithSelf
+    ConstantAssertExpression
+    ConstantIfExpression
+    ConstantTernaryExpression
+    DeadCode
+    DoubleNegative
+    DuplicateCaseStatement
+    DuplicateMapKey
+    DuplicateSetValue
+    EmptyCatchBlock
+    EmptyClass
+    EmptyElseBlock
+    EmptyFinallyBlock
+    EmptyForStatement
+    EmptyIfStatement
+    EmptyInstanceInitializer
+    EmptyMethod
+    EmptyStaticInitializer
+    EmptySwitchStatement
+    EmptySynchronizedStatement
+    EmptyTryBlock
+    EmptyWhileStatement
+    EqualsAndHashCode
+    EqualsOverloaded
+    ExplicitGarbageCollection
+    ForLoopShouldBeWhileLoop
+    HardCodedWindowsFileSeparator
+    HardCodedWindowsRootDirectory
+    IntegerGetInteger
+    MultipleUnaryOperators
+    RandomDoubleCoercedToZero
+    RemoveAllOnSelf
+    ReturnFromFinallyBlock
+    ThrowExceptionFromFinallyBlock
+
+    // rulesets/braces.xml
+    ElseBlockBraces
+    ForStatementBraces
+    IfStatementBraces
+    WhileStatementBraces
+
+    // rulesets/concurrency.xml
+    BusyWait
+    DoubleCheckedLocking
+    InconsistentPropertyLocking
+    InconsistentPropertySynchronization
+    NestedSynchronization
+    StaticCalendarField
+    StaticConnection
+    StaticDateFormatField
+    StaticMatcherField
+    StaticSimpleDateFormatField
+    SynchronizedMethod
+    SynchronizedOnBoxedPrimitive
+    SynchronizedOnGetClass
+    SynchronizedOnReentrantLock
+    SynchronizedOnString
+    SynchronizedOnThis
+    SynchronizedReadObjectMethod
+    SystemRunFinalizersOnExit
+    ThisReferenceEscapesConstructor
+    ThreadGroup
+    ThreadLocalNotStaticFinal
+    ThreadYield
+    UseOfNotifyMethod
+    VolatileArrayField
+    VolatileLongOrDoubleField
+    WaitOutsideOfWhileLoop
+
+    // rulesets/convention.xml
+    ConfusingTernary
+    CouldBeElvis
+    CouldBeSwitchStatement
+    FieldTypeRequired
+    HashtableIsObsolete
+    IfStatementCouldBeTernary
+    InvertedCondition
+    InvertedIfElse
+    LongLiteralWithLowerCaseL
+    MethodParameterTypeRequired
+    MethodReturnTypeRequired
+    NoDef
+    NoTabCharacter
+    ParameterReassignment
+    TernaryCouldBeElvis
+    TrailingComma
+    VariableTypeRequired
+    VectorIsObsolete
+
+    // rulesets/design.xml
+    AbstractClassWithPublicConstructor
+    AbstractClassWithoutAbstractMethod
+    AssignmentToStaticFieldFromInstanceMethod
+    BooleanMethodReturnsNull
+    BuilderMethodWithSideEffects
+    CloneableWithoutClone
+    CloseWithoutCloseable
+    CompareToWithoutComparable
+    ConstantsOnlyInterface
+    EmptyMethodInAbstractClass
+    FinalClassWithProtectedMember
+    ImplementationAsType
+    Instanceof
+    LocaleSetDefault
+    NestedForLoop
+    PrivateFieldCouldBeFinal
+    PublicInstanceField
+    ReturnsNullInsteadOfEmptyArray
+    ReturnsNullInsteadOfEmptyCollection
+    SimpleDateFormatMissingLocale
+    StatelessSingleton
+    ToStringReturnsNull
+
+    // rulesets/dry.xml
+    DuplicateListLiteral
+    DuplicateMapLiteral
+    DuplicateNumberLiteral
+    DuplicateStringLiteral
+
+    // rulesets/enhanced.xml
+    CloneWithoutCloneable
+    MissingOverrideAnnotation
+    UnsafeImplementationAsMap
+
+    // rulesets/exceptions.xml
+    CatchArrayIndexOutOfBoundsException
+    CatchError
+    CatchException
+    CatchIllegalMonitorStateException
+    CatchIndexOutOfBoundsException
+    CatchNullPointerException
+    CatchRuntimeException
+    CatchThrowable
+    ConfusingClassNamedException
+    ExceptionExtendsError
+    ExceptionExtendsThrowable
+    ExceptionNotThrown
+    MissingNewInThrowStatement
+    ReturnNullFromCatchBlock
+    SwallowThreadDeath
+    ThrowError
+    ThrowException
+    ThrowNullPointerException
+    ThrowRuntimeException
+    ThrowThrowable
+
+    // rulesets/formatting.xml
+    BlankLineBeforePackage
+    BlockEndsWithBlankLine
+    BlockStartsWithBlankLine
+    BracesForClass
+    BracesForForLoop
+    BracesForIfElse
+    BracesForMethod
+    BracesForTryCatchFinally
+    ClosureStatementOnOpeningLineOfMultipleLineClosure
+    ConsecutiveBlankLines
+    FileEndsWithoutNewline
+    Indentation
+    LineLength
+    MissingBlankLineAfterImports
+    MissingBlankLineAfterPackage
+    SpaceAfterCatch
+    SpaceAfterClosingBrace
+    SpaceAfterComma
+    SpaceAfterFor
+    SpaceAfterIf
+    SpaceAfterOpeningBrace
+    SpaceAfterSemicolon
+    SpaceAfterSwitch
+    SpaceAfterWhile
+    SpaceAroundClosureArrow
+    SpaceAroundMapEntryColon
+    SpaceAroundOperator
+    SpaceBeforeClosingBrace
+    SpaceBeforeOpeningBrace
+    TrailingWhitespace
+
+    // rulesets/generic.xml
+    IllegalClassMember
+    IllegalClassReference
+    IllegalPackageReference
+    IllegalRegex
+    IllegalString
+    IllegalSubclass
+    RequiredRegex
+    RequiredString
+    StatelessClass
+
+    // rulesets/grails.xml
+    GrailsDomainHasEquals
+    GrailsDomainHasToString
+    GrailsDomainReservedSqlKeywordName
+    GrailsDomainWithServiceReference
+    GrailsDuplicateConstraint
+    GrailsDuplicateMapping
+    GrailsMassAssignment
+    GrailsPublicControllerMethod
+    GrailsServletContextReference
+    GrailsStatelessService
+
+    // rulesets/groovyism.xml
+    AssignCollectionSort
+    AssignCollectionUnique
+    ClosureAsLastMethodParameter
+    CollectAllIsDeprecated
+    ConfusingMultipleReturns
+    ExplicitArrayListInstantiation
+    ExplicitCallToAndMethod
+    ExplicitCallToCompareToMethod
+    ExplicitCallToDivMethod
+    ExplicitCallToEqualsMethod
+    ExplicitCallToGetAtMethod
+    ExplicitCallToLeftShiftMethod
+    ExplicitCallToMinusMethod
+    ExplicitCallToModMethod
+    ExplicitCallToMultiplyMethod
+    ExplicitCallToOrMethod
+    ExplicitCallToPlusMethod
+    ExplicitCallToPowerMethod
+    ExplicitCallToRightShiftMethod
+    ExplicitCallToXorMethod
+    ExplicitHashMapInstantiation
+    ExplicitHashSetInstantiation
+    ExplicitLinkedHashMapInstantiation
+    ExplicitLinkedListInstantiation
+    ExplicitStackInstantiation
+    ExplicitTreeSetInstantiation
+    GStringAsMapKey
+    GStringExpressionWithinString
+    GetterMethodCouldBeProperty
+    GroovyLangImmutable
+    UseCollectMany
+    UseCollectNested
+
+    // rulesets/imports.xml
+    DuplicateImport
+    ImportFromSamePackage
+    ImportFromSunPackages
+    MisorderedStaticImports
+    NoWildcardImports
+    UnnecessaryGroovyImport
+    UnusedImport
+
+    // rulesets/jdbc.xml
+    DirectConnectionManagement
+    JdbcConnectionReference
+    JdbcResultSetReference
+    JdbcStatementReference
+
+    // rulesets/logging.xml
+    LoggerForDifferentClass
+    LoggerWithWrongModifiers
+    LoggingSwallowsStacktrace
+    MultipleLoggers
+    PrintStackTrace
+    Println
+    SystemErrPrint
+    SystemOutPrint
+
+    // rulesets/naming.xml
+    AbstractClassName
+    ClassName
+    ClassNameSameAsFilename
+    ClassNameSameAsSuperclass
+    ConfusingMethodName
+    FactoryMethodName
+    FieldName
+    InterfaceName
+    InterfaceNameSameAsSuperInterface
+    ObjectOverrideMisspelledMethodName
+    PackageName
+    PackageNameMatchesFilePath
+    ParameterName
+    PropertyName
+    VariableName
+
+    // rulesets/security.xml
+    FileCreateTempFile
+    InsecureRandom
+    JavaIoPackageAccess
+    NonFinalPublicField
+    NonFinalSubclassOfSensitiveInterface
+    ObjectFinalize
+    PublicFinalizeMethod
+    SystemExit
+    UnsafeArrayDeclaration
+
+    // rulesets/serialization.xml
+    EnumCustomSerializationIgnored
+    SerialPersistentFields
+    SerialVersionUID
+    SerializableClassMustDefineSerialVersionUID
+
+    // rulesets/size.xml
+    AbcMetric   // Requires the GMetrics jar
+    ClassSize
+    CrapMetric   // Requires the GMetrics jar and a Cobertura coverage file
+    CyclomaticComplexity   // Requires the GMetrics jar
+    MethodCount
+    MethodSize
+    NestedBlockDepth
+    ParameterCount
+
+    // rulesets/unnecessary.xml
+    AddEmptyString
+    ConsecutiveLiteralAppends
+    ConsecutiveStringConcatenation
+    UnnecessaryBigDecimalInstantiation
+    UnnecessaryBigIntegerInstantiation
+    UnnecessaryBooleanExpression
+    UnnecessaryBooleanInstantiation
+    UnnecessaryCallForLastElement
+    UnnecessaryCallToSubstring
+    UnnecessaryCast
+    UnnecessaryCatchBlock
+    UnnecessaryCollectCall
+    UnnecessaryCollectionCall
+    UnnecessaryConstructor
+    UnnecessaryDefInFieldDeclaration
+    UnnecessaryDefInMethodDeclaration
+    UnnecessaryDefInVariableDeclaration
+    UnnecessaryDotClass
+    UnnecessaryDoubleInstantiation
+    UnnecessaryElseStatement
+    UnnecessaryFinalOnPrivateMethod
+    UnnecessaryFloatInstantiation
+    UnnecessaryGString
+    UnnecessaryGetter
+    UnnecessaryIfStatement
+    UnnecessaryInstanceOfCheck
+    UnnecessaryInstantiationToGetClass
+    UnnecessaryIntegerInstantiation
+    UnnecessaryLongInstantiation
+    UnnecessaryModOne
+    UnnecessaryNullCheck
+    UnnecessaryNullCheckBeforeInstanceOf
+    UnnecessaryObjectReferences
+    UnnecessaryOverridingMethod
+    UnnecessaryPackageReference
+    UnnecessaryParenthesesForMethodCallWithClosure
+    UnnecessaryPublicModifier
+    UnnecessaryReturnKeyword
+    UnnecessarySafeNavigationOperator
+    UnnecessarySelfAssignment
+    UnnecessarySemicolon
+    UnnecessarySetter
+    UnnecessaryStringInstantiation
+    UnnecessarySubstring
+    UnnecessaryTernaryExpression
+    UnnecessaryToString
+    UnnecessaryTransientModifier
+
+    // rulesets/unused.xml
+    UnusedArray
+    UnusedMethodParameter
+    UnusedObject
+    UnusedPrivateField
+    UnusedPrivateMethod
+    UnusedPrivateMethodParameter
+    UnusedVariable
+
+
+}


### PR DESCRIPTION
Add [codenarc](http://codenarc.sourceforge.net/) to allow us to enforce a consistent style in our groovy code (in particular, in our Spock tests).

The current list of checks is a slightly cut down version of their [example list](http://codenarc.sourceforge.net/StarterRuleSet-AllRulesByCategory.groovy.txt).

You can run the linter by

    ./gradlew codenarcTest

See also the [gradle plugin documentation](https://docs.gradle.org/current/userguide/codenarc_plugin.html).

The list of rules needs to be cut down for our project! This PR is not ready to merge yet. Some of the warnings it raises are legitimate, and we should fix them; others are a configuration error, or at least a difference of opinion.

Once this PR is merged, we should add the job to our CI; look at the [existing Checkstyle job definition](https://ci.psm.solutionguidance.com/job/checkstyle/) for a template. We'll probably also want to figure out how to present the reports in a useful fashion; there isn't obviously a way to make it generate Checkstyle XML reports. Adding the line `reportFormat = 'console'` in the `codeNarc {` block might be a reasonable compromise.

As this work is incomplete, I encourage you, dear reviewer, to either complete it or close the PR; I'm afraid I won't be able to dedicate the time to do either.

Issue #456 Use consistent code style