### PR TITLE
Remove colons from last of the 'default' JSPs

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_agency_rows.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_agency_rows.jsp
@@ -1,43 +1,35 @@
 <div class="row">
     <label>Agency Name</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_11_name']}</span>
 </div>
 <div class="row">
     <label>Agency Id</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_11_agencyId']}</span>
 </div>
 <div class="row">
     <label>Agency NPI/UMPI</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_11_npi']}</span>
 </div>
 <div class="row">
     <label>Fax Number</label>
-    <span class="floatL"><b>:</b></span>
     <span>
         ${requestScope['_11_fax1']}<c:if test="${requestScope['_11_fax2'] ne ''}">-</c:if>${requestScope['_11_fax2']}<c:if test="${requestScope['_11_fax3'] ne ''}">-</c:if>${requestScope['_11_fax3']}
     </span>
 </div>
 <div class="row">
     <label>Agency Contact Name</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_11_contactName']}</span>
 </div>
 <div class="row">
     <label>Background Study ID</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_11_bgsId']}</span>
 </div>
 <div class="row">
     <label>Clearance Date</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_11_clearanceDate']}</span>
 </div>
 <div class="row">
     <label>Has this individual maintained continuous employment with your agency since this BGS was completed?</label>
-    <span class="floatL"><b>&nbsp;</b></span>
     <span><c:choose>
         <c:when test="${requestScope['_11_continuousEmployment'] eq 'Y'}">Yes</c:when>
         <c:when test="${requestScope['_11_continuousEmployment'] eq 'N'}">No</c:when>
@@ -46,7 +38,6 @@
 <div class="row">
     <label> You have the option to affiliate/enroll the individual PCA  with other agencies you own without completing another
             application and agreement. Do you want to affiliate this individual PCA with any other agency(ies) you own?</label>
-    <span class="floatL"><b>&nbsp;</b></span>
     <span><c:choose>
         <c:when test="${requestScope['_11_additionalAgency'] eq 'Y'}">Yes</c:when>
         <c:when test="${requestScope['_11_additionalAgency'] eq 'N'}">No</c:when>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_pca_rows.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_pca_rows.jsp
@@ -1,26 +1,21 @@
 <div class="row">
     <label>First Name</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_10_firstName']}</span>
 </div>
 <div class="row">
     <label>Middle Name</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_10_middleName']}</span>
 </div>
 <div class="row">
     <label>Last Name</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_10_lastName']}</span>
 </div>
 <div class="row">
     <label>Social Security Number</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_10_ssn']}</span>
 </div>
 <div class="row address">
     <label>Residential Address</label>
-    <span class="floatL"><b>:</b></span>
     <h:address name="residential"
         streetAddress="${requestScope['_10_addressLine1']}"
         extendedAddress="${requestScope['_10_addressLine2']}"
@@ -32,19 +27,16 @@
 
 <div class="row">
     <label>UMPI</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_10_npi']}</span>
 </div>
 
 <div class="row">
     <label>Date of Birth</label>
-    <span class="floatL"><b>:</b></span>
     <span>${requestScope['_10_dob']}</span>
 </div>
 
 <div class="row">
     <label>Phone Number</label>
-    <span class="floatL"><b>:</b></span>
     <span>
     ${requestScope['_10_phone1']}<c:if test="${requestScope['_10_phone2'] ne ''}">-</c:if>${requestScope['_10_phone2']}<c:if test="${requestScope['_10_phone3'] ne ''}">-</c:if>${requestScope['_10_phone3']}<c:if test="${requestScope['_10_phone4'] ne ''}">ext.</c:if>${requestScope['_10_phone4']}
     </span>
@@ -52,7 +44,6 @@
 
 <div class="row">
     <label>Are you 18 years or older?</label>
-    <span class="floatL"><b>&nbsp;</b></span>
     <span><c:choose>
         <c:when test="${requestScope['_10_adultInd'] eq 'Y'}">Yes</c:when>
         <c:when test="${requestScope['_10_adultInd'] eq 'N'}">No</c:when>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_capacity.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_capacity.jsp
@@ -1,3 +1,4 @@
+<%-- Used for Regional Treatment Center application --%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="facility_capacity"></c:set>
@@ -11,7 +12,6 @@
                 <c:set var="formName" value="_27_numberOfBeds"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Number of Beds <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <input id="${formIdPrefix}_${formName}" type="text" class="normalInput" name="${formName}" value="${formValue}" maxlength="6"/>
             </div>
             <div class="clearFixed"></div>
@@ -23,7 +23,6 @@
                 <label for="${formIdPrefix}_${formName}">Effective Date <span class="required">*</span>
                     <span class="label">(MM/DD/YYYY)</span>
                 </label>
