### PR TITLE
Remove colons from PCPO pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -43,38 +43,26 @@
                     <div class="col1">
                       <div class="row">
                         <label>Request Type</label>
-                        <span class="floatL">
-                          <b>:</b>
-                        </span>
                         <span>${requestScope['_99_requestType']}</span>
                       </div>
                       <div class="row">
                         <label>Status</label>
-                        <span class="floatL">
-                          <b>:</b>
-                        </span>
                         <span>${requestScope['_99_requestStatus'] eq 'Rejected' ? 'Denied' : requestScope['_99_requestStatus']}</span>
                       </div>
                     </div>
                     <div class="col2">
                       <div class="row">
                         <label>Submitted On</label>
-                        <span class="floatL">
-                          <b>:</b>
-                        </span>
                         <span>${requestScope['_99_submittedOn']}</span>
                       </div>
                       <div class="row">
                         <label>Status Date</label>
-                        <span class="floatL">
-                          <b>:</b>
-                        </span>
                         <span>${requestScope['_99_statusDate']}</span>
                       </div>
                     </div>
                     <div class="col3">
                       <div class="row">
-                        <label>Risk Level &nbsp;&nbsp;&nbsp;&nbsp;:</label>
+                        <label>Risk Level</label>
                         <span>${requestScope['_99_riskLevel']}</span>
                       </div>
                     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pca_billing.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pca_billing.jsp
@@ -13,21 +13,18 @@
                 <c:set var="formName" value="_24_billingContactName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">NAME OF RESPONSIBLE BILLING PERSON <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_24_billingContactTitle"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">TITLE <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row">
                 <c:set var="formName" value="_24_billingContactHireDate"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">DATE OF EMPLOYMENT</label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -36,14 +33,12 @@
                 <c:set var="formName" value="_24_billingContactSSN"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">SOCIAL SECURITY NUMBER <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
             <div class="row">
                 <c:set var="formName" value="_24_billingContactDOB"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">DATE OF BIRTH</label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pca_billing.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pca_billing.jsp
@@ -12,19 +12,19 @@
             <div class="row requireField">
                 <c:set var="formName" value="_24_billingContactName"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">NAME OF RESPONSIBLE BILLING PERSON <span class="required">*</span></label>
+                <label for="${formIdPrefix}_${formName}">Name of Responsible Billing Person <span class="required">*</span></label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_24_billingContactTitle"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">TITLE <span class="required">*</span></label>
+                <label for="${formIdPrefix}_${formName}">Title <span class="required">*</span></label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="row">
                 <c:set var="formName" value="_24_billingContactHireDate"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">DATE OF EMPLOYMENT</label>
+                <label for="${formIdPrefix}_${formName}">Date of Employment</label>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -32,13 +32,13 @@
             <div class="row requireField">
                 <c:set var="formName" value="_24_billingContactSSN"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">SOCIAL SECURITY NUMBER <span class="required">*</span></label>
+                <label for="${formIdPrefix}_${formName}">Social Security Number <span class="required">*</span></label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
             <div class="row">
                 <c:set var="formName" value="_24_billingContactDOB"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">DATE OF BIRTH</label>
+                <label for="${formIdPrefix}_${formName}">Date of Birth</label>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
@@ -13,7 +13,6 @@
                 <c:set var="formName" value="_25_liabilityInsuranceId"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of certificate of liability insurance</label>
-                <span class="floatL"><b>:</b></span>
                 <c:if test="${not empty formValue}">
                     <c:url var="downloadLink" value="/provider/enrollment/attachment">
                          <c:param name="id" value="${requestScope[formName]}"></c:param>
@@ -28,7 +27,6 @@
             <div class="row">
                 <c:set var="formName" value="_25_compensationInsuranceId"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of Workers' Compensation insurance</label>
-                <span class="floatL"><b>:</b></span>
                 <c:if test="${not empty  requestScope[formName]}">
                     <c:url var="downloadLink" value="/provider/enrollment/attachment">
                          <c:param name="id" value="${requestScope[formName]}"></c:param>
@@ -43,7 +41,6 @@
             <div class="row requireField">
                 <c:set var="formName" value="_25_fidelityBondId"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of fidelity bond</label>
