### PR TITLE
Improve advanced search panel layout

### DIFF
--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -2452,16 +2452,16 @@ input.date{
   padding:15px 10px;
 }
 
-#advancedSearch .leftCol{
-  width:45%;
-  float:left;
-  display:inline;
+#advancedSearch .leftCol {
+  width: 45%;
+  float: left;
+  display: inline;
 }
 
-#advancedSearch .rightCol{
-  width:50%;
-  float:left;
-  display:inline;
+#advancedSearch .rightCol {
+  width: 50%;
+  float: left;
+  display: inline;
 }
 
 #advancedSearch .buttons{
@@ -2488,8 +2488,8 @@ input.date{
   line-height:30px;
 }
 
-#advancedSearch label{
-  width:102px;
+#advancedSearch label {
+  width: 102px;
 }
 
 #advancedSearch input[type=text]{
@@ -2532,18 +2532,18 @@ input.date{
 }
 
 
-#advancedSearch .checkRow .checkWrapper{
-  width:360px;
-  float:left;
-  display:inline;
+#advancedSearch .checkRow .checkWrapper {
+  width: 360px;
+  float: left;
+  display: inline;
 }
 
 
-#advancedSearch .checkRow span.label{
-  width:94px;
-  float:left;
-  display:inline;
-  cursor:pointer;
+#advancedSearch .checkRow span.label {
+  width: 94px;
+  float: left;
+  display: inline;
+  cursor: pointer;
 }
 span.label, span.label strong {
   font-weight: normal !important;

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -2453,13 +2453,13 @@ input.date{
 }
 
 #advancedSearch .leftCol {
-  width: 45%;
+  width: 40%;
   float: left;
   display: inline;
 }
 
 #advancedSearch .rightCol {
-  width: 50%;
+  width: 58%;
   float: left;
   display: inline;
 }
@@ -2489,7 +2489,7 @@ input.date{
 }
 
 #advancedSearch label {
-  width: 102px;
+  width: 90px;
 }
 
 #advancedSearch input[type=text]{
@@ -2531,16 +2531,13 @@ input.date{
   padding:0;
 }
 
-
 #advancedSearch .checkRow .checkWrapper {
-  width: 360px;
   float: left;
   display: inline;
+  margin-bottom: 5px;
 }
 
-
 #advancedSearch .checkRow span.label {
-  width: 94px;
   float: left;
   display: inline;
   cursor: pointer;


### PR DESCRIPTION
These are the CSS layout changes split off from PR #1069 which now just removes the colons.

The same advanced search panel appears for both provider and service admin logins.

Before this and #1069 (yikes...):

![screenshot_2018-08-29 advanced search 1](https://user-images.githubusercontent.com/1091693/44819277-46822080-abba-11e8-8052-8c9971a5eb34.png)

After:

![screenshot_2018-08-29 advanced search 2](https://user-images.githubusercontent.com/1091693/44819289-513cb580-abba-11e8-9ef5-a2c203bc799c.png)

The CSS changes also slightly affect (in a slightly positive way, IMHO) the system admin advance search panel.  Before this and #1069:

![screenshot_2018-08-29 advanced search system admin](https://user-images.githubusercontent.com/1091693/44819343-82b58100-abba-11e8-94c8-205efade7b3d.png)

After:

![screenshot_2018-08-29 advanced search system admin 2](https://user-images.githubusercontent.com/1091693/44819346-8812cb80-abba-11e8-8a21-35e68631cb03.png)

Tested by logging in and looking at the advanced search pages for the three logins.

Issue #376: Remove right-justified colons...