### PR TITLE
Fix 1047 by adding "Previous" etc. buttons at top

### DIFF
--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/steps_navigation_buttons.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/steps_navigation_buttons.jsp
@@ -1,0 +1,54 @@
+<%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
+
+<div class="buttonBox ${isTopNavigation ? 'topButtonBox' : ''}">
+
+  <button
+    type="submit"
+    class="prevBtn greyBtn"
+    name="previous"
+  >
+    <span class="icon">
+      Previous
+    </span>
+  </button>
+
+  <c:if test="${not isSubmissionPage}">
+    <button
+      type="submit"
+      class="nextBtn greyBtn"
+      name="next"
+    >
+      <span class="icon">
+        Next
+      </span>
+    </button>
+  </c:if>
+
+  <c:if test="${isSubmissionPage && not isTopNavigation}">
+    <button
+      type="submit"
+      class="purpleBtn"
+      name="submit"
+    >
+      Submit Enrollment
+    </button>
+  </c:if>
+
+  <button
+    type="submit"
+    class="greyBtn"
+    name="save"
+  >
+    Save as Draft
+  </button>
+
+  <c:if test="${showExportNavigation}">
+    <a
+      class="greyBtn iconPdf"
+      href="<c:url value="/provider/enrollment/export" />"
+    >
+      Export to PDF
+    </a>
+  </c:if>
+
+</div>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/steps_navigation_buttons.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/steps_navigation_buttons.jsp
@@ -34,13 +34,15 @@
     </button>
   </c:if>
 
-  <button
-    type="submit"
-    class="greyBtn"
-    name="save"
-  >
-    Save as Draft
-  </button>
+  <c:if test="${not isSubmissionPage || (isSubmissionPage && not isTopNavigation)}">
+    <button
+      type="submit"
+      class="greyBtn"
+      name="save"
+    >
+      Save as Draft
+    </button>
+  </c:if>
 
   <c:if test="${showExportNavigation}">
     <a

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp
@@ -5,7 +5,7 @@
 <div class="stepWidget ${viewModel.individual ? 'stepWidget5Item' : 'stepWidget6Item'}">
     <ul>
         <c:set var="activeIdx" value="1"></c:set>
-        <c:set var="isInSubmissionPage" value="${false}"></c:set>
+        <c:set var="isSubmissionPage" value="${false}" />
         <c:forEach var="tabName" items="${viewModel.tabNames}" varStatus="status">
             <c:if test="${viewModel.currentTab eq tabName}"><c:set var="activeIdx" value="${status.count}"></c:set></c:if>
         </c:forEach>
@@ -21,7 +21,9 @@
                 <c:when test="${status.count + 1 < activeIdx}"><c:set var="tabActiveCls" value="activePrev"></c:set></c:when>
             </c:choose>
             <c:if test="${viewModel.currentTab eq tabName}"><c:set var="tabActiveCls" value="active"></c:set></c:if>
-            <c:if test="${viewModel.currentTab eq tabName and status.last}"><c:set var="isInSubmissionPage" value="${true}"></c:set></c:if>
+            <c:if test="${viewModel.currentTab == tabName and status.last}">
+              <c:set var="isSubmissionPage" value="${true}" />
+            </c:if>
             <li class="${status.first ? 'firstStep' : ''} ${status.last ? 'lastStep' : ''} ${tabCls} ${tabActiveCls}">
                <span><strong>${status.count}. ${tabLabel}</strong></span>
             </li>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
@@ -4,17 +4,30 @@
 <div class="clearFixed"></div>
 <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp" %>
 
-<div class="requiredInfo">
-  <span class="required">*</span> Indicates Required Fields
-</div>
-<!-- /.requiredInfo -->
-
 <form action="<c:url value="/provider/enrollment/page" />"
       id="enrollmentForm"
       method="post"
       enctype="multipart/form-data">
   <sec:csrfInput />
-  <!-- /.errorInfo -->
+
+  <div class="buttonBox topButtonBox">
+    <button class="greyBtn prevBtn" type="submit" name="previous">
+      <span class="icon">Previous</span>
+    </button>
+    <c:if test="${not isInSubmissionPage}">
+      <button class="nextBtn greyBtn" type="submit" name="next">
+        <span class="icon">Next</span>
+      </button>
+    </c:if>
+    <button class="greyBtn" type="submit" name="save">
+      Save as Draft
+    </button>
+  </div>
+
+  <div class="requiredInfo">
+    <span class="required">*</span> Indicates Required Fields
+  </div>
+
   <%@include file="/WEB-INF/pages/provider/enrollment/steps/errors.jsp" %>
 
   <c:forEach var="formName" items="${viewModel.currentFormNames}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
@@ -10,19 +10,10 @@
       enctype="multipart/form-data">
   <sec:csrfInput />
 
