### PR TITLE
Add save and submit integration tests

### DIFF
--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -2211,6 +2211,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
         saveRelatedEntities(enrollment.clone());
 
         if (insertDetails) {
+            details.setOwnerId(user.getUserId());
             insertProfile(dbEnrollment.getEnrollmentId(), details);
             dbEnrollment.setProfileReferenceId(details.getProfileId());
 
@@ -2347,6 +2348,7 @@ public class ProviderEnrollmentServiceBean extends BaseService implements Provid
 
             saveRelatedEntities(updatedProfile);
         } else {
+            updatedProfile.setOwnerId(ticket.getSubmittedBy().getUserId());
             insertProfile(ticket.getEnrollmentId(), updatedProfile);
         }
 

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -557,6 +557,11 @@ public class EnrollmentSteps {
     }
 
     @Step
+    void closeSaveAsDraftModal() {
+        enrollmentDetailsPage.closeSaveAsDraftModal();
+    }
+
+    @Step
     void enterEmptyEmailAddress() {
         personalInfoPage.enterEmail("");
     }

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -90,6 +90,12 @@ public class IndividualEnrollmentStepDefinitions {
         enrollmentSteps.advanceFromIndividualSummaryToProviderStatementPage();
     }
 
+    @When("^I save the application as a draft$")
+    public void i_save_the_application_as_a_draft() {
+        enrollmentSteps.clickSaveAsDraft();
+        enrollmentSteps.closeSaveAsDraftModal();
+    }
+
     @Given("^I am going to enroll as a Personal Care Assistant$")
     public void i_am_going_to_enroll_as_a_personal_care_assistant() {
         enrollmentSteps.preparePersonalCareAssistantEnrollment();

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentDetailsPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentDetailsPage.java
@@ -14,4 +14,8 @@ public class EnrollmentDetailsPage extends PsmPage {
     public void closeSubmitModal() {
         click($("#submitEnrollmentModal a.okBtn"));
     }
+
+    public void closeSaveAsDraftModal() {
+        click$("#saveAsDraftModal a.okBtn");
+    }
 }

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/edit_submit_application.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/edit_submit_application.feature
@@ -1,0 +1,22 @@
+Feature: Editing and Submitting Applications
+  Users wish to edit and submit applications
+
+  @issue_1105
+  @ignore
+  Scenario: Save and then submit Speech Language Pathologist application
+    Given I have started an enrollment
+    And I am on the individual provider statement page
+    And I save the application as a draft
+    When I enter my individual provider statement
+    And I submit the enrollment
+    Then I should have no errors
+
+  @issue_1105
+  @ignore
+  Scenario: Save and then submit Head Start application
+    Given I have started an enrollment
+    And I am on the organization provider statement page
+    And I save the application as a draft
+    When I enter my organization provider statement
+    And I submit the enrollment
+    Then I should have no errors

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/edit_submit_application.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/edit_submit_application.feature
@@ -2,7 +2,6 @@ Feature: Editing and Submitting Applications
   Users wish to edit and submit applications
 
   @issue_1105
-  @ignore
   Scenario: Save as draft twice for Speech Language Pathologist application
     Given I have started an enrollment
     And I am on the individual summary page
@@ -20,7 +19,6 @@ Feature: Editing and Submitting Applications
     Then I should have no errors
 
   @issue_1105
-  @ignore
   Scenario: Save and then submit Speech Language Pathologist application
     Given I have started an enrollment
     And I am on the individual provider statement page
@@ -30,7 +28,6 @@ Feature: Editing and Submitting Applications
     Then I should have no errors
 
   @issue_1105
-  @ignore
   Scenario: Save and then submit Head Start application
     Given I have started an enrollment
     And I am on the organization provider statement page

--- a/psm-app/integration-tests/src/test/resources/features/enrollment/edit_submit_application.feature
+++ b/psm-app/integration-tests/src/test/resources/features/enrollment/edit_submit_application.feature
@@ -3,6 +3,24 @@ Feature: Editing and Submitting Applications
 
   @issue_1105
   @ignore
+  Scenario: Save as draft twice for Speech Language Pathologist application
+    Given I have started an enrollment
+    And I am on the individual summary page
+    And I save the application as a draft
+    And I save the application as a draft
+    Then I should have no errors
+
+  @issue_1104
+  @ignore
+  Scenario: Save as draft twice for Head Start application
+    Given I have started an enrollment
+    And I am on the organization summary page
+    And I save the application as a draft
+    And I save the application as a draft
+    Then I should have no errors
+
+  @issue_1105
+  @ignore
   Scenario: Save and then submit Speech Language Pathologist application
     Given I have started an enrollment
     And I am on the individual provider statement page


### PR DESCRIPTION
Add integration tests for save as draft and submit, and for save as draft twice.  Currently these tests fail, see issues below, so they are ignored for the moment.

Issue #1105 Access denied error on application save and submit
Issue #1104 'Save as Draft' only works once for organization applications