### PR TITLE
Remove remaining unneeded colons

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
@@ -40,17 +40,14 @@
                     <div class="wholeCol">
                       <div class="row">
                         <label>Start Date</label>
-                        <span class="floatL"><b>:</b></span>
                         <span><fmt:formatDate value="${cos.startDate}" pattern="MM/dd/yyyy"/></span>
                       </div>
                       <div class="row">
                         <label>End Date</label>
-                        <span class="floatL"><b>:</b></span>
                         <span id="edt-${cos.id}"><fmt:formatDate value="${cos.endDate}" pattern="MM/dd/yyyy"/></span>
                       </div>
                       <div class="row">
                         <label>COS</label>
-                        <span class="floatL"><b>:</b></span>
                         <span id="cats-${cos.id}">
                           <c:forEach var="cat" items="${cos.categories}" varStatus="loop2">
                             ${cat.code}
@@ -76,17 +73,14 @@
                   <div class="wholeCol">
                     <div class="row">
                       <label for="enrollmentCosStartDate">Start Date</label>
-                      <span class="floatL"><b>:</b></span>
                       <span><input id="enrollmentCosStartDate" name="startDate" class="shortInput text mdate" value="" /></span>
                     </div>
                     <div class="row">
                       <label for="enrollmentCosEndDate">End Date</label>
-                      <span class="floatL"><b>:</b></span>
                       <span><input id="enrollmentCosEndDate" name="endDate" class="shortInput text mdate" value="" /></span>
                     </div>
                     <div class="row">
                       <label for="enrollmentCosCosSelect">COS</label>
-                      <span class="floatL"><b>:</b></span>
                       <select id="enrollmentCosCosSelect" name="cos" multiple="multiple" style="width:350px;" class="chzn-select">
                         <c:forEach var="code" items="${codes}">
                           <option value="${code.code}">${code.code}</option>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
@@ -40,17 +40,14 @@
                     <div class="wholeCol">
                       <div class="row">
                         <label>Start Date</label>
-                        <span class="floatL"><b>:</b></span>
                         <span><fmt:formatDate value="${cos.startDate}" pattern="MM/dd/yyyy"/></span>
                       </div>
                       <div class="row">
                         <label>End Date</label>
-                        <span class="floatL"><b>:</b></span>
                         <span id="edt-${cos.id}"><fmt:formatDate value="${cos.endDate}" pattern="MM/dd/yyyy"/></span>
                       </div>
                       <div class="row">
                         <label>COS</label>
-                        <span class="floatL"><b>:</b></span>
                         <span id="cats-${cos.id}">
                           <c:forEach var="cat" items="${cos.categories}" varStatus="loop2">
                             ${cat.code}
@@ -76,17 +73,14 @@
                   <div class="wholeCol">
                     <div class="row">
                       <label for="startDate">Start Date</label>
-                      <span class="floatL"><b>:</b></span>
                       <span><input id="startDate" name="startDate" class="shortInput text mdate" value="" /></span>
                     </div>
                     <div class="row">
                       <label for="endDate">End Date</label>
-                      <span class="floatL"><b>:</b></span>
                       <span><input id="endDate" name="endDate" class="shortInput text mdate" value="" /></span>
                     </div>
                     <div class="row">
                       <label for="cosSelect">COS</label>
-                      <span class="floatL"><b>:</b></span>
                       <select id="cosSelect" name="cos" multiple="multiple" style="width:350px;" class="chzn-select">
                         <c:forEach var="code" items="${codes}">
                           <option value="${code.code}">${code.code}</option>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
@@ -35,32 +35,26 @@
                 <div class="wholeCol">
                   <div class="row">
                     <label>NPI / UMPI</label>
-                    <span class="floatL"><b>:</b></span>
                     <a href="${ctx}/provider/enrollment/view?id=${profile.ticketId}">${profile.npi}</a>
                   </div>
                   <div class="row">
                     <label>Date Submitted</label>
-                    <span class="floatL"><b>:</b></span>
                     <span><fmt:formatDate value="${profile.submissionDate}" pattern="MM/dd/yyyy"/></span>
                   </div>
                   <div class="row">
                     <label>Provider Type</label>
-                    <span class="floatL"><b>:</b></span>
                     <span><c:out value="${profile.providerType}"/></span>
                   </div>
                   <div class="row">
                     <label>Provider Name</label>
-                    <span class="floatL"><b>:</b></span>
                     <span><c:out value="${profile.providerName}"/></span>
                   </div>
                   <div class="row">
                     <label>Request Type</label>
-                    <span class="floatL"><b>:</b></span>
                     <span><c:out value="${profile.requestType}"/></span>
                   </div>
                   <div class="row">
                     <label>Status</label>
-                    <span class="floatL"><b>:</b></span>
                     <c:choose>
                     <c:when test="${fn:toLowerCase(profile.status)=='approved'}"><span class="green">Approved</span></c:when>
                     <c:when test="${fn:toLowerCase(profile.status)=='rejected'}"><span class="red">Denied</span></c:when>
@@ -69,7 +63,6 @@
                   </div>
                   <div class="row">
                     <label>Risk Level</label>
