### PR TITLE
Fix table header style glitch due to 'state/territory'

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
@@ -70,7 +70,7 @@
                     <th class="alignCenter"><span class="multi">License/Certification<br/> Number</span> <span class="required-dark-background">*</span><span class="sep"></span></th>
                     <th class="alignCenter"><span class="multi">Original Issue Date<br/> (MM/DD/YYYY)</span> <span class="required-dark-background">*</span><span class="sep"></span></th>
                     <th class="alignCenter"><span class="multi">Renewal End Date<br/> (MM/DD/YYYY)</span> <span class="required-dark-background">*</span><span class="sep"></span></th>
-                    <th class="alignCenter">Issuing State/Territory <span class="required-dark-background">*</span><span class="sep"></span></th>
+                    <th class="alignCenter"><span class="multi">Issuing State<br/>/Territory</span> <span class="required-dark-background">*</span><span class="sep"></span></th>
                     <th class="alignCenter"><span class="multi">Copy of License<br/>/Certification</span> <span class="sep"></span></th>
                     <th></th>
                 </tr>


### PR DESCRIPTION
The wider 'state/territory' wording needed to be split up so the `<th>` wasn't too wide, messing up the styling of the row.  (I ran into this while reviewing PR #1074.)  I checked for other cases of this and this seems to be the only header row that uses this kind of styling that has 'state/territory'.

Before:

![screenshot_2018-09-07 facility credentials 9](https://user-images.githubusercontent.com/1091693/45248507-927e4500-b2df-11e8-956b-7be650189d54.png)

After:

![screenshot_2018-09-07 facility credentials 10](https://user-images.githubusercontent.com/1091693/45248508-94e09f00-b2df-11e8-97f7-b52aedae81e9.png)

Issue #62 Include territories in list of states?