### PR TITLE
Improve the Upload File UI on three pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/adult_day_treatment_application.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/adult_day_treatment_application.jsp
@@ -1,5 +1,7 @@
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <input type="hidden" name="formNames" value="<%= ViewStatics.ADULT_DAY_TREATMENT_APPLICATION_FORM %>">
 <c:set var="selectedMarkup" value='selected="selected"' />
 
@@ -10,16 +12,17 @@
     <div class="section">
         <div class="">
             <div class="row requireField">
-                <label for="applicationFileUpload" class="mediumLbl">Please upload a copy of application*</label>
-                <c:set var="formName" value="_35_application"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <c:if test="${not empty formValue}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="applicationFileUpload" type="file" class="fileUpload" name="${formName}" />
+                <label class="mediumLbl">Please upload a copy of application*</label>
+                <span class="floatL">
+                    <c:set var="formName" value="_35_application" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Adult Day Treatment Application"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download"
+                    />
+                </span>
             </div>
         </div>
         <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
@@ -1,5 +1,6 @@
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 
 <c:set var="specialtyTrigger" value="${viewModel.tabModels[viewModel.currentTab].formSettings['Highest Degree Form'].settings['specialtyTrigger']}"></c:set>
 <c:set var="isActivated" value="${true}"></c:set>
@@ -40,26 +41,16 @@
                 </span>
             </div>
             <div class="row">
-                <c:set var="formName" value="_14_copyOfHighestDegree"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="copyOfDegree_${formName}">Copy of Highest Degree Earned</label>
+                <label>Copy of Highest Degree Earned</label>
                 <span class="floatL">
-                    <input
-                      id="copyOfDegree_${formName}"
-                      type="file"
-                      class="fileUpload newEnrollmentPanelButton"
-                      size="10"
-                      name="${formName}"
+                    <c:set var="formName" value="_14_copyOfHighestDegree" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Copy of Highest Degree Earned"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download"
                     />
-
-                    <c:if test="${not empty formValue}">
-                        <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                             <c:param name="id" value="${requestScope[formName]}"></c:param>
-                        </c:url>
-                        <div><a href="${downloadLink}">View</a></div>
-                        <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                        <input type="hidden" name="${formName}" value="${formValue}"/>
-                    </c:if>
                 </span>
             </div>
             <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
@@ -1,5 +1,7 @@
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <c:set var="formIdPrefix" value="pcpo_insurance"></c:set>
 
 <input type="hidden" name="formNames" value="<%= ViewStatics.PCPO_INSURANCE_FORM %>">
@@ -10,58 +12,65 @@
     <div class="section">
         <div class="wholeCol organizationInfo">
             <div class="row requireField">
-                <c:set var="formName" value="_25_liabilityInsuranceId"></c:set>
-                <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of certificate of liability insurance</label>
-                <c:if test="${not empty formValue}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="${formIdPrefix}_${formName}" type="file" class="fileUpload" name="${formName}" />
+                <label class="mediumLbl">Copy of certificate of liability insurance</label>
+                <span class="floatL">
+                    <c:set var="formName" value="_25_liabilityInsuranceId" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Certificate of liability insurance"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download"
+                    />
+                </span>
             </div>
             <div class="row">
             </div>
 
             <div class="row">
-                <c:set var="formName" value="_25_compensationInsuranceId"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of Workers' Compensation insurance</label>
-                <c:if test="${not empty  requestScope[formName]}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="${formIdPrefix}_${formName}" type="file" class="fileUpload" name="${formName}" />
-            </div>
-            <div class="row">
-            </div>
-
-            <div class="row requireField">
-                <c:set var="formName" value="_25_fidelityBondId"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of fidelity bond</label>
-                <c:if test="${not empty  requestScope[formName]}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="${formIdPrefix}_${formName}" type="file" class="fileUpload" name="${formName}" />
+                <label class="mediumLbl">Copy of Workers' Compensation insurance</label>
+                <span class="floatL">
+                    <c:set var="formName" value="_25_compensationInsuranceId" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Workers' Compensation insurance"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download"
+                    />
+                </span>
             </div>
             <div class="row">
             </div>
 
             <div class="row requireField">
