### PR TITLE
Implement screenings page functionality rework

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
@@ -36,7 +36,9 @@ import javax.ejb.TransactionManagementType;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -180,9 +182,18 @@ public class ScreeningServiceBean extends BaseService implements ScreeningServic
             ScreeningSearchCriteria criteria
     ) {
         if (criteria.getStartDate() != null && criteria.getEndDate() != null) {
-            clauseList.add("created_at BETWEEN :startDate AND :endDate");
+            clauseList.add("created_at >= :startDate AND created_at < :endDate");
             bindParams.put("startDate", criteria.getStartDate());
-            bindParams.put("endDate", criteria.getEndDate());
+            bindParams.put("endDate",
+                    Date.from(
+                            criteria.getEndDate()
+                                    .toInstant()
+                                    .atZone(ZoneId.systemDefault())
+                                    .toLocalDate()
+                                    .plusDays(1)
+                                    .atStartOfDay(ZoneId.systemDefault()).toInstant()
+                    )
+            );
         }
     }
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_tab_section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_tab_section.jsp
@@ -3,39 +3,47 @@
   <div class="tabR">
     <div class="tabM">
       <a
-        class="tab allTab
-          <c:if test="${active_screenings_tab=='all'}">active</c:if>"
+        class="tab screeningsAllTab
+          <c:if test="${activeTab=='all'}">active</c:if>"
         href="#"
       >
         <span class="aR">
-          <span class="aM">All</span>
+          <span class="aM">
+            All
+          </span>
         </span>
       </a>
       <a
-        class="tab failedTab
-          <c:if test="${active_screenings_tab=='failed'}">active</c:if>"
+        class="tab screeningsFailedTab
+          <c:if test="${activeTab=='fail'}">active</c:if>"
         href="#"
       >
         <span class="aR">
-          <span class="aM">Failed</span>
+          <span class="aM">
+            Failed
+          </span>
         </span>
       </a>
       <a
-        class="tab passedTab
-          <c:if test="${active_screenings_tab=='passed'}">active</c:if>"
+        class="tab screeningsPassedTab
+          <c:if test="${activeTab=='pass'}">active</c:if>"
         href="#"
       >
         <span class="aR">
-          <span class="aM">Passed</span>
+          <span class="aM">
+            Passed
+          </span>
         </span>
       </a>
       <a
-        class="tab errorsTab
-          <c:if test="${active_screenings_tab=='errors'}">active</c:if>"
-        href="#"
+        class="tab screeningsErrorsTab
+          <c:if test="${activeTab=='error'}">active</c:if>"
+        href="#" 
       >
         <span class="aR">
-          <span class="aM">Errors</span>
+          <span class="aM">
+            Errors
+          </span>
         </span>
       </a>
     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
@@ -46,7 +46,12 @@
       varStatus="status"
     >
       <tr class="${status.index % 2 == 0 ? 'odd' : 'even'}">
-        <td>${screening.date}</td>
+        <td>
+          <fmt:formatDate
+            value="${screening.date}"
+            pattern="MM/dd/yyyy"
+          />
+        </td>
         <td>${screening.npi}</td>
         <td>${screening.providerName}</td>
         <td>${screening.providerType}</td>
@@ -56,15 +61,21 @@
         <td class="alignCenter">
           <a
             class="actionLink"
-            href="#"
+            href="${ctx}/provider/enrollment/view?id=${screening.enrollmentId}"
           >
-            Auto Screen
+            View
           </a>
           <a
             class="actionLink"
-            href="#"
+            href="${ctx}/agent/automatic-screening/${screening.screeningId}"
           >
-            Manual Screen
+            Run Again
+          </a>
+          <a
+            class="actionLink"
+            href="${ctx}/agent/enrollment/screeningReview?id=${screening.enrollmentId}"
+          >
+            Review
           </a>
         </td>
       </tr>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
@@ -75,7 +75,11 @@
           </a>
           <a
             class="actionLink"
