### PR TITLE
Fix changeset checksum.

### DIFF
--- a/psm-app/db/changelog/db-changelog-1.0.xml
+++ b/psm-app/db/changelog/db-changelog-1.0.xml
@@ -6,6 +6,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet author="" id="issue254-create-hibernate-sequence">
+    <validCheckSum>ANY</validCheckSum>
     <createSequence sequenceName="hibernate_sequence"
       minValue="2000" />
     <rollback>


### PR DESCRIPTION
When merging #1052 to add integration tests, the hibernate sequence
was updated, but the changeset was changed so that existing databases
would not get the new sequence.  This updates to allow any changesets.

Related to Issue #1050: Add integration tests