-                <span class="floatL"><b>:</b></span>
                 <span class="dateWrapper floatL">
                     <input id="${formIdPrefix}_${formName}" class="date" type="text" name="${formName}" value="${formValue}"/>
                 </span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_contracts.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_contracts.jsp
@@ -1,3 +1,4 @@
+<%-- Used in County Contracted Mental Health Rehab applications --%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
@@ -23,7 +24,6 @@
                     <label for="beginDate_adultRehabilitativeMentalHealthServices_${formName}">Begin Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_beginDate_0"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -37,7 +37,6 @@
                     <label for="endDate_adultRehabilitativeMentalHealthServices_${formName}">End Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_endDate_0"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -49,7 +48,6 @@
             <div class="clear"></div>
             <div class="row requireField">
                 <label for="certification_adultRehabilitativeMentalHealthServices_${formName}">Certification <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_34_attachment_0"></c:set>
                 <input id="certification_adultRehabilitativeMentalHealthServices_${formName}" type="file" class="fileUpload" name="${formName}" />
                 <c:set var="formName" value="_34_filename_0"></c:set>
@@ -84,7 +82,6 @@
                     <label for="ctss_beginDate_${formName}">Begin Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_beginDate_1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -98,7 +95,6 @@
                     <label for="ctss_endDate_${formName}">End Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_endDate_1"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -110,7 +106,6 @@
             <div class="clear"></div>
             <div class="row requireField">
                 <label for="ctss_certification_${formName}">Certification <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_34_attachment_1"></c:set>
                 <input id="ctss_certification_${formName}" type="file" class="fileUpload" name="${formName}" />
                 <c:set var="formName" value="_34_filename_1"></c:set>
@@ -145,7 +140,6 @@
                     <label for="adultCrisisAssessment_beginDate_${formName}">Begin Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_beginDate_2"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -159,7 +153,6 @@
                     <label for="adultCrisisAssessment_endDate_${formName}">End Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_endDate_2"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -171,7 +164,6 @@
             <div class="clear"></div>
             <div class="row requireField">
                 <label for="adultCrisisAssessment_contract_${formName}">County Contract <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_34_attachment_2"></c:set>
                 <input id="adultCrisisAssessment_contract_${formName}" type="file" class="fileUpload" name="${formName}" />
                 <c:set var="formName" value="_34_filename_2"></c:set>
@@ -206,7 +198,6 @@
                     <label for="adultCrisisStabilization_beginDate_${formName}">Begin Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_beginDate_3"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -220,7 +211,6 @@
                     <label for="adultCrisisStabilization_endDate_${formName}">End Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_endDate_3"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -232,7 +222,6 @@
             <div class="clear"></div>
             <div class="row requireField">
                 <label for="adultCrisisStabilization_contract_${formName}">County Contract <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_34_attachment_3"></c:set>
                 <input id="adultCrisisStabilization_contract_${formName}" type="file" class="fileUpload" name="${formName}" />
                 <c:set var="formName" value="_34_filename_3"></c:set>
@@ -267,7 +256,6 @@
                     <label for="adultCrisisShortTermResidential_beginDate_${formName}">Begin Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_beginDate_4"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -281,7 +269,6 @@
                     <label for="adultCrisisShortTermResidential_endDate_${formName}">End Date <span class="required">*</span>
                         <span class="label">(MM/DD/YYYY)</span>
                     </label>
-                    <span class="floatL"><b>:</b></span>
                                 <span class="dateWrapper floatL">
                         <c:set var="formName" value="_34_endDate_4"></c:set>
                         <c:set var="formValue" value="${requestScope[formName]}"></c:set>
@@ -293,7 +280,6 @@
             <div class="clear"></div>
             <div class="row requireField">
                 <label for="adultCrisisShortTermResidential_contract_${formName}">County Contract <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:set var="formName" value="_34_attachment_4"></c:set>
                 <input id="adultCrisisShortTermResidential_contract_${formName}" type="file" class="fileUpload" name="${formName}" />
                 <c:set var="formName" value="_34_filename_4"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tcm_contract.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tcm_contract.jsp
@@ -1,3 +1,4 @@
+<%-- TCM is for Targeted Case Management application --%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="tcm_contract"></c:set>
@@ -12,7 +13,6 @@
                 <c:set var="formName" value="_28_contractAttachment"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Upload copy of contract <span class="required">*</span></label>
-                <span class="floatL"><b>:</b></span>
                 <c:if test="${not empty formValue}">
                     <c:url var="downloadLink" value="/provider/enrollment/attachment">
                          <c:param name="id" value="${requestScope[formName]}"></c:param>
@@ -39,7 +39,6 @@
                 <c:set var="formName" value="_28_coverSheet1"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Mental Health TCM Contract Cover Sheet (DHS-5638)</label>
