### PR TITLE
Improve the Upload File UI on two pages

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/phn_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/phn_agency.jsp
@@ -1,5 +1,7 @@
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <c:set var="formIdPrefix" value="phn_agency"></c:set>
 
 <input type="hidden" name="formNames" value="<%= ViewStatics.PHN_AGENCY_FORM %>">
@@ -42,15 +44,14 @@
                                     </label>
                                 </td>
                                 <td>
-                                    <c:set var="formName" value="_26_contractAttachment"></c:set>
-                                    <input type="file" title="Contract File" class="fileUpload" name="${formName}" />
-                                    <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                                    <c:if test="${not empty formValue}">
-                                        <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                                             <c:param name="id" value="${formValue}"></c:param>
-                                        </c:url>
-                                        <div><a href="${downloadLink}">Download</a></div>
-                                    </c:if>
+                                    <c:set var="formName" value="_26_contractAttachment" />
+                                    <h:attachment
+                                        name="${formName}"
+                                        title="Contract File"
+                                        attachmentId="${requestScope[formName]}"
+                                        attachmentIdName="_26_contractAttachmentId"
+                                        filename="Download"
+                                    />
                                 </td>
                             </tr>
                             </tbody>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/physician_clinic_facility_qualification.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/physician_clinic_facility_qualification.jsp
@@ -7,6 +7,8 @@
 
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
+<%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
+
 <c:set var="formIdPrefix" value="physician_clinic_facility_qualification"></c:set>
 <input type="hidden" name="formNames" value="<%= ViewStatics.PHYSICIAN_CLINIC_FACILITY_QUALIFICATION_FORM %>">
 <c:set var="selectedMarkup" value='selected="selected"' />
@@ -29,15 +31,14 @@
                             </label>
                         </td>
                         <td>
-                           <c:set var="formName" value="_40_designationApproval"></c:set>
-                           <input type="file" title="Approval Letter File" class="fileUpload" name="${formName}" />
-                           <c:set var="formValue" value="${requestScope[formName]}"></c:set>
-                           <c:if test="${not empty formValue}">
-                               <c:url var="downloadLink" value="/provider/enrollment/attachment">
-                                    <c:param name="id" value="${formValue}"></c:param>
-                               </c:url>
-                               <div><a href="${downloadLink}">Download</a></div>
-                           </c:if>
+                           <c:set var="formName" value="_40_designationApproval" />
+                           <h:attachment
+                               name="${formName}"
+                               title="Approval Letter File"
+                               attachmentId="${requestScope[formName]}"
+                               attachmentIdName="${formName}"
+                               filename="Download"
+                           />
                         </td>
                     </tr>
                     </tbody>

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
@@ -76,8 +76,10 @@ public class PHNAgencyFormBinder extends BaseFormBinder {
         if ("Y".equals(countyInfo.getCountyInd())) {
             countyInfo.setCountyName(param(request, "countyName"));
         } else if ("N".equals(countyInfo.getCountyInd())) {
-            String attachmentId = (String) request.getAttribute(NAMESPACE + "contractAttachment");
-            if (attachmentId != null) {
+            String attachmentId = (String) request.getAttribute(name("contractAttachment"));
+            if (attachmentId == null) {
+                attachmentId = param(request, "contractAttachmentId");
+            } else {
                 replaceDocument(XMLUtility.nsGetAttachments(provider), attachmentId, CONTRACT_WITH_COUNTY);
             }
 


### PR DESCRIPTION
These commits are from @jasonaowen 's PR #1074. These two commits/pages did not work as expected so I'm separating them out into their own PR for further work.

On these pages (in the Public Health Nursing Organization and Physician Clinic applications), you can submit a file and the file name shows up as expected, but when you save as draft or move away from that page and go back, the button says "upload" again and there's no download link, as if you hadn't uploaded the file.  When logging in as an admin, the UI is the same ("upload" button), so it appears that the file is not being uploaded.

(I rebased the commits on master and did a tiny bit of reformatting.)

Issue #158 "No file selected" is confusing when a file is uploaded
Resolves #734 Moving backward in PHN enrollment loses county contract