-                <span class="floatL"><b>:</b></span>
                 <c:if test="${not empty  requestScope[formName]}">
                     <c:url var="downloadLink" value="/provider/enrollment/attachment">
                          <c:param name="id" value="${requestScope[formName]}"></c:param>
@@ -58,7 +55,6 @@
             <div class="row requireField">
                 <c:set var="formName" value="_25_suretyBondId"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of surety bond</label>
-                <span class="floatL"><b>:</b></span>
                 <c:if test="${not empty  requestScope[formName]}">
                     <c:url var="downloadLink" value="/provider/enrollment/attachment">
                          <c:param name="id" value="${requestScope[formName]}"></c:param>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
@@ -17,7 +17,6 @@
                 <c:set var="formName" value="_29_qpType_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">QP Type <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_29_qpTypes']}">
@@ -29,14 +28,12 @@
                 <c:set var="formName" value="_29_name_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Name <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_29_npi_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">NPI</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>
             <div class="row requireField">
@@ -45,7 +42,6 @@
                 <label for="${formIdPrefix}_${formName}">Date of Employment <span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -66,7 +62,6 @@
                 <c:set var="formName" value="_29_qpSubType_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">MHP Type</label>
-                <span class="floatL"><b>:</b></span>
                 <span class="floatL">
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}"/>
                 </span>
@@ -77,7 +72,6 @@
                 <label for="${formIdPrefix}_${formName}">Date of Birth <span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -86,7 +80,6 @@
                 <c:set var="formName" value="_29_ssn_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Social Security Number <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="9"/>
             </div>
             <div class="row requireField">
@@ -100,7 +93,6 @@
                 <c:set var="formName" value="_29_endDate_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">End Date (MM/DD/YYYY)</label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -114,7 +106,6 @@
                 <c:set var="formName" value="_29_addressLine1_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Residence Address</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" title="Residence Address, Line 1" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
@@ -122,21 +113,19 @@
                 <c:set var="formName" value="_29_addressLine2_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input type="text" title="Residence Address, Line 2" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_29_city_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City <span class="required">*</span> : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City <span class="required">*</span></label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="cityInputFor" name="${formName}" value="${formValue}" maxlength="18"/>
 
                 <c:set var="formName" value="_29_state_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State/Territory <span class="required">*</span> : </label>
+                <label for="${formIdPrefix}_${formName}">State/Territory <span class="required">*</span></label>
                 <select id="${formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -146,12 +135,12 @@
 
                 <c:set var="formName" value="_29_zip_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code <span class="required">*</span> : </label>
+                <label for="${formIdPrefix}_${formName}">ZIP Code <span class="required">*</span></label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                 <c:set var="formName" value="_29_county_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">County : </label>
+                <label for="${formIdPrefix}_${formName}">County</label>
                 <select id="${formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -166,7 +155,6 @@
                 <c:set var="formName" value="_29_bgsNumber_${status.index - 1}"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">BGS ID NUMBER <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="clearFixed"></div>
@@ -179,7 +167,6 @@
                 <label for="${formIdPrefix}_${formName}">BGS Clearance Date <span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -362,7 +349,6 @@
                 <c:set var="formName" value="_29_qpType"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">QP Type <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <select id="${formIdPrefix}_${formName}" name="${formName}" class="qpTypeSelect">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_29_qpTypes']}">
@@ -374,14 +360,12 @@
                 <c:set var="formName" value="_29_name"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Name <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="nameInput normalInput" name="${formName}" value="${formValue}" maxlength="100"/>
             </div>
             <div class="row requireField">
                 <c:set var="formName" value="_29_npi"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">NPI</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="npiMasked normalInput" name="${formName}" value="${formValue}" maxlength="10"/>
             </div>
             <div class="row requireField">
@@ -390,7 +374,6 @@
                 <label for="${formIdPrefix}_${formName}">Date of Employment <span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -402,7 +385,6 @@
                 <c:set var="formName" value="_29_qpSubType"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">MHP Type</label>
-                <span class="floatL"><b>:</b></span>
                 <span class="floatL">
                     <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}"/>
                 </span>
@@ -413,7 +395,6 @@
                 <label for="${formIdPrefix}_${formName}">Date of Birth <span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -422,7 +403,6 @@
                 <c:set var="formName" value="_29_ssn"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Social Security Number <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="ssnMasked normalInput" name="${formName}" value="${formValue}" maxlength="11"/>
             </div>
             <div class="row requireField">