-  <div class="buttonBox topButtonBox">
-    <button class="greyBtn prevBtn" type="submit" name="previous">
-      <span class="icon">Previous</span>
-    </button>
-    <c:if test="${not isInSubmissionPage}">
-      <button class="nextBtn greyBtn" type="submit" name="next">
-        <span class="icon">Next</span>
-      </button>
-    </c:if>
-    <button class="greyBtn" type="submit" name="save">
-      Save as Draft
-    </button>
-  </div>
+  <input type="hidden" name="pageName" value="${pageName}"/>
+  <c:set var="showExportNavigation" value="${false}" />
+  <c:set var="isTopNavigation" value="${true}" />
+  <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/steps_navigation_buttons.jsp" %>
 
   <div class="requiredInfo">
     <span class="required">*</span> Indicates Required Fields
@@ -38,25 +29,7 @@
     </c:forEach>
   </c:forEach>
 
-  <div class="buttonBox">
-    <input type="hidden" name="pageName" value="${pageName}"/>
+  <c:set var="isTopNavigation" value="${false}" />
+  <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/steps_navigation_buttons.jsp" %>
 
-    <button type="submit" class="greyBtn prevBtn" name="previous">
-      <span class="icon">Previous</span>
-    </button>
-    <c:if test="${not isInSubmissionPage}">
-      <button type="submit" class="nextBtn greyBtn" name="next">
-        <span class="icon">Next</span>
-      </button>
-    </c:if>
-    <c:if test="${isInSubmissionPage}">
-      <button type="submit" class="purpleBtn" name="submit">
-        Submit Enrollment
-      </button>
-    </c:if>
-    <button type="submit" class="greyBtn" name="save">
-      Save as Draft
-    </button>
-  </div>
-  <!-- /.buttonBox -->
 </form>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary.jsp
@@ -8,22 +8,12 @@
     method="post"
     enctype="multipart/form-data">
   <sec:csrfInput />
-  <div class="buttonBox topButtonBox">
-    <button class="greyBtn prevBtn" type="submit" name="previous">
-      <span class="icon">Previous</span>
-    </button>
-    <button class="nextBtn greyBtn" type="submit" name="next">
-      <span class="icon">Next</span>
-    </button>
-    <button class="greyBtn" type="submit" name="save">
-      Save as Draft
-    </button>
-    <a class="greyBtn iconPdf" href="<c:url value="/provider/enrollment/export" />">
-      Export to PDF
-    </a>
-  </div>
 
-  <!-- /.buttonBox -->
+  <input type="hidden" name="pageName" value="${pageName}"/>
+  <c:set var="showExportNavigation" value="${true}" />
+  <c:set var="isTopNavigation" value="${true}" />
+  <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/steps_navigation_buttons.jsp" %>
+
   <div class="personalPanel summaryPageWrapper">
     <c:set var="afterSummary" value="${false}"></c:set>
     <c:forEach var="tabName" items="${viewModel.tabNames}" varStatus="status">
@@ -55,20 +45,7 @@
     <div class="br"></div>
   </div>
 
-  <div class="buttonBox topButtonBox">
-    <input type="hidden" name="pageName" value="${pageName}"/>
-    <button class="greyBtn prevBtn" type="submit" name="previous">
-      <span class="icon">Previous</span>
-    </button>
-    <button class="nextBtn greyBtn" type="submit" name="next">
-      <span class="icon">Next</span>
-    </button>
-    <button class="greyBtn" type="submit" name="save">
-      Save as Draft
-    </button>
-    <a class="greyBtn iconPdf" href="<c:url value="/provider/enrollment/export" />">
-      Export to PDF
-    </a>
-  </div>
-  <!-- /.buttonBox -->
+  <c:set var="isTopNavigation" value="${false}"></c:set>
+  <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/steps_navigation_buttons.jsp" %>
+
 </form>


### PR DESCRIPTION
Add "Previous", "Next", and "Save as Draft" buttons to the top of the application steps pages, so you don't have to scroll to the bottom of the page to access them.

Tested by logging in as a provider and a service admin and editing a draft application, confirming that the buttons appeared and worked.

The summary page stays the same, since it already had these buttons at the top:

![screenshot_2018-09-18 summary information 16](https://user-images.githubusercontent.com/1091693/45965717-39105880-bff7-11e8-9790-8268c99a2518.png)

Before:

![screenshot_2018-09-18 ownership information 1](https://user-images.githubusercontent.com/1091693/45965712-3877c200-bff7-11e8-986e-1d9e9d34f09e.png)

After:

![screenshot_2018-09-18 ownership information](https://user-images.githubusercontent.com/1091693/45965716-39105880-bff7-11e8-9f9b-4066be9631fa.png)

Before:

![screenshot_2018-09-18 facility credentials 4](https://user-images.githubusercontent.com/1091693/45965713-39105880-bff7-11e8-9268-fe412ce3685a.png)

After:

![screenshot_2018-09-18 facility credentials 3](https://user-images.githubusercontent.com/1091693/45965715-39105880-bff7-11e8-866a-e130f1adcc45.png)


Before:

![screenshot_2018-09-18 provider statement 3](https://user-images.githubusercontent.com/1091693/45965711-3877c200-bff7-11e8-86a2-f6333e090277.png)

After:

![screenshot_2018-09-24 provider statement](https://user-images.githubusercontent.com/1091693/45965867-9dcbb300-bff7-11e8-8f00-8b502d1e2856.png)

Resolves #1047: "Previous" button at bottom is too far...