-                <c:set var="formName" value="_25_suretyBondId"></c:set>
-                <label for="${formIdPrefix}_${formName}" class="mediumLbl">Copy of surety bond</label>
-                <c:if test="${not empty  requestScope[formName]}">
-                    <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                         <c:param name="id" value="${requestScope[formName]}"></c:param>
-                    </c:url>
-                    <a href="${downloadLink}">Download</a>
-                </c:if>
-                <input id="${formIdPrefix}_${formName}" type="file" class="fileUpload" name="${formName}" />
+                <label class="mediumLbl">Copy of fidelity bond</label>
+                <span class="floatL">
+                    <c:set var="formName" value="_25_fidelityBondId" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Fidelity bond"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download"
+                    />
+                </span>
+            </div>
+            <div class="row">
+            </div>
+
+            <div class="row requireField">
+                <label class="mediumLbl">Copy of surety bond</label>
+                <span class="floatL">
+                    <c:set var="formName" value="_25_suretyBondId" />
+                    <h:attachment
+                        name="${formName}"
+                        title="Surety bond"
+                        attachmentId="${requestScope[formName]}"
+                        attachmentIdName="${formName}"
+                        filename="Download"
+                    />
+                </span>
             </div>
 
             <div class="clearFixed"></div>

--- a/psm-app/cms-web/WebContent/css/style.css
+++ b/psm-app/cms-web/WebContent/css/style.css
@@ -1429,8 +1429,7 @@ input.date{
   margin:0 0 0 7px;
 }
 
-.practicePanel span.floatL{
-  width:1%;
+.practicePanel span.floatL {
   margin:0;
 }
 
@@ -4221,9 +4220,6 @@ input.passwordNormalInput{
 }.memberInfoPanel .section .inlineBox label{
   display: inline;
   width: auto;
-}
-.memberInfoPanel .section span.floatL{
-  width: 5px;
 }
 .memberInfoPanel .section span.floatL.inputCnt{
   width: 552px;


### PR DESCRIPTION
These commits are from @jasonaowen 's PR #1074.  These commits/pages worked as expected, while the other two in PR #1074 did not, so I'm separating the work out into separate PRs.

This PR removes some CSS styles to fix a visual glitch I noticed on the Day Treatment and PCPO applications.  I think the removed styles were originally for the spans with right-aligned colons that are no longer there.  (What else would need to be so narrow?)  They were causing the license file name ('my-license.txt') to be split onto multiple lines:

![screenshot_2018-09-17 facility credentials](https://user-images.githubusercontent.com/1091693/45637931-b2e59680-ba79-11e8-92d8-774a9ed26622.png)

Here it is fixed:

![screenshot_2018-09-17 facility credentials 1](https://user-images.githubusercontent.com/1091693/45637935-b547f080-ba79-11e8-830d-48e30a75d037.png)

Those two screenshots above show the three states of the upload button.  Before upload, immediately after upload (where the file title is shown), and after saving or moving away from the page (when "Download" link is shown).  The next 3 show each of these in separate screenshots:

![screenshot_2018-09-17 facility credentials 2](https://user-images.githubusercontent.com/1091693/45637940-b8db7780-ba79-11e8-8de4-ed89cc717825.png)

![screenshot_2018-09-17 facility credentials 3](https://user-images.githubusercontent.com/1091693/45637953-bed15880-ba79-11e8-8a78-7a8a8a82f9b6.png)

![screenshot_2018-09-17 facility credentials 4](https://user-images.githubusercontent.com/1091693/45637959-c264df80-ba79-11e8-92fe-33d1e5e617bc.png)

And the same for the social worker application:

![screenshot_2018-09-17 license information](https://user-images.githubusercontent.com/1091693/45638149-4cad4380-ba7a-11e8-819a-62c66a907848.png)

![screenshot_2018-09-17 license information 1](https://user-images.githubusercontent.com/1091693/45638148-4cad4380-ba7a-11e8-8773-f1f57ffcd594.png)

![screenshot_2018-09-17 license information 2](https://user-images.githubusercontent.com/1091693/45638147-4cad4380-ba7a-11e8-81a0-0b3bb607bf1e.png)

Issue #158 "No file selected" is confusing when a file is uploaded