@@ -435,7 +415,6 @@
                 <c:set var="formName" value="_29_endDate"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}" class="label">Date Ended (MM/DD/YYYY)</label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>
@@ -449,7 +428,6 @@
                 <c:set var="formName" value="_29_addressLine1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Residence Address</label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" title="Residence Address, Line 1" type="text" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
@@ -457,21 +435,19 @@
                 <c:set var="formName" value="_29_addressLine2"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <input title="Residence Address, Line 2" type="text" class="normalInput addressInputFor" name="${formName}" value="${formValue}" maxlength="28"/>
             </div>
 
             <div class="row inlineBox">
                 <span class="label">&nbsp;</span>
-                <span class="floatL"><b>&nbsp;</b></span>
                 <c:set var="formName" value="_29_city"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="cityLabel">City <span class="required">*</span> : </label>
+                <label for="${formIdPrefix}_${formName}" class="cityLabel">City <span class="required">*</span></label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="cityInputFor" name="${formName}" value="${formValue}" maxlength="20"/>
 
                 <c:set var="formName" value="_29_state"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">State/Territory <span class="required">*</span> : </label>
+                <label for="${formIdPrefix}_${formName}">State/Territory <span class="required">*</span></label>
                 <select id="${formIdPrefix}_${formName}" class="stateSelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_states']}">
@@ -481,12 +457,12 @@
 
                 <c:set var="formName" value="_29_zip"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">ZIP Code <span class="required">*</span> : </label>
+                <label for="${formIdPrefix}_${formName}">ZIP Code <span class="required">*</span></label>
                 <input id="${formIdPrefix}_${formName}" type="text" class="zipInputFor" name="${formName}" value="${formValue}" maxlength="10"/>
 
                 <c:set var="formName" value="_29_county"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}">County : </label>
+                <label for="${formIdPrefix}_${formName}">County</label>
                 <select id="${formIdPrefix}_${formName}" class="countySelectFor" name="${formName}">
                     <option value="">Please select</option>
                     <c:forEach var="opt" items="${requestScope['_99_counties']}">
@@ -501,7 +477,6 @@
                 <c:set var="formName" value="_29_bgsNumber"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">BGS ID NUMBER <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="45"/>
             </div>
             <div class="clearFixed"></div>
@@ -514,7 +489,6 @@
                 <label for="${formIdPrefix}_${formName}">BGS Clearance Date <span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_capacity.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_capacity.jsp
@@ -1,31 +1,16 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<c:if test="${requestScope['_24_bound'] eq 'Y'}">
+<c:if test="${requestScope['_27_bound'] eq 'Y'}">
 <div class="section">
     <div class="leftCol">
         <div class="row">
-            <label>NAME OF RESPONSIBLE BILLING PERSON</label>
+            <label>Number of Beds</label>
             <span class="floatL"><b>:</b></span>
-            <span >${requestScope['_24_billingContactName']}</span>
+            <span >${requestScope['_27_numberOfBeds']}</span>
         </div>
         <div class="row">
-            <label>TITLE</label>
+            <label>Effective Date</label>
             <span class="floatL"><b>:</b></span>
-            <span >${requestScope['_24_billingContactTitle']}</span>
-        </div>
-        <div class="row">
-            <label>DATE OF EMPLOYMENT</label>
-            <span class="floatL"><b>:</b></span>
-            <span >${requestScope['_24_billingContactHireDate']}</span>
-        </div>
-        <div class="row">
-            <label>SOCIAL SECURITY NUMBER</label>
-            <span class="floatL"><b>:</b></span>
-            <span >${requestScope['_24_billingContactSSN']}</span>
-        </div>
-        <div class="row">
-            <label>DATE OF BIRTH</label>
-            <span class="floatL"><b>:</b></span>
-            <span >${requestScope['_24_billingContactDOB']}</span>
+            <span >${requestScope['_27_effectiveDate']}</span>
         </div>
     </div>
     <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/pca_billing.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/pca_billing.jsp
@@ -3,23 +3,23 @@
 <div class="section">
     <div class="leftCol">
         <div class="row">
-            <label>NAME OF RESPONSIBLE BILLING PERSON</label>
+            <label>Name of Responsible Billing Person</label>
             <span >${requestScope['_24_billingContactName']}</span>
         </div>
         <div class="row">