-                <span class="floatL"><b>:</b></span>
                 <c:if test="${not empty formValue}">
                     <c:url var="downloadLink" value="/provider/enrollment/attachment">
                          <c:param name="id" value="${requestScope[formName]}"></c:param>
@@ -52,7 +51,6 @@
                 <c:set var="formName" value="_28_coverSheet2"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}">Relocation Service Coordination TCM Contract Cover Sheet (DHS-5639)</label>
-                <span class="floatL"><b>:</b></span>
                 <c:if test="${not empty formValue}">
                     <c:url var="downloadLink" value="/provider/enrollment/attachment">
                          <c:param name="id" value="${requestScope[formName]}"></c:param>
@@ -65,7 +63,6 @@
                 <c:set var="formName" value="_28_coverSheet3"></c:set>
                 <c:set var="formValue" value="${requestScope[formName]}"></c:set>
                 <label for="${formIdPrefix}_${formName}"> Child Welfare TCM Contract Cover Sheet (DHS-5702)</label>
-                <span class="floatL"><b>:</b></span>
                 <c:if test="${not empty formValue}">
                     <c:url var="downloadLink" value="/provider/enrollment/attachment">
                          <c:param name="id" value="${requestScope[formName]}"></c:param>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_capacity.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_capacity.jsp
@@ -4,12 +4,10 @@
     <div class="leftCol">
         <div class="row">
             <label>Number of Beds</label>
-            <span class="floatL"><b>:</b></span>
             <span >${requestScope['_27_numberOfBeds']}</span>
         </div>
         <div class="row">
             <label>Effective Date</label>
-            <span class="floatL"><b>:</b></span>
             <span >${requestScope['_27_effectiveDate']}</span>
         </div>
     </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_agency_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_agency_information.jsp
@@ -1,3 +1,4 @@
+<%-- Used for Personal Care Assistant application --%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_11_bound'] eq 'Y'}">
     <div class="practiceSection">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_pca_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_pca_information.jsp
@@ -1,3 +1,4 @@
+<%-- Used for Personal Care Assistant application --%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 <c:if test="${requestScope['_10_bound'] eq 'Y'}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/physician_clinic_facility_qualification.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/physician_clinic_facility_qualification.jsp
@@ -6,7 +6,6 @@
             <label>Facility Qualifications</label>
             <span>
                 <label>Hospital Based Clinic Designation:  approval letter from CMS</label>
-                <span class="floatL"><b>:</b></span>
                 <span>
                     <c:if test="${requestScope['_40_designationApprovalIndicator'] eq 'Y'}">
                          Provided


### PR DESCRIPTION
This batch finishes all the JSPs in the 'default' and 'common' directories.

Before:

![screenshot_2018-09-17 summary information 3](https://user-images.githubusercontent.com/1091693/45653727-0cb08580-baa7-11e8-80f8-e6d39e518ca6.png)

After:

![screenshot_2018-09-17 summary information 4](https://user-images.githubusercontent.com/1091693/45653726-0cb08580-baa7-11e8-9dee-6220b4afcb0d.png)

Before:

![screenshot_2018-09-17 facility credentials 8](https://user-images.githubusercontent.com/1091693/45653730-0d491c00-baa7-11e8-965b-01eda20c20b6.png)

After:

![screenshot_2018-09-17 facility credentials 9](https://user-images.githubusercontent.com/1091693/45653729-0d491c00-baa7-11e8-8891-dd57c157d018.png)

Before:

![screenshot_2018-09-17 facility credentials 6](https://user-images.githubusercontent.com/1091693/45653732-0d491c00-baa7-11e8-9125-642fe7662e52.png)

After:

![screenshot_2018-09-17 facility credentials 7](https://user-images.githubusercontent.com/1091693/45653731-0d491c00-baa7-11e8-88f3-91303a97b83f.png)

Before:

![screenshot_2018-09-17 summary information 1](https://user-images.githubusercontent.com/1091693/45653734-0d491c00-baa7-11e8-88d4-c42150893dd1.png)

After:

![screenshot_2018-09-17 summary information 2](https://user-images.githubusercontent.com/1091693/45653733-0d491c00-baa7-11e8-8cfd-87b81f277fb5.png)

Just After (no colons on number of beds or effective date, default jsp):

![screenshot_2018-09-17 facility credentials 5](https://user-images.githubusercontent.com/1091693/45653736-0d491c00-baa7-11e8-9148-71a3423c0b70.png)

Just After (no colons on number of beds or effective date, summary jsp):

![screenshot_2018-09-17 summary information](https://user-images.githubusercontent.com/1091693/45653735-0d491c00-baa7-11e8-8cd0-16a404664566.png)

Issue #376: Remove right-justified colons...