-            href="${ctx}/agent/automatic-screening/${screening.screeningId}"
+            href="javascript:alert('Manually re-running a screening is not currently supported.');"
+            <%--
+              The href for this link:
+              href="${ctx}/agent/automatic-screening/${screening.screeningId}"
+            --%>
           >
             Run Again
           </a>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
@@ -17,12 +17,20 @@
         Provider
         <span class="sep"></span>
       </th>
-      <th>
-        Provider Type
+      <%--
+        Just using 'style' below for now since this will be reworked when we add
+        sortable columns to this table, and these spans will probably go away.
+      --%>
+      <th class="twoline">
+        <span style="display: inline-block;">
+          Provider<br>Type
+        </span>
         <span class="sep"></span>
       </th>
-      <th>
-        Screening Type
+      <th class="twoline">
+        <span style="display: inline-block;">
+          Screening<br>Type
+        </span>
         <span class="sep"></span>
       </th>
       <th>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
@@ -3,6 +3,8 @@
 <html lang="en-US">
   <c:set var="title" value="Screenings"/>
   <c:set var="activeTabScreenings" value="true" />
+  <fmt:formatDate value="${startDate}" pattern="MM/dd/yyyy" var="searchStartDate" />
+  <fmt:formatDate value="${endDate}" pattern="MM/dd/yyyy" var="searchEndDate" />
   <h:handlebars template="includes/html_head" context="${pageContext}" />
   <body>
     <div id="wrapper">
@@ -23,12 +25,17 @@
           <div class="clearFixed"></div>
 
             <div class="detailPanel screeningsDateRange">
-              <form
+              <form:form
                 id="screening_form"
                 action="${ctx}/agent/screenings"
-                class="paginationForm"
+                cssClass="paginationForm"
+                modelAttribute="criteria"
                 method="get"
               >
+
+                <form:hidden path="pageSize" />
+                <form:hidden path="pageNumber" />
+
                 <input
                   type="hidden"
                   id="status"
@@ -45,7 +52,7 @@
                       placeholder="Start Date"
                       class="date"
                       type="text"
-                      value="${startDate}"
+                      value="${searchStartDate}"
                     />
                   </span>
                   <span class="floatL">-</span>
@@ -58,7 +65,7 @@
                       placeholder="End Date"
                       class="date"
                       type="text"
-                      value="${endDate}"
+                      value="${searchEndDate}"
                     />
                   </span>
                   <input
@@ -67,7 +74,7 @@
                     class="purpleBtn screeningsTabDatesBtn"
                   />
                 </div>
-              </form>
+              </form:form>
             </div>
 
           <div class="tabSection" id="enrollmentSection">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
@@ -24,10 +24,17 @@
 
             <div class="detailPanel screeningsDateRange">
               <form
+                id="screening_form"
                 action="${ctx}/agent/screenings"
                 class="paginationForm"
-                :method "get"
+                method="get"
               >
+                <input
+                  type="hidden"
+                  id="status"
+                  name="status"
+                  value="${activeTab}"
+                />
                 <div class="row rowDateRange">
                   <span class="dateWrapper floatL">
                     <input
@@ -38,7 +45,7 @@
                       placeholder="Start Date"
                       class="date"
                       type="text"
-                      value=""
+                      value="${startDate}"
                     />
                   </span>
                   <span class="floatL">-</span>
@@ -51,7 +58,7 @@
                       placeholder="End Date"
                       class="date"
                       type="text"
-                      value=""
+                      value="${endDate}"
                     />
                   </span>
                   <input

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AutomaticScreeningController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AutomaticScreeningController.java
@@ -1,28 +1,43 @@
 package gov.medicaid.controllers.admin;
 
+import gov.medicaid.controllers.BaseController;
 import gov.medicaid.controllers.dto.ScreeningDTO;
 import gov.medicaid.entities.AutomaticScreening;
 import gov.medicaid.entities.DmfAutomaticScreening;
+import gov.medicaid.entities.Enrollment;
 import gov.medicaid.entities.LeieAutomaticScreening;
+import gov.medicaid.entities.ProviderProfile;
 import gov.medicaid.entities.dto.ViewStatics;
 import gov.medicaid.services.PortalServiceRuntimeException;