-            <label>TITLE</label>
+            <label>Title</label>
             <span >${requestScope['_24_billingContactTitle']}</span>
         </div>
         <div class="row">
-            <label>DATE OF EMPLOYMENT</label>
+            <label>Date of Employment</label>
             <span >${requestScope['_24_billingContactHireDate']}</span>
         </div>
         <div class="row">
-            <label>SOCIAL SECURITY NUMBER</label>
+            <label>Social Security Number</label>
             <span >${requestScope['_24_billingContactSSN']}</span>
         </div>
         <div class="row">
-            <label>DATE OF BIRTH</label>
+            <label>Date of Birth</label>
             <span >${requestScope['_24_billingContactDOB']}</span>
         </div>
     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/pca_billing.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/pca_billing.jsp
@@ -4,27 +4,22 @@
     <div class="leftCol">
         <div class="row">
             <label>NAME OF RESPONSIBLE BILLING PERSON</label>
-            <span class="floatL"><b>:</b></span>
             <span >${requestScope['_24_billingContactName']}</span>
         </div>
         <div class="row">
             <label>TITLE</label>
-            <span class="floatL"><b>:</b></span>
             <span >${requestScope['_24_billingContactTitle']}</span>
         </div>
         <div class="row">
             <label>DATE OF EMPLOYMENT</label>
-            <span class="floatL"><b>:</b></span>
             <span >${requestScope['_24_billingContactHireDate']}</span>
         </div>
         <div class="row">
             <label>SOCIAL SECURITY NUMBER</label>
-            <span class="floatL"><b>:</b></span>
             <span >${requestScope['_24_billingContactSSN']}</span>
         </div>
         <div class="row">
             <label>DATE OF BIRTH</label>
-            <span class="floatL"><b>:</b></span>
             <span >${requestScope['_24_billingContactDOB']}</span>
         </div>
     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/pca_billing.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/pca_billing.jsp
@@ -1,16 +1,31 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
-<c:if test="${requestScope['_27_bound'] eq 'Y'}">
+<c:if test="${requestScope['_24_bound'] eq 'Y'}">
 <div class="section">
     <div class="leftCol">
         <div class="row">
-            <label>Number of Beds</label>
+            <label>NAME OF RESPONSIBLE BILLING PERSON</label>
             <span class="floatL"><b>:</b></span>
-            <span >${requestScope['_27_numberOfBeds']}</span>
+            <span >${requestScope['_24_billingContactName']}</span>
         </div>
         <div class="row">
-            <label>Effective Date</label>
+            <label>TITLE</label>
             <span class="floatL"><b>:</b></span>
-            <span >${requestScope['_27_effectiveDate']}</span>
+            <span >${requestScope['_24_billingContactTitle']}</span>
+        </div>
+        <div class="row">
+            <label>DATE OF EMPLOYMENT</label>
+            <span class="floatL"><b>:</b></span>
+            <span >${requestScope['_24_billingContactHireDate']}</span>
+        </div>
+        <div class="row">
+            <label>SOCIAL SECURITY NUMBER</label>
+            <span class="floatL"><b>:</b></span>
+            <span >${requestScope['_24_billingContactSSN']}</span>
+        </div>
+        <div class="row">
+            <label>DATE OF BIRTH</label>
+            <span class="floatL"><b>:</b></span>
+            <span >${requestScope['_24_billingContactDOB']}</span>
         </div>
     </div>
     <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/qualified_professional.jsp
@@ -7,25 +7,21 @@
         <div class="leftCol">
             <div class="row">
                 <label>QP Type</label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_qpType_${status.index - 1}"></c:set>
                 <span>${requestScope[formName]}</span>
             </div>
             <div class="row">
                 <label>Name</label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_name_${status.index - 1}"></c:set>
                 <span>${requestScope[formName]}</span>
             </div>
             <div class="row">
                 <label>NPI</label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_npi_${status.index - 1}"></c:set>
                 <span>${requestScope[formName]}</span>
             </div>
             <div class="row">
                 <label>Date of Employment</label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_startDate_${status.index - 1}"></c:set>
                 <span>${requestScope[formName]}</span>
             </div>