-                    <span class="floatL"><b>:</b></span>
                     <c:choose>
                     <c:when test="${fn:toLowerCase(profile.riskLevel)=='limited'}"><span class="green">Limited</span></c:when>
                     <c:when test="${fn:toLowerCase(profile.riskLevel)=='high'}"><span class="red">High</span></c:when>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
@@ -45,12 +45,10 @@
                   <div class="leftCol">
                     <div class="row">
                       <label for="npiInput">NPI/UMPI</label>
-                      <span class="floatL"><b>:</b></span>
                       <input id="npiInput" type="text" class="normalInput" value="${searchCriteria.npi}"/>
                     </div>
                     <div class="row">
                       <label>Date Submitted</label>
-                      <span class="floatL"><b>:</b></span>
                       <span class="dateWrapper floatL">
                         <input id="submissionDateStartInput" title="Submission Date Start" value='<fmt:formatDate value="${searchCriteria.submissionDateStart}" pattern="MM/dd/yyyy"/>' class="date" type="text" readonly="readonly"/>
                       </span>
@@ -61,7 +59,6 @@
                     </div>
                     <div class="row">
                       <label for="providerTypeInput">Provider Type</label>
-                      <span class="floatL"><b>:</b></span>
                       <select id="providerTypeInput" class="longSelect">
                         <option value="">All</option>
                         <c:forEach var="item" items="${providerTypesLookup}">
@@ -71,14 +68,12 @@
                     </div>
                     <div class="row">
                       <label for="providerNameInput">Provider Name</label>
-                      <span class="floatL"><b>:</b></span>
                       <input id="providerNameInput" value="${searchCriteria.providerName}" type="text" class="normalInput"/>
                     </div>
                   </div>
                   <div class="rightCol">
                     <div class="row">
                       <label for="requestTypeInput">Request Type</label>
-                      <span class="floatL"><b>:</b></span>
                       <select id="requestTypeInput" class="longSelect">
                         <option value="">All</option>
                         <c:forEach var="item" items="${requestTypesLookup}">
@@ -88,7 +83,6 @@
                     </div>
                     <div class="row">
                       <label for="enrollmentStatusesInput">Status</label>
-                      <span class="floatL"><b>:</b></span>
                       <select id="enrollmentStatusesInput" class="longSelect">
                         <option value="">All</option>
                         <c:forEach var="item" items="${enrollmentStatusesLookup}">
@@ -98,7 +92,6 @@
                     </div>
                     <div class="row">
                       <label for="riskLevelInput">Risk Level</label>
-                      <span class="floatL"><b>:</b></span>
                       <select id="riskLevelInput" class="longSelect">
                         <option value="">All</option>
                         <c:forEach var="item" items="${riskLevelsLookup}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
@@ -26,12 +26,10 @@
                 <div class="col1">
                   <div class="row">
                     <label>Request Type</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_99_requestType']}</span>
                   </div>
                   <div class="row">
                     <label>Status</label>
-                    <span class="floatL"><b>:</b></span>
                     <span class="enrollmentStatus">
                       ${requestScope['_99_requestStatus'] == 'Rejected' ? 'Denied' : requestScope['_99_requestStatus']}
                     </span>
@@ -40,18 +38,16 @@
                 <div class="col2">
                   <div class="row">
                     <label>Submitted On</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_99_submittedOn']}</span>
                   </div>
                   <div class="row">
                     <label>Status Date</label>
-                    <span class="floatL"><b>:</b></span>
                     <span>${requestScope['_99_statusDate']}</span>
                   </div>
                 </div>
                 <div class="col3">
                   <div class="row">
-                    <label>Risk Level &nbsp;&nbsp;&nbsp;&nbsp;:</label>
+                    <label>Risk Level</label>
                     <span>${requestScope['_99_riskLevel']}</span>
                   </div>
                 </div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
@@ -44,9 +44,6 @@
                   <div class="wholeCol">
                     <div class="row">
                       <label>System</label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
 
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="systemId">
@@ -58,9 +55,6 @@
                     </div>
                     <div class="row">
                       <label for="createLinkAccountId">Account Id</label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
 
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="accountId">
@@ -70,9 +64,6 @@
                     </div>
                     <div class="row">
                       <label for="createLinkPassword">Password</label>
-                      <span class="floatL">
-                        <b>:</b>
-                      </span>
 
                       <c:set var="errorCls" value=""/>
                       <spring:bind path="password">


### PR DESCRIPTION
I have not been able to locate and access these pages in our current UI (thus, no screenshots).  So I suggest that we go ahead and remove these colons since 1. we have not run into any serious formatting issues when removing these kinds of colons elsewhere and 2. it seems unlikely that these pages are currently accessible, so there's no real risk or reason not to go ahead and remove them.

Details: Two of these JSPs are for COS (Category of Service) functionality, which is no longer exposed in the UI.  Most of the others appear to be pages that might have, at some point, been accessible via the 'service agent' role, a role that we are likely removing (per previous discussions with @cecilia-donnelly  and @jasonaowen ).  The last one, that is not 'service agent' related, (`onboarding/create_link`) involves linking to external accounts, which is also functionality we are not currently supporting.

These are the last of these colons that we want to remove.

Resolves #376: Remove right-justified colons...