+import gov.medicaid.services.ProviderEnrollmentService;
 import gov.medicaid.services.ScreeningService;
-
+import org.apache.commons.collections.MapUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
-
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Controller
 @RequestMapping("/agent/")
-public class AutomaticScreeningController {
+public class AutomaticScreeningController extends BaseController {
     private final ScreeningService screeningService;
+    private final ProviderEnrollmentService providerEnrollmentService;
+    private static final String DATE_PATTERN = "MM/dd/yyyy";
 
-    public AutomaticScreeningController(ScreeningService screeningService) {
+    public AutomaticScreeningController(
+            ScreeningService screeningService,
+            ProviderEnrollmentService providerEnrollmentService
+    ) {
         this.screeningService = screeningService;
+        this.providerEnrollmentService = providerEnrollmentService;
     }
 
     @RequestMapping("/automatic-screening/{automaticScreeningId}")
@@ -89,31 +104,56 @@ public class AutomaticScreeningController {
     }
 
     private ScreeningDTO getScreeningDetails(AutomaticScreening screening) {
-        // TODO: Accessing provider details is WIP.
-        // Entity entity = screening.getEnrollment().getDetails().getEntity();
-        // entity.getNpi();
-        // entity.getName();
-        // entity.getProviderType().getDescription();
+        Enrollment enrollment = screening.getEnrollment();
+        ProviderProfile profile = providerEnrollmentService
+                .getProviderDetailsByTicket(enrollment.getTicketId(), true);
 
         ScreeningDTO dto = new ScreeningDTO();
-        dto.date = screening.getCreatedAt();
-        dto.npi = "...";
-        dto.providerName = "...";
-        dto.providerType = "...";
-        dto.reason = "New Enrollment";
-
+        dto.date = Date.from(screening.getCreatedAt()
+                .atZone(ZoneId.systemDefault())
+                .toInstant());
+        dto.npi = profile.getEntity().getNpi();
+        dto.screeningId = screening.getAutomaticScreeningId();
+        dto.providerName = profile.getEntity().getName();
+        dto.providerType = profile.getEntity()
+                .getProviderType()
+                .getDescription();
+        dto.reason = enrollment.getStatusNote();
         dto.screeningType = screening.getType();
         dto.result = screening.getResult();
+        dto.enrollmentId = enrollment.getTicketId();
         return dto;
     }
 
     @RequestMapping(value = "/screenings", method = RequestMethod.GET)
-    public ModelAndView view() {
+    public ModelAndView view(
+            @RequestParam Map<String, String> params
+    ) {
         ModelAndView mv = new ModelAndView("admin/screenings");
-
+        mv.addObject("activeTab", MapUtils.getObject(params, "status", "all"));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_PATTERN);
+        if (!params.containsKey("endDate")) {
+            params.put(
+                    "endDate",
+                    LocalDateTime.now()
+                            .toLocalDate()
+                            .format(formatter)
+            );
+        }
+        if (!params.containsKey("startDate")) {
+            params.put(
+                    "startDate",
+                    LocalDateTime.now()
+                            .minusMonths(1)
+                            .toLocalDate()
+                            .format(formatter)
+            );
+        }
+        mv.addObject("startDate", params.get("startDate"));
+        mv.addObject("endDate", params.get("endDate"));
         mv.addObject(
                 "screenings",
-                screeningService.getAllScreenings()
+                screeningService.getScreenings(params)
                         .stream()
                         .map(this::getScreeningDetails)
                         .collect(Collectors.toList())

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -201,7 +201,7 @@ public class EnrollmentController extends BaseController {
             @RequestParam("id") long id
     ) throws PortalServiceException {
         CMSUser user = ControllerHelper.getCurrentUser();
-        enrollmentService.rejectTicket(user, id, "Manual Reject by the agent");
+        enrollmentService.rejectTicket(user, id, "Manual Rejection");
         ModelAndView mv = new ModelAndView("redirect:/provider/enrollments/rejected?statuses=Rejected&showFilterPanel=true");
         return mv;
     }

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ScreeningDTO.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ScreeningDTO.java
@@ -1,19 +1,20 @@
 package gov.medicaid.controllers.dto;
 
 import gov.medicaid.entities.AutomaticScreening;
-
-import java.time.LocalDateTime;
+import java.util.Date;
 
 public class ScreeningDTO {
-    public LocalDateTime date;
+    public Date date;
     public String npi;
     public String providerName;
     public String providerType;
     public String screeningType;
     public String reason;
     public AutomaticScreening.Result result;
+    public long enrollmentId;
+    public long screeningId;
 
-    public LocalDateTime getDate() {
+    public Date getDate() {
         return date;
     }
 
@@ -40,4 +41,13 @@ public class ScreeningDTO {
     public AutomaticScreening.Result getResult() {
         return result;
     }
+
+    public long getEnrollmentId() {
+        return enrollmentId;
+    }
+
+    public long getScreeningId() {
+        return screeningId;
+    }
+
 }

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/AutomaticScreeningControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/AutomaticScreeningControllerTest.groovy
@@ -6,6 +6,7 @@ import gov.medicaid.entities.EnrollmentStatus
 import gov.medicaid.entities.LeieAutomaticScreening
 import gov.medicaid.entities.dto.ViewStatics
 import gov.medicaid.services.PortalServiceRuntimeException
+import gov.medicaid.services.ProviderEnrollmentService
 import gov.medicaid.services.ScreeningService
 import spock.lang.Specification
 
@@ -17,16 +18,21 @@ class AutomaticScreeningControllerTest extends Specification {
     private static final long ENROLLMENT_ID = 1
 
     AutomaticScreeningController controller
-    ScreeningService service
+    ScreeningService screeningService
+    ProviderEnrollmentService providerEnrollmentService
 
     def setup() {
-        service = Mock(ScreeningService)
-        controller = new AutomaticScreeningController(service)
+        screeningService = Mock(ScreeningService)
+        providerEnrollmentService = Mock(ProviderEnrollmentService)
+        controller = new AutomaticScreeningController(
+                screeningService,
+                providerEnrollmentService
+        )
     }
 
     def 'An invalid screening ID throws'() {
         given:
-        service.findScreening(_) >> Optional.empty()
+        screeningService.findScreening(_) >> Optional.empty()
 
         when:
         controller.viewScreening(1)
@@ -37,7 +43,7 @@ class AutomaticScreeningControllerTest extends Specification {
 
     def 'A non-LEIE screening throws'() {
         given:
-        service.findScreening(_) >> Optional.of(new AutomaticScreening() {
+        screeningService.findScreening(_) >> Optional.of(new AutomaticScreening() {
             String getType() { return "" }
         })
 
@@ -113,6 +119,6 @@ class AutomaticScreeningControllerTest extends Specification {
         screening.npiSearchTerm = NPI
         screening.result = AutomaticScreening.Result.PASS
 
-        service.findScreening(_) >> Optional.of(screening)
+        screeningService.findScreening(_) >> Optional.of(screening)
     }
 }

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -242,6 +242,8 @@ $(document).ready(function () {
   // Screenings page
   function submitScreeningsForm(status) {
     $('#status').val(status);
+    $('#screening_form input[name=pageSize]').val(0);
+    $('#screening_form input[name=pageNumber]').val(0);
     $('#screening_form').submit();
   }
 

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -239,6 +239,17 @@ $(document).ready(function () {
     }
   });
 
+  // Screenings page
+  function submitScreeningsForm(status) {
+    $('#status').val(status);
+    $('#screening_form').submit();
+  }
+
+  $('.screeningsAllTab').click(submitScreeningsForm.bind(undefined, 'all'));
+  $('.screeningsPassedTab').click(submitScreeningsForm.bind(undefined, 'pass'));
+  $('.screeningsFailedTab').click(submitScreeningsForm.bind(undefined, 'fail'));
+  $('.screeningsErrorsTab').click(submitScreeningsForm.bind(undefined, 'error'));
+
   $("#providerTypeForm").validate({
         rules: {
           name: {

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSearchCriteria.java
@@ -1,0 +1,33 @@
+package gov.medicaid.entities;
+
+import java.util.Date;
+
+public class ScreeningSearchCriteria extends SearchCriteria {
+    private String status;
+    private Date startDate;
+    private Date endDate;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(Date startDate) {
+        this.startDate = startDate;
+    }
+
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(Date endDate) {
+        this.endDate = endDate;
+    }
+}

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -18,9 +18,11 @@ package gov.medicaid.services;
 
 import gov.medicaid.entities.AutomaticScreening;
 import gov.medicaid.entities.ScreeningSchedule;
+import gov.medicaid.entities.ScreeningSearchCriteria;
+import gov.medicaid.entities.SearchResult;
+
 import javax.jws.WebService;
-import java.util.List;
-import java.util.Map;
+
 import java.util.Optional;
 
 /**
@@ -58,12 +60,12 @@ public interface ScreeningService {
     Optional<AutomaticScreening> findScreening(long screeningId);
 
     /**
-     * @param params - Key-value pair of parameters for sql query
+     * @param criteria - screening search criteria
      * @return list of matched screenings or empty list
      * @throws PortalServiceRuntimeException
      */
-    List<AutomaticScreening> getScreenings(
-            Map<String, String> params
+    SearchResult<AutomaticScreening> getScreenings(
+            ScreeningSearchCriteria criteria
     ) throws PortalServiceRuntimeException;
 
     void saveScreening(AutomaticScreening screening);

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -18,10 +18,9 @@ package gov.medicaid.services;
 
 import gov.medicaid.entities.AutomaticScreening;
 import gov.medicaid.entities.ScreeningSchedule;
-
 import javax.jws.WebService;
-
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -56,11 +55,16 @@ public interface ScreeningService {
             ScreeningSchedule screeningSchedule
     ) throws PortalServiceException;
 
-    Optional<AutomaticScreening> findScreening(
-            long screeningId
-    );
+    Optional<AutomaticScreening> findScreening(long screeningId);
 
-    List<AutomaticScreening> getAllScreenings();
+    /**
+     * @param params - Key-value pair of parameters for sql query
+     * @return list of matched screenings or empty list
+     * @throws PortalServiceRuntimeException
+     */
+    List<AutomaticScreening> getScreenings(
+            Map<String, String> params
+    ) throws PortalServiceRuntimeException;
 
     void saveScreening(AutomaticScreening screening);
 }


### PR DESCRIPTION
This is further work on @HemKal 's PR #1077, addressing the points from my review there, namely:
- fix compilation failure
- use hidden input for screening status
- fix errors tab
- fix styling of table header
- remove vertical '|' separators from action column
- code formatting

I rebased most of these changes into the initial commit.  I also added a JS alert for the WIP 'auto screen' link rather than let users hit system errors, and reworded the 'reason' shown for manual rejections.  All of this is just polish on the original work, which was described as:

Following Items are functional in this commit
-Date Range and Status Filter
-Data fetched from DB
-Tabs Functional
-Format dates in the table
-View Application Link is added
-Screening links are hooked to proper controllers (Auto screen is WIP)
-Limit initial fetch to last 30 days of screenings

Tested by logging in as a service admin and clicking around the screenings page to see that everything works as expected.  Pagination widgets remain to be wired up in a follow-up effort.

Before:

![screenshot_2018-09-04 screenings 1](https://user-images.githubusercontent.com/1091693/45104152-6d32e080-b0ff-11e8-81d8-5e12384a8a13.png)

With PR #1077:

![screenshot_2018-09-04 screenings](https://user-images.githubusercontent.com/1091693/45104227-994e6180-b0ff-11e8-83f6-d0544fdded60.png)


After:

![screenshot_2018-09-04 screenings 2](https://user-images.githubusercontent.com/1091693/45104162-72902b00-b0ff-11e8-9b8b-12018588f4f5.png)

Issue #933 Improve the admin Screenings page