@@ -35,25 +31,21 @@
         <div class="rightCol">
             <div class="row">
                 <label>Date of Birth</label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_dob_${status.index - 1}"></c:set>
                 <span>${requestScope[formName]}</span>
             </div>
             <div class="row">
                 <label>Social Security Number</label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_ssn_${status.index - 1}"></c:set>
                 <span>${requestScope[formName]}</span>
             </div>
             <div class="row">
                 <label>The affiliation has ended</label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_ended_${status.index - 1}"></c:set>
                 <span>${requestScope[formName]}</span>
             </div>
             <div class="row">
                 <label>Termination Date</label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_endDate_${status.index - 1}"></c:set>
                 <span>${requestScope[formName]}</span>
             </div>
@@ -63,7 +55,6 @@
         <div class="">
             <div class="row">
                 <label>Home Residence Address</label>
-                <span class="floatL"><b>:</b></span>
 
                 <c:set var="streetAddress" value="_29_addressLine1_${status.index - 1}" />
                 <c:set var="extendedAddress" value="_29_addressLine2_${status.index - 1}" />
@@ -84,7 +75,6 @@
         <div class="leftCol">
             <div class="row requireField">
                 <label>BGS ID NUMBER <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_29_bgsNumber_${status.index - 1}"></c:set>
                 <span>${requestScope[formName]}</span>
             </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/remittance_sequence.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/remittance_sequence.jsp
@@ -4,7 +4,6 @@
     <div class="wholeCol">
         <div class="row">
             <label>Remittance Sequence</label>
-            <span class="floatL"><b>:</b></span>
             <c:choose>
                 <c:when test="${requestScope['_23_remittanceSequenceNumber'] eq 'PATIENT_ACCOUNT_OR_OWN_REFERENCE_ORDER'}">
                     <span>Patient Account or Own Reference Number Order</span>


### PR DESCRIPTION
Also use lowercase letters instead of all-caps in two JSPs, and correct a file name to file content mismatch in two JSPs.

Tested by creating a Personal Care Provider Organizati,on application and checking the pages for colons.  Also by editing said application as an admin to see the 'Edit Enrollment' header JSP.

The "Qualified Professional" summary JSP is not showing anything for some reason.  A separate issue should be filed for that bug.

(These pages were encountered while reviewing PR #1074.)

Before:

![screenshot_2018-09-07 facility credentials 12](https://user-images.githubusercontent.com/1091693/45249336-fce9b200-b2ec-11e8-9c30-ebaf8c66ebfb.png)

After:

![screenshot_2018-09-07 organization information 4](https://user-images.githubusercontent.com/1091693/45249333-fce9b200-b2ec-11e8-839b-457e91a84906.png)

Before:

![screenshot_2018-09-07 qualified professional 3](https://user-images.githubusercontent.com/1091693/45249340-fd824880-b2ec-11e8-91d4-3130e6667b80.png)

After:

![screenshot_2018-09-07 qualified professional 4](https://user-images.githubusercontent.com/1091693/45249334-fce9b200-b2ec-11e8-9985-b4b905313d9b.png)

Before:

![screenshot_2018-09-07 facility credentials 11](https://user-images.githubusercontent.com/1091693/45249341-fd824880-b2ec-11e8-899b-5d51de602613.png)

After:

![screenshot_2018-09-07 facility credentials 13](https://user-images.githubusercontent.com/1091693/45249335-fce9b200-b2ec-11e8-8eee-c624ccc1cc6d.png)

Before:

![screenshot_2018-09-07 organization information 1](https://user-images.githubusercontent.com/1091693/45249342-fd824880-b2ec-11e8-8e6c-52e3ace06ab2.png)

After:

![screenshot_2018-09-07 organization information 3](https://user-images.githubusercontent.com/1091693/45249337-fd824880-b2ec-11e8-9db1-336541a8df12.png)

After: (the PCA Billing section at the bottom ("Name of Responsible...") now displays because the file names are corrected, and the text is not in all caps):

![screenshot_2018-09-07 organization information 2](https://user-images.githubusercontent.com/1091693/45249338-fd824880-b2ec-11e8-8b51-cd0b1fc8b6ab.png)

After: (no colon for 'Remittance Sequence' line):

![screenshot_2018-09-07 summary information 1](https://user-images.githubusercontent.com/1091693/45249344-fd824880-b2ec-11e8-81e6-5c5fcfb9c917.png)

Issue 376: Remove right-justified colons...