### PR TITLE
Cleanup license comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,6 +280,31 @@ important that the codebase continue to be publishable under that
 license.  To make that possible, here are some guidelines on including
 3rd party code in the codebase.
 
+The default method of getting your code added to the codebase is to
+include the following header as the first part of your file (example
+below is for java):
+
+````
+/*
+ * Copyright 20XX The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+````
+
+See [#300](https://github.com/SolutionGuidance/psm/issues/300) for more
+context.
+
 If you submit code that you wrote or that you have authority to submit
 from your employer or institution, you give it to us under version 2
 of the Apache Software License.  If the material you submit is already

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AdditionalCategory.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AdditionalCategory.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AdditionalCategory.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AdditionalCategory.java
@@ -18,10 +18,6 @@ package gov.medicaid.domain.rules.inference;
 
 /**
  * Represents a possible dual license selection for a provider type.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
  */
 public class AdditionalCategory {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AddressEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AddressEntry.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AddressEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/AddressEntry.java
@@ -21,10 +21,6 @@ import gov.medicaid.domain.model.AddressType;
 /**
  * This class is used by the rules to perform validation on an address within a context, since an address may appear in
  * different levels of a profile.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
  */
 public class AddressEntry {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/CertificateException.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/CertificateException.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/CertificateException.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/CertificateException.java
@@ -19,9 +19,6 @@ package gov.medicaid.domain.rules.inference;
 
 /**
  * This class is used by the rules logically insert exceptions.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class CertificateException {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ErrorReporter.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ErrorReporter.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ErrorReporter.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ErrorReporter.java
@@ -23,9 +23,6 @@ import gov.medicaid.domain.model.ValidationResultType;
 
 /**
  * This is a wrapper to the validation result entity to allow quickly adding messages from the rules.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ErrorReporter {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsIndividual.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsIndividual.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsIndividual.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsIndividual.java
@@ -20,9 +20,6 @@ import gov.medicaid.domain.model.ProviderInformationType;
 
 /**
  * This class is used by the rules to differentiate individual from organizational requests.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class IsIndividual {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsOrganization.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsOrganization.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsOrganization.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/IsOrganization.java
@@ -20,9 +20,6 @@ import gov.medicaid.domain.model.ProviderInformationType;
 
 /**
  * This class is used by the rules to differentiate individual from organizational requests.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class IsOrganization {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LookupEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LookupEntry.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LookupEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/LookupEntry.java
@@ -18,8 +18,6 @@ package gov.medicaid.domain.rules.inference;
 
 /**
  * This is a container for lookup entries referenced by the rules.
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class LookupEntry {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NPIEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NPIEntry.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NPIEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/NPIEntry.java
@@ -19,10 +19,6 @@ package gov.medicaid.domain.rules.inference;
 /**
  * This class is used by the rules to perform validation on an address within a context, since an address may appear in
  * different levels of a profile.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
  */
 public class NPIEntry {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/PhoneNumberEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/PhoneNumberEntry.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/PhoneNumberEntry.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/PhoneNumberEntry.java
@@ -19,9 +19,6 @@ package gov.medicaid.domain.rules.inference;
 /**
  * This class is used by the rules to perform validation on a phone number within a context, since a phone number may
  * appear in different levels of a profile.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PhoneNumberEntry {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderSpecialty.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderSpecialty.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderSpecialty.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderSpecialty.java
@@ -18,10 +18,6 @@ package gov.medicaid.domain.rules.inference;
 
 /**
  * Represents a possible selection for the provider's specialty.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
  */
 public class ProviderSpecialty {
 

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderTypeException.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderTypeException.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderTypeException.java
+++ b/psm-app/cms-business-model/src/main/java/gov/medicaid/domain/rules/inference/ProviderTypeException.java
@@ -18,9 +18,6 @@ package gov.medicaid.domain.rules.inference;
 
 /**
  * This class is used by the rules logically insert exceptions based on the provider type.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ProviderTypeException {
 

--- a/psm-app/cms-business-model/src/main/resources/EnrollmentProcess.xsd
+++ b/psm-app/cms-business-model/src/main/resources/EnrollmentProcess.xsd
@@ -8,8 +8,6 @@
     <documentation xml:lang="en">
       This defines the aggregate schema used by the enrollment business process.
 
-      @author TCSASSEMBLER
-      @version 1.0
     </documentation>
   </annotation>
   <import schemaLocation="Entities.xsd"

--- a/psm-app/cms-business-model/src/test/groovy/HelloSpec.groovy
+++ b/psm-app/cms-business-model/src/test/groovy/HelloSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import spock.lang.*
 
 @Unroll

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/CMSKnowledgeUtility.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/CMSKnowledgeUtility.java
@@ -25,8 +25,6 @@ import javax.transaction.UserTransaction;
  * This class is used to configure and execute CMS Business rules.
  *
  * v1.1 - WAS Porting - pass reference to user transaction when invoking BPMN
- * @author TCSASSEMBLER
- * @version 1.1
  */
 public class CMSKnowledgeUtility {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/CMSKnowledgeUtility.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/CMSKnowledgeUtility.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DroolsKnowledgeDelegate.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DroolsKnowledgeDelegate.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DroolsKnowledgeDelegate.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/DroolsKnowledgeDelegate.java
@@ -43,8 +43,6 @@ import javax.transaction.UserTransaction;
  * This class is used to configure and execute CMS Business rules.
  *
  * v1.1 - WAS Porting - pass reference to user transaction when invoking BPMN, add flag to use guvnor
- * @author TCSASSEMBLER
- * @version 1.1
  */
 public class DroolsKnowledgeDelegate implements KnowledgeDelegate {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/GlobalLookups.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/GlobalLookups.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/GlobalLookups.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/GlobalLookups.java
@@ -48,9 +48,6 @@ import java.util.Map.Entry;
  * <li>added new EntityType and EDITradingPartnerType</li>
  * </ul>
  * </p>
- *
- * @author TCSASSEMBLER
- * @version 1.5
  */
 public class GlobalLookups {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/KnowledgeDelegate.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/KnowledgeDelegate.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/KnowledgeDelegate.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/domain/rules/KnowledgeDelegate.java
@@ -25,8 +25,6 @@ import javax.transaction.UserTransaction;
  * Knowledge delegate definition.
  *
  * v1.1 - WAS Porting - pass reference to user transaction when invoking BPMN
- * @author TCSASSEMBLER
- * @version 1.1
  */
 public interface KnowledgeDelegate {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/AcceptedHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/AcceptedHandler.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/AcceptedHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/AcceptedHandler.java
@@ -38,9 +38,6 @@ import java.util.Date;
 
 /**
  * This initializes the application model.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class AcceptedHandler extends GenericHandler {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/EnrollmentMonitor.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/EnrollmentMonitor.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/EnrollmentMonitor.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/EnrollmentMonitor.java
@@ -29,9 +29,6 @@ import org.drools.runtime.process.NodeInstance;
 
 /**
  * This tracks the progress of the enrollment process.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class EnrollmentMonitor implements ProcessEventListener {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ExcludedProvidersScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ExcludedProvidersScreeningHandler.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/Exclusion.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/Exclusion.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.process.enrollment;
 
 import ca.uhn.fhir.model.api.annotation.Child;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/GenericHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/GenericHandler.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/GenericHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/GenericHandler.java
@@ -22,9 +22,6 @@ import org.drools.runtime.process.WorkItemManager;
 
 /**
  * This is a generic handler for BPMN work items.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public abstract class GenericHandler implements WorkItemHandler {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/PreProcessHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/PreProcessHandler.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/PreProcessHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/PreProcessHandler.java
@@ -32,9 +32,6 @@ import java.util.logging.Logger;
 
 /**
  * This initializes the application model.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PreProcessHandler extends GenericHandler {
     private final Logger logger = Logger.getLogger(getClass().getName());

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/RejectedHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/RejectedHandler.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/RejectedHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/RejectedHandler.java
@@ -35,9 +35,6 @@ import java.util.Date;
 
 /**
  * This initializes the application model.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class RejectedHandler extends GenericHandler {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ScreeningHandler.java
@@ -41,9 +41,6 @@ import java.util.logging.Logger;
 
 /**
  * This handler is responsible all screening rules.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ScreeningHandler extends GenericHandler {
     /**

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ValidationHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ValidationHandler.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ValidationHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/process/enrollment/ValidationHandler.java
@@ -26,9 +26,6 @@ import java.util.logging.Logger;
 
 /**
  * This is a mock handler for front-end validation.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ValidationHandler extends GenericHandler {
     private final Logger logger = Logger.getLogger(getClass().getName());

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BaseService.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BaseService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BaseService.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BaseService.java
@@ -38,9 +38,6 @@ import java.util.logging.Logger;
  * <b>Thread Safety</b> This bean is mutable and not thread-safe as it deals with non-thread-safe entities. However, in
  * the context of being used in a container, it is thread-safe.
  * </p>
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public abstract class BaseService {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/BusinessProcessServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/DBIdentityProviderDAOBean.java
@@ -32,9 +32,6 @@ import java.util.List;
 /**
  * This is an EJB implementation for the {@link IdentityProviderDAO} which connects directly to the database
  * servers.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @Local(IdentityProviderDAO.class)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/EnrollmentWebServiceBean.java
@@ -50,8 +50,6 @@ import javax.ejb.TransactionManagementType;
  * Web service facade for enrollment requests.
  *
  * v1.1 - WAS Porting - split transaction of save and submit, so JBPM errors still saves the request
- * @author TCSASSEMBLER
- * @version 1.1
  */
 @Stateless
 @Local(EnrollmentWebService.class)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExportServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExportServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExportServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExportServiceBean.java
@@ -58,9 +58,6 @@ import java.util.Map;
  * <b>Thread Safety</b> This bean is mutable and not thread-safe as it deals with non-thread-safe entities. However, in
  * the context of being used in a container, it is thread-safe.
  * </p>
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @Local(ExportService.class)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExternalScreeningTimerBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ExternalScreeningTimerBean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.services.impl;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateAgreementDocumentBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateAgreementDocumentBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateAgreementDocumentBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateAgreementDocumentBean.java
@@ -48,9 +48,6 @@ import java.util.Map;
  * This bean is mutable and not thread-safe as it deals with non-thread-safe entities. However, in the context of being
  * used in a container, it is thread-safe.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @TransactionManagement(TransactionManagementType.CONTAINER)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateEventServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateEventServiceBean.java
@@ -39,9 +39,6 @@ import java.util.List;
  * This bean is mutable and not thread-safe as it deals with non-thread-safe entities. However, in the context of being
  * used in a container, it is thread-safe.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @TransactionManagement(TransactionManagementType.CONTAINER)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateEventServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/HibernateEventServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LeieExternalScreener.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LeieExternalScreener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.services.impl;
 
 import ca.uhn.fhir.context.FhirContext;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LocalHumanTaskHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LocalHumanTaskHandler.java
@@ -47,9 +47,6 @@ import java.util.logging.Logger;
  * This is a port of org.jbpm.process.workitem.wsht.CommandBasedWSHumanTaskHandler to use local connections.
  *
  * See https://community.jboss.org/thread/201834
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class LocalHumanTaskHandler extends GenericHandler {
 
@@ -203,9 +200,6 @@ public class LocalHumanTaskHandler extends GenericHandler {
 
     /**
      * Callback for completed human task.
-     *
-     * @author TCSASSEMBLER
-     * @version 1.0
      */
     private class TaskCompletedHandler extends AbstractBaseResponseHandler implements EventResponseHandler {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LocalHumanTaskHandler.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LocalHumanTaskHandler.java
@@ -1,5 +1,18 @@
 /*
- * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
+ * Copyright 2013 TopCoder Inc.
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package gov.medicaid.services.impl;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/LookupServiceBean.java
@@ -36,9 +36,6 @@ import java.util.List;
 
 /**
  * Defines the UI related services.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @Local(LookupService.class)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
@@ -31,9 +31,6 @@ import java.util.List;
 
 /**
  * Implementation of a partner service.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @Local(PartnerSystemService.class)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/MockMNITSPartnerServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/NotificationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/NotificationServiceBean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.services.impl;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/OnboardingServiceBean.java
@@ -41,9 +41,6 @@ import java.util.Map;
 
 /**
  * This is a mock onboarding service implementation used to demo profile imports.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @Local(OnboardingService.class)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/PresentationServiceBean.java
@@ -55,9 +55,6 @@ import java.util.Map;
 
 /**
  * Defines the UI related services.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @Local(PresentationService.class)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderEnrollmentServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ProviderTypeServiceBean.java
@@ -50,9 +50,6 @@ import java.util.stream.Collectors;
  * <b>Thread Safety</b> This bean is mutable and not thread-safe as it deals with non-thread-safe entities. However, in
  * the context of being used in a container, it is thread-safe.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @TransactionManagement(TransactionManagementType.CONTAINER)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/RegistrationServiceBean.java
@@ -58,9 +58,6 @@ import java.util.Map;
 
 /**
  * Defines registration related logic.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @Local(RegistrationService.class)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/ScreeningServiceBean.java
@@ -52,9 +52,6 @@ import java.util.stream.Collectors;
  * <b>Thread Safety</b> This bean is mutable and not thread-safe as it deals with non-thread-safe entities. However, in
  * the context of being used in a container, it is thread-safe.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @TransactionManagement(TransactionManagementType.CONTAINER)

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
@@ -20,8 +20,6 @@ import java.io.StringWriter;
 
 /**
  * This class is used to ensure backward compatibility of request models thru XML serialization.
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class XMLSerializingEnrollmentProcess extends EnrollmentProcess implements Externalizable {
 

--- a/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
+++ b/psm-app/cms-business-process/src/main/java/gov/medicaid/services/impl/XMLSerializingEnrollmentProcess.java
@@ -1,5 +1,18 @@
 /*
- * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
+ * Copyright 2013 TopCoder Inc.
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package gov.medicaid.services.impl;

--- a/psm-app/cms-business-process/src/main/resources/cms.screening.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.screening.drl
@@ -5,12 +5,6 @@ import gov.medicaid.domain.rules.inference.*
 
 rule 'Setup validation reporting'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         not ErrorReporter()
         $validation: ValidationResultType()
@@ -21,12 +15,6 @@ end
 
 rule 'Assert provider agreements'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 salience 100
     when
         $provider: ProviderInformationType( )
@@ -39,12 +27,6 @@ end
 
 rule 'Assert provider documents'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 salience 100
     when
         $provider: ProviderInformationType( )
@@ -57,12 +39,6 @@ end
 
 rule 'Assert provider licenses'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 salience 100
     when
         $provider: ProviderInformationType()
@@ -74,32 +50,9 @@ salience 100
 end
 
 
-/*
-rule 'Provider Agreement (DHS-4138) Is Required'
-dialect 'mvel'
-    when
-        $provider: ProviderInformationType()
-        $acceptedAgreements: AcceptedAgreementsType( ) from $provider.acceptedAgreements;
-        not ProviderAgreementType(acceptedDate != null, agreementDocumentTitle == DocumentNames.PROVIDER_AGREEMENT_DHS_4138.value()) from $acceptedAgreements.providerAgreement;
-        $report: ErrorReporter()
-    then
-        $report.addError(
-            "/ProviderInformation/AcceptedAgreements",
-            "00002",
-            "Provider Agreement(DHS-4138) Is Required."
-        );
-
-end
- */
 
 rule 'Department of Health Registration As Audiologist Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.AUDIOLOGIST.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -116,12 +69,6 @@ end
 
 rule 'Audiologists That Will Also Be Registered As Hearing Aid Dispensers Must Also Provide HAD Registration'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.AUDIOLOGIST.value())
         $licenseInformation: LicenseInformationType(additionalServiceCategoryRequest contains ServiceCategoryNames.HEARING_AIDS.value()) from $provider.licenseInformation;
@@ -138,12 +85,6 @@ end
 
 rule 'FEIN for the employer should not be listed for Individual Audiologist or Hearing Aid Dispenser'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.AUDIOLOGIST.value() || providerType == ProviderType.HEARING_AID_DISPENSER.value())
         PracticeInformationType(groupNPI != null, FEIN != null) from $provider.practiceInformation
@@ -159,12 +100,6 @@ end
 
 rule 'Tribal Code Must Be One Of The Recognized Values'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType()
         LicenseInformationType($tribalCode : tribalCode, tribalCode != null) from $provider.licenseInformation;
@@ -181,12 +116,6 @@ end
 
 rule 'Traditional Midwife License from the MN Board of Medical Practice Is Present'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "traditional-midwife-license-activation"
     when
         $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_PROFESSIONAL_MIDWIFE.value())
@@ -198,12 +127,6 @@ end
 
 rule 'Traditional Midwife License Not Issued by MN Is Acceptable If Working On A Reservation Is Present'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "traditional-midwife-license-activation"
     when
         $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_PROFESSIONAL_MIDWIFE.value())
@@ -215,12 +138,6 @@ end
 
 rule 'A Traditional Midwife License Or Equivalent Certificate Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 salience -10
 activation-group "traditional-midwife-license-activation"
     when
@@ -237,12 +154,6 @@ end
 
 rule 'Copy of MnSCU Certification Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_HEALTH_CARE_WORKER.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -259,12 +170,6 @@ end
 
 rule 'MHCP Applicant Assurance Statement Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_HEALTH_CARE_WORKER.value())
         $attachedDocuments: AttachedDocumentsType( ) from $provider.attachedDocuments;
@@ -281,12 +186,6 @@ end
 
 rule 'MnSCU Certification Must Be Issued By the Approved Institutions'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_HEALTH_CARE_WORKER.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -305,12 +204,6 @@ end
 rule 'Individual Applicant Risk Level Is Limited With Some Exceptions'
 dialect 'mvel'
 salience 20
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $enrollment: EnrollmentInformationType(riskLevel == null)
         ProviderInformationType(applicantType == ApplicantType.INDIVIDUAL, providerType != ProviderType.PHYSICAL_THERAPIST.value())
@@ -323,12 +216,6 @@ end
 
 rule 'Applicant Must Not Be In the Excluded Providers List'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         VerificationStatusType(nonExclusion != "Y")
         $report: ErrorReporter()
@@ -363,12 +250,6 @@ end
 
 rule 'Registered Nurse Certificate Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType in (ProviderType.CLINICAL_NURSE_SPECIALIST.value(), ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST.value()))
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -385,12 +266,6 @@ end
 
 rule 'If the applicant is working on a reservation, any state license is acceptable including those issued by a reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "registered-nurse-license-activation"
     when
         $provider: ProviderInformationType(providerType in (ProviderType.CLINICAL_NURSE_SPECIALIST.value(), ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST.value()))
@@ -414,12 +289,6 @@ end
 
 rule 'If the state is an NLC state, licenses issued by residence state is acceptable only if the residence state is also an NLC state'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "registered-nurse-license-activation"
     when
         $provider: ProviderInformationType(providerType in (ProviderType.CLINICAL_NURSE_SPECIALIST.value(), ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST.value()))
@@ -437,12 +306,6 @@ end
 
 rule 'RN License Must Be Issued By An Accepted Board'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 salience -10
 activation-group "registered-nurse-license-activation"
     when
@@ -462,12 +325,6 @@ end
 
 rule 'Clinical Nurse Specialist Certificate Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.CLINICAL_NURSE_SPECIALIST.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -484,12 +341,6 @@ end
 
 rule 'CRNA Certification from the AANA for Nurse Anesthetists Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -506,12 +357,6 @@ end
 
 rule 'Chiropractic Examiner License Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.CHIROPRACTOR.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -528,12 +373,6 @@ end
 
 rule 'Podiatrist License Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.PODIATRIST.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -550,12 +389,6 @@ end
 
 rule 'Marriage And Family Therapist License From The Practice State Is Provided'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "marriage-and-family-therapy-license-activation"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value())
@@ -567,12 +400,6 @@ end
 
 rule 'MN Accepts LMFT from ND As Substitute For MFT License And The Person Must Have A Masters in Social Work'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "marriage-and-family-therapy-license-activation"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value())
@@ -586,12 +413,6 @@ end
 
 rule 'MN Accepts LPCC from ND As Substitute For MFT License And The Person Must Have A Masters in Social Work'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "marriage-and-family-therapy-license-activation"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_MARRIAGE_AND_FAMILY_THERAPIST.value())
@@ -605,12 +426,6 @@ end
 
 rule 'Marriage And Family Therapist License Or Equivalent Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 salience -10
 activation-group "marriage-and-family-therapy-license-activation"
     when
@@ -628,12 +443,6 @@ end
 
 rule 'LPCC License From the MN is Provided'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "professional-clinical-counserlor-license-activation"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value())
@@ -645,12 +454,6 @@ end
 
 rule 'MN Accepts LPCC License from Virginia'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "professional-clinical-counserlor-license-activation"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value())
@@ -662,12 +465,6 @@ end
 
 rule 'MN Accepts LPCC License from other states or from a reservation for providers working on a reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "professional-clinical-counserlor-license-activation"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value())
@@ -679,12 +476,6 @@ end
 
 rule 'Professional Clinical Counselor License Or Equivalent Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 salience -10
 activation-group "professional-clinical-counserlor-license-activation"
     when
@@ -701,12 +492,6 @@ end
 
 rule 'ND Licensed LPCC Should be enrolled as Marriage and Family Therapist'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "professional-clinical-counserlor-license-activation"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PROFESSIONAL_CLINICAL_COUNSELOR.value())
@@ -724,12 +509,6 @@ end
 
 rule 'Physician License or Equivalent Is required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "physician-license-or-equivalent-is-required"
 salience -10
     when
@@ -746,12 +525,6 @@ end
 
 rule 'Physician License From MN is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "physician-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.PHYSICIAN.value())
@@ -763,12 +536,6 @@ end
 
 rule 'Physician License From Other States Or A Reservation Is Accepted If Working On A Reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "physician-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.PHYSICIAN.value())
@@ -780,12 +547,6 @@ end
 
 rule 'Physicians with Specialization is required to have Certification for that Specialization'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.PHYSICIAN.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation
@@ -803,12 +564,6 @@ end
 
 rule 'Psychologist License From MN is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "psychologist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
@@ -820,12 +575,6 @@ end
 
 rule 'Psychologist License From Other States Or A Reservation Is Accepted If Working On A Reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "psychologist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
@@ -837,12 +586,6 @@ end
 
 rule 'Psychologist License From State of Practice Or Equivalent Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "psychologist-license-or-equivalent-is-required"
 salience -10
     when
@@ -859,12 +602,6 @@ end
 
 rule 'MDH Psychologist Registration Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
         $licenseInformation: LicenseInformationType() from $provider.licenseInformation
@@ -881,12 +618,6 @@ end
 
 rule 'If Neuropsychology Is Entered As Specialty, Supporting Documentation Must Be Provided'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "psychologist-neuropsychology-supporting-document-is-required"
 salience -10
     when
@@ -904,12 +635,6 @@ end
 
 rule 'Received A Diploma From American Board of Clinical Neuropsychology (ABCN)'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "psychologist-neuropsychology-supporting-document-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
@@ -921,12 +646,6 @@ end
 
 rule 'Received A Diploma From American Board of Professional Neuropsychology (ABPN)'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "psychologist-neuropsychology-supporting-document-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
@@ -938,12 +657,6 @@ end
 
 rule 'Received A Diploma From American Academy of Pediatric Neuropsychology (AAPN)'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "psychologist-neuropsychology-supporting-document-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
@@ -955,12 +668,6 @@ end
 
 rule 'Earned a doctoral degree in psychology from an accredited university training program and completed experience requirements'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "psychologist-neuropsychology-supporting-document-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
@@ -975,12 +682,6 @@ end
 
 rule 'Been licensed or credentialed by another state board'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "psychologist-neuropsychology-supporting-document-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
@@ -992,12 +693,6 @@ end
 
 rule 'Acupuncturist License or Equivalent is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "acupuncturist-license-or-equivalent-is-required"
 salience -10
     when
@@ -1014,13 +709,6 @@ end
 
 rule 'Certification from NBCOT is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.OCCUPATIONAL_THERAPIST.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -1037,12 +725,6 @@ end
 
 rule 'Clinical Social Worker License Or Equivalent Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "clinical-social-worker-license-or-equivalent-is-required"
 salience -10
     when
@@ -1059,13 +741,6 @@ end
 
 rule 'Collaborative Practice Dental Hygienist Assurance Statement is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.ALLIED_DENTAL_PROFESSIONAL.value())
         $attachedDocuments: AttachedDocumentsType( ) from $provider.attachedDocuments;
@@ -1082,13 +757,6 @@ end
 
 rule 'Copy of Collaborative Agreement that meets MN requirements Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.ALLIED_DENTAL_PROFESSIONAL.value())
         $attachedDocuments: AttachedDocumentsType( ) from $provider.attachedDocuments;
@@ -1105,12 +773,6 @@ end
 
 rule 'Copy Of Hearing Instrument Dispenser Certificate Or Equivalent Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 salience -10
 activation-group "hearing-instrument-dispenser-certificate-or-equivalent-is-required"
     when
@@ -1127,13 +789,6 @@ end
 
 rule 'Copy of License of Dentist who signed Collaborative Agreement Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.ALLIED_DENTAL_PROFESSIONAL.value())
         $attachedDocuments: AttachedDocumentsType( ) from $provider.attachedDocuments;
@@ -1150,12 +805,6 @@ end
 
 rule 'Copy Of Masters Degree In A Related Field Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_MENTAL_HEALTH_REHAB_PROF_CPRP.value())
         $attachedDocuments: AttachedDocumentsType( ) from $provider.attachedDocuments;
@@ -1172,12 +821,6 @@ end
 
 rule 'Copy Of Masters Degree In Social Work Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
         $attachedDocuments: AttachedDocumentsType( ) from $provider.attachedDocuments;
@@ -1194,13 +837,6 @@ end
 
 rule 'Dental Hygienist License or Equivalent is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "dental-hygienist-license-or-equivalent-is-required"
 salience -10
     when
@@ -1217,12 +853,6 @@ end
 
 rule 'Dental License From MN Is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "dental-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.DENTIST.value())
@@ -1234,12 +864,6 @@ end
 
 rule 'Dental License Or Equivalent Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 salience -10
 activation-group "dental-license-or-equivalent-is-required"
     when
@@ -1256,12 +880,6 @@ end
 
 rule 'DHS-6095 Is Required For CPRP'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_MENTAL_HEALTH_REHAB_PROF_CPRP.value())
         $attachedDocuments: AttachedDocumentsType( ) from $provider.attachedDocuments;
@@ -1278,12 +896,6 @@ end
 
 rule 'Dietician Or Nutritionist License Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "dietician-or-nutritionist-license-or-equivalent-is-required"
 salience -10
     when
@@ -1300,12 +912,6 @@ end
 
 rule 'Dietician, Nutritionist License From The State Of Practice Is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "dietician-or-nutritionist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_DIETICIAN_OR_LICENSED_NUTRITIONIST.value())
@@ -1318,12 +924,6 @@ end
 
 rule 'HAD Certificate From State Of Practice Is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "hearing-instrument-dispenser-certificate-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.HEARING_AID_DISPENSER.value())
@@ -1336,12 +936,6 @@ end
 
 rule 'IA Independent Social Worker License Is Acceptable'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "clinical-social-worker-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
@@ -1353,12 +947,6 @@ end
 
 rule 'If Practice is in WI, Audiologist Certificate from WI Is Acceptable'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "hearing-instrument-dispenser-certificate-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.HEARING_AID_DISPENSER.value())
@@ -1372,12 +960,6 @@ end
 
 rule 'LICSW With Dual License To Offer MFT Service Must Also Present An MFT License'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
         $licenseInformation: LicenseInformationType(additionalServiceCategoryRequest contains ServiceCategoryNames.MARRIAGE_AND_FAMILY_THERAPY.value()) from $provider.licenseInformation;
@@ -1394,13 +976,6 @@ end
 
 rule 'MN Acupuncturist License is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "acupuncturist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.ACUPUNCTURIST.value())
@@ -1412,13 +987,6 @@ end
 
 rule 'MN Dental Hygienist License is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "dental-hygienist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.ALLIED_DENTAL_PROFESSIONAL.value())
@@ -1430,13 +998,6 @@ end
 
 rule 'MN Department of Health Certification As Speech Pathologist Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.SPEECH_LANGUAGE_PATHOLOGIST.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -1453,12 +1014,6 @@ end
 
 rule 'MN Independent Clinical Social Worker License Is Acceptable'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "clinical-social-worker-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
@@ -1470,13 +1025,6 @@ end
 
 rule 'MN Physical Therapist License is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "physical-therapist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.PHYSICAL_THERAPIST.value())
@@ -1488,13 +1036,6 @@ end
 
 rule 'MN Physician Assistant License is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "physician-assistant-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.PHYSICIAN_ASSISTANT.value())
@@ -1506,12 +1047,6 @@ end
 
 rule 'ND Independent Clinical Social Worker License Is Acceptable'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "clinical-social-worker-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
@@ -1523,12 +1058,6 @@ end
 
 rule 'Nurse Midwife Specialty Certification Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.NURSE_MIDWIFE.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -1545,13 +1074,6 @@ end
 
 rule 'Nurse Practitioner Certificate Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.NURSE_PRACTITIONER.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -1568,13 +1090,6 @@ end
 
 rule 'Occupational Therapist License Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $provider: ProviderInformationType(providerType == ProviderType.OCCUPATIONAL_THERAPIST.value())
         $licenseInformation: LicenseInformationType( ) from $provider.licenseInformation;
@@ -1591,13 +1106,6 @@ end
 
 rule 'Only OT in private practice are eligible for MHCP enrollment'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $provider: ProviderInformationType(maintainsOwnPrivatePractice != "Y", providerType == ProviderType.OCCUPATIONAL_THERAPIST.value())
         $report: ErrorReporter()
@@ -1612,13 +1120,6 @@ end
 
 rule 'Only PT in private practice are eligible for MHCP enrollment'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $provider: ProviderInformationType(maintainsOwnPrivatePractice != "Y", providerType == ProviderType.PHYSICAL_THERAPIST.value())
         $report: ErrorReporter()
@@ -1633,12 +1134,6 @@ end
 
 rule 'Optometrist License From the State Of Practice Is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "optometrist-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.OPTOMETRIST.value())
@@ -1651,12 +1146,6 @@ end
 
 rule 'Optometrist License Or Equivalent Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "optometrist-or-equivalent-is-required"
 salience -10
     when
@@ -1673,12 +1162,6 @@ end
 
 rule 'Oral Surgeon Certificate Is Required If Selected Specialty Includes Oral Surgery'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
     when
         $provider: ProviderInformationType(  providerType == ProviderType.DENTIST.value())
         SpecialtiesType(specialtyName contains SpecialtyNames.ORAL_SURGERY.value()) from $provider.specialties
@@ -1696,12 +1179,6 @@ end
 
 rule 'Out Of State Optometrist License Is Acceptable If Working On A Reserveration'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "optometrist-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.OPTOMETRIST.value())
@@ -1714,13 +1191,6 @@ end
 
 rule 'Out of State Acupuncturist License Is Accepted If Working On A Reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "acupuncturist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.ACUPUNCTURIST.value())
@@ -1732,13 +1202,6 @@ end
 
 rule 'Out of State Dental Hygienist License Is Accepted If Working On A Reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "dental-hygienist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.ALLIED_DENTAL_PROFESSIONAL.value())
@@ -1750,12 +1213,6 @@ end
 
 rule 'Out of State Dental License is Accepted If Working On A Reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "dental-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.DENTIST.value())
@@ -1767,12 +1224,6 @@ end
 
 rule 'Out Of State Dietician, Nutritionist License Is Acceptable If Working On A Reserveration'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "dietician-or-nutritionist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_DIETICIAN_OR_LICENSED_NUTRITIONIST.value())
@@ -1785,12 +1236,6 @@ end
 
 rule 'Out of State HAD License Is Acceptable If Working On A Reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "hearing-instrument-dispenser-certificate-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.HEARING_AID_DISPENSER.value())
@@ -1802,12 +1247,6 @@ end
 
 rule 'Out Of State ICSW License Is Acceptable If Working On A Reserveration'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "clinical-social-worker-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
@@ -1819,12 +1258,6 @@ end
 
 rule 'Out of State Physical Therapist License Is Accepted If Working On A Reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "physical-therapist-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.PHYSICAL_THERAPIST.value())
@@ -1836,13 +1269,6 @@ end
 
 rule 'Out of State Physician License Is Accepted If Working On A Reservation'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "physician-assistant-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.PHYSICIAN_ASSISTANT.value())
@@ -1855,13 +1281,6 @@ end
 rule 'Physical Therapist Applicant Risk Level Is Moderate'
 dialect 'mvel'
 salience 20
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $enrollment: EnrollmentInformationType(riskLevel == null)
         ProviderInformationType(providerType == ProviderType.PHYSICAL_THERAPIST.value())
@@ -1874,13 +1293,6 @@ end
 
 rule 'Physical Therapist License or Equivalent is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "physical-therapist-license-or-equivalent-is-required"
 salience -10
     when
@@ -1897,13 +1309,6 @@ end
 
 rule 'Physician Assistant License or Equivalent is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 activation-group "physician-assistant-license-or-equivalent-is-required"
 salience -10
     when
@@ -1920,12 +1325,6 @@ end
 
 rule 'Psychosocial Rehabilitation Practitioner Certificate Is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "national-certification-is-required-for-cprp"
     when
         $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_MENTAL_HEALTH_REHAB_PROF_CPRP.value())
@@ -1937,12 +1336,6 @@ end
 
 rule 'Rehabilitation Counselor Certificate Is Accepted'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "national-certification-is-required-for-cprp"
     when
         $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_MENTAL_HEALTH_REHAB_PROF_CPRP.value())
@@ -1954,12 +1347,6 @@ end
 
 rule 'SD Clinical Social Worker License Is Acceptable'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "clinical-social-worker-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
@@ -1971,12 +1358,6 @@ end
 
 rule 'WI Clinical Social Worker License Is Acceptable'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- */
 activation-group "clinical-social-worker-license-or-equivalent-is-required"
     when
         $provider: ProviderInformationType(providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
@@ -1986,9 +1367,6 @@ activation-group "clinical-social-worker-license-or-equivalent-is-required"
 
 end
 
-/**
- * Added by cyberjag - PESP-309
- */
 rule 'Organizational Providers Risk Level Is Limited With Some Exceptions'
 dialect 'mvel'
 salience 20

--- a/psm-app/cms-business-process/src/main/resources/cms.validation.drl
+++ b/psm-app/cms-business-process/src/main/resources/cms.validation.drl
@@ -48,13 +48,6 @@ function Calendar get18YearsFromNow() {
 
 rule '1099 Address Index Must Reference An Existing Address'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -72,13 +65,6 @@ end
 
 rule 'Actual Street Address Is Required For Education Plans'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
      when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -97,13 +83,6 @@ end
 
 rule 'Additional Location Address Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -123,13 +102,6 @@ end
 
 rule 'Additional Location Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -150,13 +122,6 @@ end
 
 rule 'Additional Location Disclosure Indicator Must Be Answered In Y,N'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         IsOrganization( )
         ProviderInformationType(agreeToDiscloseLocations != null, agreeToDiscloseLocations != "Y", agreeToDiscloseLocations != "N" )
@@ -211,13 +176,6 @@ end
 
 rule 'Additional Location Group Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -237,13 +195,6 @@ end
 
 rule 'Additional Location Group Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -263,13 +214,6 @@ end
 
 rule 'Additional Location Group NPI Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -289,13 +233,6 @@ end
 
 rule 'Additional Location Group NPI Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -331,13 +268,6 @@ end
 
 rule 'Additional Location Indicator Must Be Answered In Y,N'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         IsOrganization( )
         $provider: ProviderInformationType(additionalLocationIndicator != null, additionalLocationIndicator != "Y", additionalLocationIndicator != "N" )
@@ -353,13 +283,6 @@ end
 
 rule 'Additional Location Indicator Should Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         IsOrganization( )
         $provider: ProviderInformationType( additionalLocationIndicator != null )
@@ -376,13 +299,6 @@ end
 
 rule 'Additional Location Provider Number Cannot Be Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         IsOrganization( )
         $provider: ProviderInformationType($additionalLocations : additionalLocations.providerNumber, additionalLocations != null)
@@ -401,13 +317,6 @@ end
 
 rule 'Additional Location Provider Number Is Required I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( )
@@ -424,13 +333,6 @@ end
 
 rule 'Additional Location Provider Number Is Required II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( )
@@ -448,13 +350,6 @@ end
 
 rule 'Additional Location Provider Number Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         IsOrganization( )
         $provider: ProviderInformationType($additionalLocations : additionalLocations.providerNumber, additionalLocations != null)
@@ -472,13 +367,6 @@ end
 
 rule 'Additional Location Provider Number Should Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( )
@@ -496,13 +384,6 @@ end
 
 rule 'Additional Locations Are Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 salience 10
     when
     then
@@ -556,13 +437,6 @@ end
 
 rule 'Address Line 1 Should Not Be A PO BOX'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $entry: AddressEntry(errorOnLine1 != "Y")
         LookupEntry($value : value, type == "POBoxWordRegex")
@@ -583,13 +457,6 @@ end
 
 rule 'Adult Day Treatment Application Is Required For Day Treatment'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.DAY_TREATMENT.value())
@@ -606,13 +473,6 @@ end
 
 rule 'Affiliated Agency Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -631,13 +491,6 @@ end
 
 rule 'Affiliated Agency Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -711,13 +564,6 @@ end
 
 rule 'Affiliated Agency StudyId Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -736,13 +582,6 @@ end
 
 rule 'Affiliated Agency StudyId Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -761,13 +600,6 @@ end
 
 rule 'Agency Address Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -785,13 +617,6 @@ dialect 'mvel'
 end
 
 rule 'Agency Address Must Be Valid'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
@@ -876,13 +701,6 @@ end
 
 rule 'Agency ContactName Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -899,13 +717,6 @@ end
 
 rule 'Agency Eligibility Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 salience 10
     when
     then
@@ -915,13 +726,6 @@ end
 
 rule 'Agency Eligibility Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
@@ -939,13 +743,6 @@ end
 
 rule 'Agency Eligibility Should Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
@@ -963,13 +760,6 @@ end
 
 rule 'Agency Fax Number Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -986,13 +776,6 @@ end
 
 rule 'Agency Fax Number Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -1009,13 +792,6 @@ end
 
 rule 'Agency Id Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -1032,13 +808,6 @@ end
 
 rule 'Agency Id Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -1054,13 +823,6 @@ dialect 'mvel'
 end
 
 rule 'Agency Information Is Required For PCA'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
@@ -1076,13 +838,6 @@ dialect 'mvel'
 end
 
 rule 'Agency Name Is Required For Agency Applications'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
@@ -1101,13 +856,6 @@ end
 
 rule 'Agency Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -1123,13 +871,6 @@ dialect 'mvel'
 end
 
 rule 'Agency Name Maximum Length Check'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 dialect 'mvel'
     when
         IsOrganization($provider: provider)
@@ -1193,13 +934,6 @@ end
 
 rule 'Agency Study Id Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -1216,13 +950,6 @@ end
 
 rule 'Agency Study Id Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -1239,13 +966,6 @@ end
 
 rule 'All Addresses City Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $entry: AddressEntry(errorOnCity != "Y")
         AddressType(city == null || city matches "^[\\s]*$") from $entry.address
@@ -1264,13 +984,6 @@ end
 
 rule 'All Addresses City Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         $entry: AddressEntry(errorOnCity != "Y")
         AddressType(city != null, city not matches "^[\\s]*$", city not matches "^.{0,100}$") from $entry.address
@@ -1289,13 +1002,6 @@ end
 
 rule 'All Addresses County Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         $entry: AddressEntry(errorOnCounty != "Y")
         AddressType(county != null, county not matches "^[\\s]*$", county not matches "^.{0,100}$") from $entry.address
@@ -1314,13 +1020,6 @@ end
 
 rule 'All Addresses Line 1 Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         $entry: AddressEntry(errorOnLine1 != "Y")
         AddressType(addressLine1 != null, addressLine1 not matches "^[\\s]*$",  addressLine1 not matches "^.{0,28}$") from $entry.address
@@ -1339,13 +1038,6 @@ end
 
 rule 'Address must not be empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $entry: AddressEntry(errorOnLine1 != "Y")
         AddressType(addressLine2 == null || addressLine2 matches "^[\\s]*$", addressLine1 == null || addressLine1 matches "^[\\s]*$") from $entry.address
@@ -1364,13 +1056,6 @@ end
 
 rule 'All Addresses Line 2 Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         $entry: AddressEntry(errorOnLine2 != "Y")
         AddressType(addressLine2 != null, addressLine2 not matches "^[\\s]*$",  addressLine2 not matches "^.{0,28}$") from $entry.address
@@ -1389,13 +1074,6 @@ end
 
 rule 'All Addresses State Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $entry: AddressEntry(errorOnState != "Y")
         AddressType(state == null || state matches "^[\\s]*$") from $entry.address
@@ -1414,13 +1092,6 @@ end
 
 rule 'All Addresses State Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         $entry: AddressEntry(errorOnState != "Y")
         AddressType(state != null, state not matches "^[\\s]*$", state not matches "^.{0,2}$") from $entry.address
@@ -1439,13 +1110,6 @@ end
 
 rule 'All Addresses Zip Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         $entry: AddressEntry(errorOnZip != "Y")
         AddressType(zipCode == null || zipCode matches "^[\\s]*$") from $entry.address
@@ -1464,13 +1128,6 @@ end
 
 rule 'All Addresses Zip Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         $entry: AddressEntry(errorOnZip != "Y")
         AddressType(zipCode != null, zipCode not matches "^[\\s]*$", zipCode not matches "^.{0,10}$") from $entry.address
@@ -1489,13 +1146,6 @@ end
 
 rule 'All Alternate Addresses Attention To Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         $provider: ProviderInformationType( )
         AlternateAddressesType($addresses: address) from $provider.alternateAddresses
@@ -1513,14 +1163,6 @@ end
 
 rule 'All Alternate Addresses Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.1
- * @since Provider Enrollment Drools Front End Validation Part 3
- * v1.1 - should be applied on all cases
- */
     when
         $provider: ProviderInformationType( )
         AlternateAddressesType($addresses: address) from $provider.alternateAddresses
@@ -1537,13 +1179,6 @@ end
 
 rule 'All Phone Number Entries Must Be In A Valid Format'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         $entry: PhoneNumberEntry(phoneNumber not matches "([0-9]{3}) ([0-9]{3})-([0-9]{4})( ext [0-9]{1,3})?", validated != "Y")
         $report: ErrorReporter()
@@ -1560,13 +1195,6 @@ end
 
 rule 'Applicant Type should be INDIVIDUAL or ORGANIZATION'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         ProviderInformationType(applicantType == null)
         $report: ErrorReporter()
@@ -1581,13 +1209,6 @@ end
 
 rule 'Articles Of Incorporation Showing Non-Profit Status Is Required For The Specified Provider Types II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType in (ProviderType.COMMUNITY_HEALTH_CLINIC.value(), ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()))
@@ -1605,13 +1226,6 @@ end
 
 rule 'Articles Of Incorporation Showing Non-Profit Status Is Required For The Specified Provider Types'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType in (ProviderType.COMMUNITY_HEALTH_CLINIC.value(), ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()))
@@ -1628,13 +1242,6 @@ end
 
 rule 'Assert alternate addresses'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
 salience 10
      when
         $provider: ProviderInformationType(alternateAddresses == null)
@@ -1646,13 +1253,6 @@ end
 
 rule 'Assert empty profile for individual applicants if personal data is not provided'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         IsIndividual($provider : provider)
         $applicantInformation: ApplicantInformationType(personalInformation  == null) from $provider.applicantInformation
@@ -1663,13 +1263,6 @@ dialect 'mvel'
 end
 
 rule 'Assert empty profile for organizations if data is not provided'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 salience 10
 dialect 'mvel'
     when
@@ -1683,13 +1276,6 @@ end
 
 rule 'Assert enrollment contact information'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         $enrollment: EnrollmentType(contactInformation == null)
     then
@@ -1700,13 +1286,6 @@ end
 
 rule 'Assert Full Validation Mode For Individuals'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         not LookupEntry( type == "UISection" )
         IsIndividual()
@@ -1722,13 +1301,6 @@ end
 
 rule 'Assert Full Validation Mode For Organizations'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         not LookupEntry( type == "UISection" )
         IsOrganization()
@@ -1747,13 +1319,6 @@ end
 
 rule 'Assert Partial Validation For Only Requested UI sections'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         $section : LookupEntry( type == "UISection" )
     then
@@ -1763,13 +1328,6 @@ end
 
 rule 'Assert provider applicant information'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
 salience 10
     when
         $provider: ProviderInformationType(applicantInformation == null)
@@ -1781,13 +1339,6 @@ end
 
 rule 'Assigned Agency Id Is Asked Only For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 salience 10
     when
     then
@@ -1797,13 +1348,6 @@ end
 
 rule 'Assigned Agency Id Must Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         ProviderInformationType(assignedAgencyId != null, assignedAgencyId not matches "^[\\s]*$")
         IsOrganization($provider : provider)
@@ -1820,13 +1364,6 @@ end
 
 rule 'At Least 1 Qualified Professional Must Be Provided'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -1845,13 +1382,6 @@ end
 
 rule 'At Least One Beneficial Owner Is Required I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -1869,13 +1399,6 @@ end
 
 rule 'At Least One Beneficial Owner Is Required II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -1894,13 +1417,6 @@ end
 
 rule 'At Least One Contract, Certification Must Be Provided For County Contracted Mental Health Rehab I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType in
@@ -1921,13 +1437,6 @@ end
 
 rule 'At Least One Contract, Certification Must Be Provided For County Contracted Mental Health Rehab II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType in
@@ -1949,13 +1458,6 @@ end
 
 rule 'At least one licensed physician member is required for Family Planning Agency'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         $provider: ProviderInformationType(providerType == ProviderType.FAMILY_PLANNING_AGENCY.value())
@@ -1974,13 +1476,6 @@ end
 rule 'At least One Member Info Is Required I'
 dialect 'mvel'
 activation-group "member-info-license-required"
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -1999,13 +1494,6 @@ end
 rule 'At least One Member Info Is Required II'
 dialect 'mvel'
 activation-group "member-info-license-required"
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2024,13 +1512,6 @@ end
 
 rule 'At Least One Pay-To Provider Is Required I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -2048,13 +1529,6 @@ end
 
 rule 'At Least One Pay-To Provider Is Required II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -2073,13 +1547,6 @@ end
 
 rule 'Authorized Representative Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
@@ -2096,13 +1563,6 @@ end
 
 rule 'Authorized Representative Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
@@ -2119,13 +1579,6 @@ end
 
 rule 'Authorized Representative Title Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
@@ -2142,13 +1595,6 @@ end
 
 rule 'Authorized Representative Title Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
@@ -2165,13 +1611,6 @@ end
 
 rule 'Background Study Is Required For Personal Care Provider Organizations'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value())
@@ -2224,13 +1663,6 @@ end
 
 rule 'Beneficial Owner Business Address is Required for Entity Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2250,13 +1682,6 @@ end
 
 rule 'Beneficial Owner Business Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2277,13 +1702,6 @@ end
 
 rule 'Beneficial Owner Date Of Birth Cannot Be A Future Date'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2324,13 +1742,6 @@ end
 
 rule 'Beneficial Owner Date Of Birth is Required for Person Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2350,13 +1761,6 @@ end
 
 rule 'Beneficial Owner Entity Info Is Required For Entity Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2375,13 +1779,6 @@ end
 
 rule 'Beneficial Owner FEIN Is Required For Entity Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2401,13 +1798,6 @@ end
 
 rule 'Beneficial Owner First Name is Required for Person Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2427,13 +1817,6 @@ end
 
 rule 'Beneficial Owner First Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2453,13 +1836,6 @@ end
 
 rule 'Beneficial Owner Full Legal Name Is Required For Entity Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2479,13 +1855,6 @@ end
 
 rule 'Beneficial Owner Full Legal Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2540,13 +1909,6 @@ end
 
 rule 'Beneficial Owner Last Name is Required for Person Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2566,13 +1928,6 @@ end
 
 rule 'Beneficial Owner Last Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2592,13 +1947,6 @@ end
 
 rule 'Beneficial Owner Middle Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2618,13 +1966,6 @@ end
 
 rule 'Beneficial Owner Other Interest  Provider Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2643,13 +1984,6 @@ end
 
 rule 'Beneficial Owner Other Interest Ownership Interest Percent Is Required If Other Interest Indicator Is Y'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2668,13 +2002,6 @@ end
 
 rule 'Beneficial Owner Other Interest Provider Address Is Required If Other Interest Indicator Is Y'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2693,13 +2020,6 @@ end
 
 rule 'Beneficial Owner Other Interest Provider Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2719,13 +2039,6 @@ end
 
 rule 'Beneficial Owner Other Interest Provider Name Is Required If Other Interest Indicator Is Y'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2744,13 +2057,6 @@ end
 
 rule 'Beneficial Owner Person Indicator Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2769,13 +2075,6 @@ end
 
 rule 'Beneficial Owner Personal Information is Required for Person Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2795,13 +2094,6 @@ end
 
 rule 'Beneficial Owner Relationship Type Must Be One Of the Following Values'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2820,13 +2112,6 @@ end
 
 rule 'Beneficial Owner Residential Address is Required for Person Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2846,13 +2131,6 @@ end
 
 rule 'Beneficial Owner Residential Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2873,13 +2151,6 @@ end
 
 rule 'Beneficial Owner SSN is Required for Person Owners'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2918,13 +2189,6 @@ end
 
 rule 'Beneficial Owner Type Description Is Required If Owner Type is Other'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2943,13 +2207,6 @@ end
 
 rule 'Beneficial Owner Type Description Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2968,13 +2225,6 @@ end
 
 rule 'Beneficial Owner Type Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -2993,13 +2243,6 @@ end
 
 rule 'Billing Address Index Must Reference An Existing Address'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -3017,13 +2260,6 @@ end
 
 rule 'Billing Address Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
@@ -3040,13 +2276,6 @@ end
 
 rule 'Billing Address Must Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
@@ -3063,13 +2292,6 @@ end
 
 rule 'Billing Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -3086,13 +2308,6 @@ end
 
 rule 'CCMHR Members Must All Be Enrolled'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         $provider: ProviderInformationType(providerType == ProviderType.COUNTY_CONTRACTED_MENTAL_HEALTH_REHAB.value())
@@ -3110,13 +2325,6 @@ end
 
 rule 'Certificate of compliance Is Required For CMHR treatment facility'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.CHILDRENS_MENTAL_HEALTH_RESIDENTIAL_TREATMENT_FACILITY.value())
@@ -3151,13 +2359,6 @@ end
 
 rule 'Class A License For Private Duty Nursing Services Is Required For PHN Org'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.PUBLIC_HEALTH_NURSING_ORGANIZATION.value())
@@ -3175,13 +2376,6 @@ end
 
 rule 'Class A Professional Home Care License Is Required For Home Health Agency'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.HOME_HEALTH_AGENCY.value())
@@ -3199,13 +2393,6 @@ end
 
 rule 'CLIA Attachment Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -3244,13 +2431,6 @@ end
 
 rule 'CLIA Certifications Are Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 salience 10
     when
     then
@@ -3264,9 +2444,6 @@ salience 10
         insertLogical(new ProviderTypeException("AskCLIACertificationsInfo", ProviderType.AMBULATORY_SURGICAL_CENTER.value()));
 end
 
-/**
- * Added by cyberjag - PESP-306
- */
 rule 'CLIA Certification is required'
 dialect 'mvel'
     when
@@ -3285,13 +2462,6 @@ end
 
 rule 'CLIA Certifications Must Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider)
@@ -3310,13 +2480,6 @@ end
 
 rule 'CLIA Copy Attachment Id Must Reference A Valid Attachment I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -3337,13 +2500,6 @@ end
 
 rule 'CLIA Copy Attachment Id Must Reference A Valid Attachment II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -3365,13 +2521,6 @@ end
 
 rule 'CLIA Number Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -3392,13 +2541,6 @@ end
 
 rule 'CLIA Number Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -3418,13 +2560,6 @@ end
 
 rule 'CMHC Members Must Be A Certified Mental Health Rehab Professional'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value())
@@ -3442,13 +2577,6 @@ end
 
 rule 'Community Health Board Indicator Must Be Answered In Y,N'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider )
@@ -3465,13 +2593,6 @@ end
 
 rule 'Complete Provider Name Is Required For Education Plans'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -3488,13 +2609,6 @@ dialect 'mvel'
 end
 
 rule 'Complete Provider Name Maximum Length Check'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
 dialect 'mvel'
     when
         IsOrganization($provider: provider)
@@ -3512,13 +2626,6 @@ end
 
 rule 'Contact Fax Number Must Be In A Valid Format'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         $enrollment: EnrollmentType()
         ContactInformationType($faxNumber: faxNumber, faxNumber != null) from $enrollment.contactInformation
@@ -3533,13 +2640,6 @@ end
 
 rule 'Contact Phone Number Must Be In A Valid Format'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         $enrollment: EnrollmentType()
         ContactInformationType($phoneNumber: phoneNumber, phoneNumber != null) from $enrollment.contactInformation
@@ -3554,13 +2654,6 @@ end
 
 rule 'Contract with county is required for CMHR treatment facility'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider, provider.providerType == ProviderType.CHILDRENS_MENTAL_HEALTH_RESIDENTIAL_TREATMENT_FACILITY.value())
@@ -3577,13 +2670,6 @@ dialect 'mvel'
 end
 
 rule 'Contract With County Is Required II'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 8
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -3603,13 +2689,6 @@ dialect 'mvel'
 end
 
 rule 'Contract With County Is Required'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -3629,13 +2708,6 @@ dialect 'mvel'
 end
 
 rule 'Contract With County Must be left empty'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -3657,13 +2729,6 @@ end
 
 rule 'Contract,Certificate Begin Date Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider)
@@ -3701,13 +2766,6 @@ end
 
 rule 'Contract, Certificate Copy Attachment Id Must Reference A Valid Attachment I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider)
@@ -3727,13 +2785,6 @@ end
 
 rule 'Contract, Certificate Copy Attachment Id Must Reference A Valid Attachment II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider)
@@ -3792,13 +2843,6 @@ end
 
 rule 'Contract, Certificate Name Must Be One Of The Accepted Values'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider)
@@ -3825,13 +2869,6 @@ end
 
 rule 'Contracts And Certificates Should Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType not in
@@ -3852,13 +2889,6 @@ end
 
 rule 'Copy Of Childrens Mental Health Residential Treatment county contract Is Required For CMHR Treatment Facility'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider, provider.providerType == ProviderType.CHILDRENS_MENTAL_HEALTH_RESIDENTIAL_TREATMENT_FACILITY.value())
@@ -3876,13 +2906,6 @@ end
 
 rule 'Copy Of Contract Must Reference A Valid Attachment I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -3902,13 +2925,6 @@ end
 
 rule 'Copy Of Contract Must Reference A Valid Attachment II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -3929,13 +2945,6 @@ end
 
 rule 'Copy Of Contract With County Is Required If Eligible Program Type Is A County Contracted Provider'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
@@ -3954,13 +2963,6 @@ end
 
 rule 'Copy Of Contract With County Is Required If Facility Type Is A County Contracted Provider'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider, provider.providerType == ProviderType.DAY_TREATMENT.value())
@@ -3978,13 +2980,6 @@ end
 
 rule 'Copy Of Contract,Certificate Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider)
@@ -4003,13 +2998,6 @@ end
 
 rule 'Copy Of DHS Contract Is Required If Community Health Board Is Y'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider )
@@ -4028,13 +3016,6 @@ end
 
 rule 'Copy Of Program Contract Must Reference A Valid Attachment I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization()
@@ -4054,13 +3035,6 @@ end
 
 rule 'Copy Of Program Contract Must Reference A Valid Attachment II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -4081,13 +3055,6 @@ end
 
 rule 'Copy Of Selected Contract Cover Sheet Must Be Provided'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -4107,13 +3074,6 @@ end
 
 rule 'Copy Of Selected Contract Cover Sheet Must Reference A Valid Attachment I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -4134,13 +3094,6 @@ end
 
 rule 'Copy Of Selected Contract Cover Sheet Must Reference A Valid Attachment II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -4231,13 +3184,6 @@ end
 
 rule 'Date of Birth is Required for Individual Applicant'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -4254,13 +3200,6 @@ end
 
 rule 'Day Training And Habilitation License Is required for Day Training And Habilitation, Day Activity Center'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.DAY_TRAINING_AND_HABILITATION_DAY_ACTIVITY_CENTER.value())
@@ -4278,13 +3217,6 @@ end
 
 rule 'DBA Name Is Required For PCPO'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider, provider.providerType == ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value())
@@ -4333,13 +3265,6 @@ end
 
 
 rule 'DBA Name Maximum Length Check'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         IsOrganization($provider: provider, provider.providerType == ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value())
@@ -4355,13 +3280,6 @@ dialect 'mvel'
 end
 
 rule 'Define Agency Applications'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 dialect 'mvel'
 salience 10
     when
@@ -4372,13 +3290,6 @@ end
 
 rule 'Define Categories Of Service For Home And Community Based Services'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 salience 10
     when
     then
@@ -4413,13 +3324,6 @@ end
 
 rule 'Define Clinical Services Options For Adult Day Treatment Application'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 salience 10
     when
     then
@@ -4435,13 +3339,6 @@ end
 
 rule 'Define Dual License Additional Category For Clinical Social Worker'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
 salience 10
     when
         ProviderInformationType($providerType: providerType, providerType == ProviderType.LICENSED_INDEPENDENT_CLINICAL_SOCIAL_WORKER.value())
@@ -4452,13 +3349,6 @@ end
 
 rule 'Define Dual License Additional Category For Psychologist'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
 salience 10
     when
         ProviderInformationType($providerType: providerType, providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
@@ -4470,13 +3360,6 @@ end
 
 rule 'Define Education Plan Organizations'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
 salience 10
     when
     then
@@ -4486,13 +3369,6 @@ end
 
 rule 'Define Eligible Recipients For Adult Day Treatment Application'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 salience 10
     when
     then
@@ -4502,13 +3378,6 @@ end
 
 rule 'Define Exceptions For Certification Certificate of Clinical Competence (CCC)'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
 salience 10
     when
     then
@@ -4527,13 +3396,6 @@ salience 10
 end
 
 rule 'Define Non-Practice Organizations'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
 salience 10
     when
@@ -4594,13 +3456,6 @@ end
 
 rule 'Define Possible Specialties For Dentist'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
 salience 10
     when
         ProviderInformationType($providerType: providerType, providerType == ProviderType.DENTIST.value())
@@ -4617,13 +3472,6 @@ end
 
 rule 'Define Possible Specialties For Licensed Psychologists'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
 salience 10
     when
         ProviderInformationType($providerType: providerType, providerType == ProviderType.LICENSED_PSYCHOLOGIST.value())
@@ -4634,13 +3482,6 @@ end
 
 rule 'Define Possible Specialties For Nurse Midwife'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
 salience 10
     when
         ProviderInformationType($providerType: providerType, providerType == ProviderType.NURSE_MIDWIFE.value())
@@ -4651,13 +3492,6 @@ end
 
 rule 'Define Possible Specialties For Nurse Practitioner'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 salience 10
     when
         ProviderInformationType($providerType: providerType, providerType == ProviderType.NURSE_PRACTITIONER.value())
@@ -4675,13 +3509,6 @@ end
 
 rule 'Define Possible Specialties For Occupational Therapist'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 salience 10
     when
         ProviderInformationType($providerType: providerType, providerType == ProviderType.OCCUPATIONAL_THERAPIST.value())
@@ -4692,13 +3519,6 @@ end
 
 rule 'Define Possible Specialties For Physician'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
 salience 10
     when
         ProviderInformationType($providerType: providerType, providerType == ProviderType.PHYSICIAN.value())
@@ -4748,13 +3568,6 @@ end
 
 rule 'Define Private Practice Indicator Exception For Allied Dental Professionals'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 salience 10
     when
     then
@@ -4764,13 +3577,6 @@ end
 
 rule 'Define Private Practice Indicator Exception For Community Health Care Workers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 salience 10
     when
     then
@@ -4780,13 +3586,6 @@ end
 
 rule 'Define Private Practice Indicator Exception For Physician Assistant'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 salience 10
     when
     then
@@ -4796,13 +3595,6 @@ end
 
 rule 'Define Provider Types That Can Enter Specialty Certifications'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
 salience 10
     when
         ProviderInformationType($providerType: providerType,
@@ -4826,13 +3618,6 @@ end
 
 rule 'Define Service Unit Options For Adult Day Treatment Application'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 salience 10
     when
     then
@@ -4844,13 +3629,6 @@ end
 
 rule 'Define Supervision Options For Adult Day Treatment Application'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
 salience 10
     when
     then
@@ -4895,13 +3673,6 @@ end
 
 rule 'DHS-4646 Is Required For These Provider Types I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         $provider: ProviderInformationType(providerType == ProviderType.CHILD_AND_TEEN_CHECKUP_CLINIC.value())
@@ -4919,13 +3690,6 @@ end
 
 rule 'DHS-4646 Is Required For These Provider Types II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         $provider: ProviderInformationType(providerType == ProviderType.CHILD_AND_TEEN_CHECKUP_CLINIC.value())
@@ -4942,13 +3706,6 @@ end
 
 rule 'DHS-5748 Must Be Signed For These Provider Types I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value())
@@ -4965,13 +3722,6 @@ end
 
 rule 'DHS-5748 Must Be Signed For These Provider Types II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value())
@@ -4989,13 +3739,6 @@ end
 
 rule 'Disclosure Question 1 Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
@@ -5012,13 +3755,6 @@ end
 
 rule 'Disclosure Question 1 Must Be Answered In Y,N'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
@@ -5035,13 +3771,6 @@ end
 
 rule 'Disclosure Question 2 Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
@@ -5058,13 +3787,6 @@ end
 
 rule 'Disclosure Question 2 Must Be Answered In Y,N'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
@@ -5081,13 +3803,6 @@ end
 
 rule 'Disclosure Question 3 Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
@@ -5104,13 +3819,6 @@ end
 
 rule 'Disclosure Question 3 Must Be Answered In Y,N'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual()
@@ -5127,13 +3835,6 @@ end
 
 rule 'Doing Business As Is Required For Organizations'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider, provider.providerType not in (
@@ -5157,13 +3858,6 @@ dialect 'mvel'
 end
 
 rule 'Doing Business As Maximum Length Check'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         IsOrganization($provider: provider, provider.providerType not in (
@@ -5203,13 +3897,6 @@ end
 
 rule 'Eighteen Years Old And Above Must Be Answered For Specified Provider Types'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider, provider.providerType == ProviderType.PERSONAL_CARE_ASSISTANT.value())
@@ -5226,13 +3913,6 @@ end
 
 rule 'Eighteen Years Old And Above Must Be Answered In Y,N'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual()
@@ -5249,13 +3929,6 @@ end
 
 rule 'Eligible Program Type Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
@@ -5273,13 +3946,6 @@ end
 
 rule 'Eligible Program Type Must Be One Of The Following Values'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
@@ -5298,13 +3964,6 @@ end
 
 rule 'Email Address Format Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         IsIndividual($provider : provider)
         $individual: IndividualApplicantType()
@@ -5323,13 +3982,6 @@ end
 
 rule 'Email Address Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         IsIndividual($provider : provider)
         $individual: IndividualApplicantType()
@@ -5425,13 +4077,6 @@ end
 
 rule 'Enrollment Contact Email Address Format Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         $enrollment: EnrollmentType()
         ContactInformationType(emailAddress != null, emailAddress not matches "^[\\s]*$",
@@ -5449,13 +4094,6 @@ end
 
 rule 'Enrollment Contact Email Address Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         $enrollment: EnrollmentType()
         ContactInformationType(emailAddress not matches "^.{0,100}$") from $enrollment.contactInformation
@@ -5471,13 +4109,6 @@ end
 
 rule 'Enrollment Contact Name  Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         $enrollment: EnrollmentType()
         ContactInformationType(name != null, name not matches "^.{0,100}$") from $enrollment.contactInformation
@@ -5493,14 +4124,6 @@ end
 
 rule 'Enrollment Contact Name is required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.1
- * @since Provider Enrollment Drools Front End Validation Part 1
- * v1.1 added organization support
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value() || value == UISection.ORGANIZATION_INFORMATION.value())
         $enrollment: EnrollmentType()
@@ -5516,13 +4139,6 @@ dialect 'mvel'
 end
 
 rule 'Enrollment Contact Phone Number Is Required For Organizations'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
@@ -5593,13 +4209,6 @@ end
 
 rule 'Entity Description Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -5616,13 +4225,6 @@ end
 
 rule 'Entity Sub Type Must Be One Of the Following Values For A Professional Association'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -5641,13 +4243,6 @@ end
 
 rule 'Entity Type Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -5665,13 +4260,6 @@ end
 
 rule 'Entity Type Must Be One Of the Following Values'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -5689,13 +4277,6 @@ end
 
 rule 'Facility Capacity Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 salience 10
     when
     then
@@ -5705,13 +4286,6 @@ end
 
 rule 'Facility Credentials Are Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 salience 10
     when
     then
@@ -5757,13 +4331,6 @@ end
 
 rule 'Facility Credentials Are Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider)
@@ -5781,13 +4348,6 @@ end
 
 rule 'Facility License Copy Attachment Id Must Reference A Valid Attachment I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -5808,13 +4368,6 @@ end
 
 rule 'Facility License Copy Attachment Id Must Reference A Valid Attachment II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -5836,13 +4389,6 @@ end
 
 rule 'Facility License Copy Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -5862,13 +4408,6 @@ end
 
 rule 'Facility License Issuing State Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -5888,13 +4427,6 @@ end
 
 rule 'Facility License Issuing State Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -5914,13 +4446,6 @@ end
 
 rule 'Facility License Number Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -5940,13 +4465,6 @@ end
 
 rule 'Facility License Number Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -6088,13 +4606,6 @@ end
 
 rule 'Facility License Type Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -6114,13 +4625,6 @@ end
 
 rule 'Facility Licenses Must Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider)
@@ -6138,13 +4642,6 @@ end
 
 rule 'Facility Type Is Required For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider, provider.providerType == ProviderType.DAY_TREATMENT.value())
@@ -6161,13 +4658,6 @@ end
 
 rule 'Facility Type Must Be One Of The Following Values'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider : provider, provider.providerType == ProviderType.DAY_TREATMENT.value())
@@ -6185,13 +4675,6 @@ end
 
 rule 'Fax Number Must Be In A Valid Format'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         IsIndividual($provider : provider)
         $individual: IndividualApplicantType()
@@ -6208,13 +4691,6 @@ end
 
 rule 'First Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         IsIndividual($provider : provider)
         IndividualApplicantType(firstName != null, firstName not matches "^.{0,50}$")
@@ -6230,13 +4706,6 @@ end
 
 rule 'Fiscal Year End Is Required For Education Plans'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -6286,13 +4755,6 @@ end
 
 rule 'Fiscal Year End Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
@@ -6309,13 +4771,6 @@ end
 
 rule 'Fiscal Year End Must Be In A Valid Format'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -6332,13 +4787,6 @@ end
 
 rule 'Fiscal Year End Must Be In The Patter MM,DD'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -6356,13 +4804,6 @@ end
 
 rule 'Fiscal Year End Should Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
@@ -6379,13 +4820,6 @@ end
 
 rule 'For Corporation, LLC, Limit The Beneficial Owner Types To The Following'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -6406,13 +4840,6 @@ end
 
 rule 'For Entity Owners, Beneficial Owner Type Must Be One Of the Following Values'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -6433,13 +4860,6 @@ end
 
 rule 'For Hospital Based, Limit The Beneficial Owner Types To The Following'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -6460,13 +4880,6 @@ end
 
 rule 'For Non-Profit Organizations, Limit The Beneficial Owner Types To The Following'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -6487,13 +4900,6 @@ end
 
 rule 'For Partnership, Limit The Beneficial Owner Types To The Following'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -6513,21 +4919,7 @@ dialect 'mvel'
 end
 
 rule 'For Person Owners, Beneficial Owner Type Must Be One Of the Following Values'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -6548,13 +4940,6 @@ end
 
 rule 'For Public, Limit The Beneficial Owner Types To The Following'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -6575,13 +4960,6 @@ end
 
 rule 'For Sole Proprietorship, Limit The Beneficial Owner Types To The Following'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -6602,13 +4980,6 @@ end
 
 rule 'For State Owned, Limit The Beneficial Owner Types To The Following'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -6629,13 +5000,6 @@ end
 
 rule 'Group Affiliation Address Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -6654,13 +5018,6 @@ end
 
 rule 'Group Affiliation Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -6680,13 +5037,6 @@ end
 
 rule 'Group Affiliation Group Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -6705,13 +5055,6 @@ end
 
 rule 'Group Affiliation Group Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -6730,13 +5073,6 @@ end
 
 rule 'Group Affiliation Group NPI Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -6790,13 +5126,6 @@ end
 
 rule 'HCFA Medicare Certification Is Required For Home Health Agency'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.HOME_HEALTH_AGENCY.value())
@@ -6814,13 +5143,6 @@ end
 
 rule 'Head Start Agency Certification Is Required For Head Start'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.HEAD_START.value())
@@ -7006,13 +5328,6 @@ end
 
 rule 'Highest Degree Earned Should Only Be Asked For Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
 salience -10
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
@@ -7030,13 +5345,6 @@ end
 
 rule 'Independent or Portable X-ray Certificationfrom CMS Is Required For X-Ray Services'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.X_RAY_SERVICES.value())
@@ -7053,13 +5361,6 @@ dialect 'mvel'
 end
 
 rule 'Individual Member Info Is Asked For Rehabilitation Agency If CORF Certificate Is Provided'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
 salience 10
     when
@@ -7074,13 +5375,6 @@ end
 
 rule 'Individual Member Info Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 salience 10
     when
     then
@@ -7117,13 +5411,6 @@ end
 
 rule 'Infer individual'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
 salience 20
     when
         $provider: ProviderInformationType(applicantType == ApplicantType.INDIVIDUAL)
@@ -7134,13 +5421,6 @@ end
 
 rule 'Infer IndividualApplicantType for individuals'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         IsIndividual($provider : provider)
         $applicantInformation: ApplicantInformationType( ) from $provider.applicantInformation
@@ -7151,13 +5431,6 @@ dialect 'mvel'
 end
 
 rule 'Infer Organization'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 salience 20
 dialect 'mvel'
     when
@@ -7169,13 +5442,6 @@ end
 
 rule 'Infer OrganizationApplicantType for organizations'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         IsOrganization($provider : provider)
         $applicantInformation: ApplicantInformationType( ) from $provider.applicantInformation
@@ -7187,13 +5453,6 @@ end
 
 rule 'Issuing Board Is Required For Specialty Certification'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType()
@@ -7212,13 +5471,6 @@ end
 
 rule 'Issuing State Is Required If There Is No Exeption Defined For License'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType()
@@ -7238,13 +5490,6 @@ end
 
 rule 'Issuing State Is Required If There Is No Exeption Defined For Tribal License'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType()
@@ -7265,13 +5510,6 @@ end
 
 rule 'Last Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         IsIndividual($provider : provider)
         IndividualApplicantType(lastName != null, lastName not matches "^.{0,50}$")
@@ -7287,13 +5525,6 @@ end
 
 rule 'Leave Agency Information Empty If Not PCA'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_INFORMATION.value())
         ProviderInformationType(agencyInformation != null, providerType != ProviderType.PERSONAL_CARE_ASSISTANT.value())
@@ -7309,13 +5540,6 @@ end
 
 rule 'Legal Name Is Required For Organizations'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider, provider.providerType not in (
@@ -7336,13 +5560,6 @@ dialect 'mvel'
 end
 
 rule 'Legal Name Maximum Length Check'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         IsOrganization($provider: provider, provider.providerType not in (
@@ -7364,13 +5581,6 @@ end
 
 rule 'License Copy Attachment Id Must Reference A Valid Attachment I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType()
@@ -7390,13 +5600,6 @@ end
 
 rule 'License Copy Attachment Id Must Reference A Valid Attachment II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -7455,13 +5658,6 @@ end
 
 rule 'License Issuing State Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType()
@@ -7518,13 +5714,6 @@ end
 
 rule 'License Number Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -7601,13 +5790,6 @@ end
 
 rule 'License Original Issue Date Is Required If There Is No Exeption Defined For License'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -7627,13 +5809,6 @@ end
 
 rule 'License Original Issue Date Is Required If There Is No Exeption Defined For Certificate Type'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -7653,13 +5828,6 @@ end
 
 rule 'License Renewal Date Is Required If There Is No Exeption Defined For License'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType()
@@ -7699,13 +5867,6 @@ end
 
 rule 'License Specialty Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -7724,13 +5885,6 @@ end
 
 rule 'License Specialty Should Be Left Empty For Provider Types That do not allow Specialty Certificates'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -7750,13 +5904,6 @@ end
 
 rule 'License Type Is Required For Provider Types That do not allow Specialty Certificates'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -7776,13 +5923,6 @@ end
 
 rule 'License Type Is Required If Defined Specialty Certificate Behavior Is AND'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -7802,13 +5942,6 @@ end
 
 rule 'License Type Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -7827,13 +5960,6 @@ end
 
 rule 'Limit Additional Categories Requested To Defined Provider Types'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -7871,14 +5997,6 @@ end
 
 rule 'Maximum of 2 Alternate Mailing Addresses are allowed'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.1
- * @since Provider Enrollment Drools Front End Validation Part 3
- * v1.1 - should be applied on all cases
- */
     when
         $provider: ProviderInformationType( )
         AlternateAddressesType( address.size() > 2 ) from $provider.alternateAddresses
@@ -7894,13 +6012,6 @@ end
 
 rule 'Medicare Approval Letter Is Required For Rehabilitation Agencies'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.REHABILITATION_AGENCY.value())
@@ -7918,13 +6029,6 @@ end
 
 rule 'Medicare Approval Letter Is Required For Rural Health Clinics'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.RURAL_HEALTH_CLINIC.value())
@@ -7942,13 +6046,6 @@ end
 
 rule 'Medicare Certification For Home Health Aide And Skilled Nursing Services Is Required For PHN Org'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.PUBLIC_HEALTH_NURSING_ORGANIZATION.value())
@@ -7966,13 +6063,6 @@ end
 
 rule 'Medicare Certification Is Required For Ambulatory Surgical Center'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.AMBULATORY_SURGICAL_CENTER.value())
@@ -7990,13 +6080,6 @@ end
 
 rule 'Member Date Of Birth Cannot Be A Future Date'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -8036,13 +6119,6 @@ end
 
 rule 'Member Date Of Birth Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -8081,13 +6157,6 @@ end
 
 rule 'Member Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -8106,13 +6175,6 @@ end
 
 rule 'Member Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null ) from $provider.memberInformation
@@ -8130,13 +6192,6 @@ end
 
 rule 'Member NPI Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -8188,13 +6243,6 @@ end
 
 rule 'Member Provider Type Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         IsOrganization($provider : provider)
         MemberInformationType($memberList : groupMember, groupMember != null) from $provider.memberInformation
@@ -8213,13 +6261,6 @@ end
 
 rule 'Member Provider Type Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -8238,13 +6279,6 @@ end
 
 rule 'Member SSN Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -8318,13 +6352,6 @@ end
 
 rule 'Middle Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         IsIndividual($provider : provider)
         IndividualApplicantType(middleName != null, middleName not matches "^.{0,50}$")
@@ -8340,13 +6367,6 @@ end
 
 rule 'Minimum of 2 licensed and enrolled CRNAs working at the clinic Is Required For CRNA group'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         $provider: ProviderInformationType(providerType == ProviderType.CERTIFIED_REGISTERED_NURSE_ANESTHETIST_GROUP.value())
@@ -8366,13 +6386,6 @@ end
 
 rule 'Name Of Person Accomplishing Form Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -8390,13 +6403,6 @@ end
 
 rule 'Name Of Person Accomplishing Form Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -8413,13 +6419,6 @@ end
 
 rule 'Notification For Authorization Request And Service Agreements Must Reference An Existing Address'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -8437,13 +6436,6 @@ end
 
 rule 'Notification For Credentials Enrollment Status Must Reference An Existing Address'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -8461,13 +6453,6 @@ end
 
 rule 'Notification For Provider Correspondence Must Reference An Existing Address'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -8485,13 +6470,6 @@ end
 
 rule 'Notification For Reimbursement Check Must Reference An Existing Address'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -8509,13 +6487,6 @@ end
 
 rule 'Notification For Remittance Advice Must Reference An Existing Address'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.MAILING_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -8533,13 +6504,6 @@ end
 
 rule 'NPI Is Required for Unless An Exception Is Defined'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value() || value == UISection.ORGANIZATION_INFORMATION.value())
         $provider: ProviderInformationType($npi : NPI, $npi == null || $npi matches "^[\\s]*$" )
@@ -8632,13 +6596,6 @@ end
 
 
 rule 'Number Of Beds Effective Date Should Be Left Empty'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -8656,13 +6613,6 @@ dialect 'mvel'
 end
 
 rule 'Number Of Beds Is Required'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -8681,13 +6631,6 @@ dialect 'mvel'
 end
 
 rule 'Number Of Beds Should Be Left Empty'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -8707,13 +6650,6 @@ end
 
 rule 'Off-site Approval Letter From Medicare Is Required For Independent Diagnostic Testing Facility'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.INDEPENDENT_DIAGNOSTIC_TESTING_FACILITY.value())
@@ -8731,13 +6667,6 @@ end
 
 rule 'Organization Address Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -8757,13 +6686,6 @@ end
 
 rule 'Organization Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -8781,13 +6703,6 @@ dialect 'mvel'
 end
 
 rule 'Organization Contact Information Is Required'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
@@ -8805,13 +6720,6 @@ end
 
 rule 'Organization County Is Required For Education Plans'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -8859,13 +6767,6 @@ end
 
 rule 'Organization County Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -8882,13 +6783,6 @@ end
 
 rule 'Organization Disclosure Question 1 Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization($provider : provider)
@@ -8905,13 +6799,6 @@ dialect 'mvel'
 end
 
 rule 'Organization Disclosure Question 1 Must Be Answered In Y,N'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
@@ -8929,13 +6816,6 @@ end
 
 rule 'Organization Disclosure Question 2 Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization($provider : provider)
@@ -8952,13 +6832,6 @@ dialect 'mvel'
 end
 
 rule 'Organization Disclosure Question 2 Must Be Answered In Y,N'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
@@ -8976,13 +6849,6 @@ end
 
 rule 'Organization Disclosure Question 3 Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization($provider : provider)
@@ -8999,13 +6865,6 @@ dialect 'mvel'
 end
 
 rule 'Organization Disclosure Question 3 Must Be Answered In Y,N'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
@@ -9023,13 +6882,6 @@ end
 
 rule 'Organization Disclosure Question 4 Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization($provider : provider)
@@ -9046,13 +6898,6 @@ dialect 'mvel'
 end
 
 rule 'Organization Disclosure Question 4 Must Be Answered In Y,N'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
@@ -9070,13 +6915,6 @@ end
 
 rule 'Organization Disclosure Question 5 Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization($provider : provider)
@@ -9093,13 +6931,6 @@ dialect 'mvel'
 end
 
 rule 'Organization Disclosure Question 5 Must Be Answered In Y,N'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
@@ -9117,13 +6948,6 @@ end
 
 rule 'Organization Disclosure Question 6 Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
         IsOrganization($provider : provider)
@@ -9140,13 +6964,6 @@ dialect 'mvel'
 end
 
 rule 'Organization Disclosure Question 6 Must Be Answered In Y,N'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_DISCLOSURE.value())
@@ -9164,13 +6981,6 @@ end
 
 rule 'Organization Fax Number Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
@@ -9187,13 +6997,6 @@ end
 
 rule 'Organization FEIN Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
@@ -9210,13 +7013,6 @@ end
 
 rule 'Organization FEIN Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
@@ -9232,13 +7028,6 @@ end
 
 rule 'Organization Fiscal Year End Must Be In The Format MM DD'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         ProviderInformationType(fiscalYearEnd != null, fiscalYearEnd not matches "^[\\d]{2}/[\\d]{2}$")
@@ -9254,13 +7043,6 @@ end
 
 rule 'Organization Name Is Required For Organizations'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -9278,13 +7060,6 @@ dialect 'mvel'
 end
 
 rule 'Organization Name Maximum Length Check'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 dialect 'mvel'
     when
         IsOrganization($provider: provider)
@@ -9303,13 +7078,6 @@ end
 
 rule 'Organization Phone Number Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
@@ -9327,13 +7095,6 @@ end
 
 rule 'Organization Phone Number Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
@@ -9390,13 +7151,6 @@ end
 
 rule 'Organization Practice Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider)
@@ -9415,13 +7169,6 @@ end
 
 rule 'Organization Provider Statement Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_PROVIDER_STATEMENT.value())
         IsOrganization($provider : provider)
@@ -9438,13 +7185,6 @@ end
 
 rule 'Organization State Tax ID Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
@@ -9461,13 +7201,6 @@ end
 
 rule 'Organizational Provider Disclosure Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 salience 10
     when
     then
@@ -9509,13 +7242,6 @@ salience 10
 end
 
 rule 'Owned Property Address Is Required'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
@@ -9534,13 +7260,6 @@ dialect 'mvel'
 end
 
 rule 'Owned Property Address Must Be Valid'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
@@ -9560,13 +7279,6 @@ dialect 'mvel'
 end
 
 rule 'Owned Property Name Is Required'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
@@ -9585,13 +7297,6 @@ dialect 'mvel'
 end
 
 rule 'Owned Property Name Maximum Length Check'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
@@ -9611,13 +7316,6 @@ end
 
 rule 'Ownership Information Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -9635,13 +7333,6 @@ end
 
 rule 'Ownership Information Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 salience 10
     when
     then
@@ -9698,13 +7389,6 @@ end
 
 rule 'Ownership Interest Percent Is Required If Beneficial Owner Type Is Owner - 5% or more'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -9722,13 +7406,6 @@ dialect 'mvel'
 end
 
 rule 'Ownership Type Is Required'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
@@ -9747,13 +7424,6 @@ dialect 'mvel'
 end
 
 rule 'Ownership Type Must Be One Of The Supported Values'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
@@ -9773,13 +7443,6 @@ end
 
 rule 'Pay-To Contact Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -9798,13 +7461,6 @@ end
 
 rule 'Pay-To Contact Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -9861,13 +7517,6 @@ end
 
 rule 'Pay-To Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -9886,13 +7535,6 @@ end
 
 rule 'Pay-To Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -9965,13 +7607,6 @@ end
 
 rule 'Pay-To Phone Number Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -9990,13 +7625,6 @@ end
 
 rule 'Pay-To Phone Number Must Be In A Valid Format'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -10014,13 +7642,6 @@ end
 
 rule 'Pay-To Providers Should Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -10039,13 +7660,6 @@ end
 
 rule 'Pay-To Type Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -10064,13 +7678,6 @@ end
 
 rule 'Pay-To Type Must Be One Of the Following Values'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_SETUP.value())
         IsOrganization($provider : provider)
@@ -10170,13 +7777,6 @@ end
 
 rule 'PCA Billing Person Designation Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 salience 10
     when
     then
@@ -10186,13 +7786,6 @@ end
 
 rule 'PCA Billing Person Is Required I'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( $provider : provider )
@@ -10210,13 +7803,6 @@ end
 
 rule 'PCA Billing Person Is Required II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( $provider : provider )
@@ -10235,13 +7821,6 @@ end
 
 rule 'PCA Billing Person Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( $provider : provider )
@@ -10261,13 +7840,6 @@ end
 
 rule 'PCA Billing Person Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( $provider : provider )
@@ -10287,13 +7859,6 @@ end
 
 rule 'PCA Billing Person SSN Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( $provider : provider )
@@ -10332,13 +7897,6 @@ end
 
 rule 'PCA Billing Person Title Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( $provider : provider )
@@ -10358,13 +7916,6 @@ end
 
 rule 'PCA Billing Person Title Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization( $provider : provider )
@@ -10383,13 +7934,6 @@ dialect 'mvel'
 end
 
 rule 'PCA Training certification is required for PCA.'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
@@ -10407,13 +7951,6 @@ dialect 'mvel'
 end
 
 rule 'Pharmacist license or specialty certification is required for pharmacists.'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
@@ -10432,13 +7969,6 @@ end
 
 rule 'Pharmacy License Is Required For Pharmacy'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.PHARMACY.value())
@@ -10455,13 +7985,6 @@ dialect 'mvel'
 end
 
 rule 'PHN Copy Of Contract With County Is Required If County Indicator is N'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -10481,13 +8004,6 @@ dialect 'mvel'
 end
 
 rule 'PHN County Indicator Is Required'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -10507,13 +8023,6 @@ dialect 'mvel'
 end
 
 rule 'PHN County Name Is Required If County Indicator Is Y'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -10533,13 +8042,6 @@ dialect 'mvel'
 end
 
 rule 'PHN County Name Maximum Length Check'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
@@ -10560,13 +8062,6 @@ end
 
 rule 'PHN Form Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 salience 10
     when
     then
@@ -10576,13 +8071,6 @@ end
 
 rule 'Phone Number Must Be In A Valid Format'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         IsIndividual($provider : provider)
         $individual: IndividualApplicantType()
@@ -10598,13 +8086,6 @@ end
 
 rule 'Physical Rehabilitative Provider Members Must Have One Of The Following Types'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.INDIVIDUAL_MEMBER_INFORMATION.value())
         $provider: ProviderInformationType(providerType == ProviderType.BILLING_ENTITY_FOR_PHYSICAL_REHABILITATIVE_PROVIDERS.value())
@@ -10631,13 +8112,6 @@ end
 
 rule 'Practice Address Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -10675,13 +8149,6 @@ end
 
 rule 'Practice Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -10699,13 +8166,6 @@ end
 
 rule 'Practice Contact Information Is Required.'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -10722,13 +8182,6 @@ end
 
 rule 'Practice FAX Number Must Be In A Valid Format'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -10745,13 +8198,6 @@ end
 
 rule 'Practice FEIN Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -10768,13 +8214,6 @@ end
 
 rule 'Practice FEIN Should Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
@@ -10867,13 +8306,6 @@ end
 
 rule 'Practice Information Must Be Provided For Individual Applicants'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -10890,13 +8322,6 @@ end
 
 rule 'Practice Phone Number Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -10914,13 +8339,6 @@ end
 
 rule 'Practice Phone Number Must Be In A Valid Format'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -10937,13 +8355,6 @@ end
 
 rule 'Primary Practice Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
@@ -10960,13 +8371,6 @@ end
 
 rule 'Primary Practice Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
@@ -11014,13 +8418,6 @@ end
 
 rule 'Private Practice Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
@@ -11037,13 +8434,6 @@ end
 
 rule 'Private Practice Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
@@ -11060,13 +8450,6 @@ end
 
 rule 'Professional Association Type Is Required If Entity Is A Professional Association'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
         IsOrganization($provider : provider)
@@ -11085,13 +8468,6 @@ end
 
 rule 'Provider Cannot Be In Private Practice'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType(maintainsOwnPrivatePractice == "Y")
@@ -11108,13 +8484,6 @@ end
 
 rule 'Provider Setup Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
 salience 10
     when
     then
@@ -11126,13 +8495,6 @@ end
 
 rule 'Provider Statement Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
@@ -11149,13 +8511,6 @@ end
 
 rule 'Provider Statement Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
@@ -11172,13 +8527,6 @@ end
 
 rule 'Provider Statement Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
@@ -11195,13 +8543,6 @@ end
 
 rule 'Provider Statement Title Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
@@ -11218,13 +8559,6 @@ end
 
 rule 'Provider Statement Title Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 4
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PROVIDER_STATEMENT.value())
         IsIndividual($provider : provider)
@@ -11241,13 +8575,6 @@ end
 
 rule 'Provider Type Cannot Be A Community Health Board'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization( )
@@ -11265,13 +8592,6 @@ end
 
 rule 'Provider Type is required for all requests'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         ProviderInformationType(providerType == null || providerType matches "^[\\s]*$")
         $report: ErrorReporter()
@@ -11286,13 +8606,6 @@ end
 
 rule 'Provider Type should be one of the configured types'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         ProviderInformationType($providerType: providerType, providerType != null, providerType not matches "^[\\s]*$")
         not LookupEntry(type == "ProviderType", value == $providerType)
@@ -11308,13 +8621,6 @@ end
 
 rule 'Provider Types Not Eligible To Obtain NPI Should Leave It Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         $provider: ProviderInformationType(NPI != null, providerType in ("TBD"))
@@ -11385,13 +8691,6 @@ end
 
 rule 'QP BGS Number Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -11410,13 +8709,6 @@ end
 
 rule 'QP BGS Number Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -11773,13 +9065,6 @@ end
 
 rule 'QP License Type Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -11800,13 +9085,6 @@ end
 
 rule 'QP Name Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -11825,13 +9103,6 @@ end
 
 rule 'QP Name Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -11884,13 +9155,6 @@ end
 
 rule 'QP SSN Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -11927,13 +9191,6 @@ end
 
 rule 'QP Type Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -11952,13 +9209,6 @@ end
 
 rule 'QP Type Must Be One Of Enumerated Values Configured'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -11977,13 +9227,6 @@ end
 
 rule 'Qualification Type Is Required For Federally Qualified Health Center'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.FEDERALLY_QUALIFIED_HEALTH_CENTER.value())
@@ -12000,13 +9243,6 @@ end
 
 rule 'Qualification Type Must Be One Of The Following Values'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.FEDERALLY_QUALIFIED_HEALTH_CENTER.value())
@@ -12030,13 +9266,6 @@ end
 
 rule 'Qualified Professional Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 salience 10
     when
     then
@@ -12046,13 +9275,6 @@ end
 
 rule 'Qualified Professional Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -12070,13 +9292,6 @@ end
 
 rule 'Qualified Professional Must Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.QUALIFIED_PROFESSIONALS.value())
         IsOrganization( $provider : provider )
@@ -12093,13 +9308,6 @@ dialect 'mvel'
 end
 
 rule 'Real Property Ownership Must Be Left Empty'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.OWNERSHIP_INFORMATION.value())
@@ -12119,13 +9327,6 @@ end
 
 rule 'Regional Treatment Center Certification Is Required For Regional Treatment Centers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.REGIONAL_TREATMENT_CENTER.value())
@@ -12143,13 +9344,6 @@ end
 
 rule 'Reimbursement Address Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
@@ -12166,13 +9360,6 @@ end
 
 rule 'Reimbursement Address Must Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y" )
@@ -12189,13 +9376,6 @@ end
 
 rule 'Reimbursement Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         IsIndividual($provider : provider)
@@ -12234,13 +9414,6 @@ end
 
 rule 'Remittance Sequence Number Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice == "Y", remittanceSequenceNumber == null || remittanceSequenceNumber matches "^[\\s]*$")
@@ -12256,13 +9429,6 @@ end
 
 rule 'Remittance Sequence Number Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         $provider: ProviderInformationType(remittanceSequenceNumber != null, remittanceSequenceNumber not matches "^.{0,100}$")
         $report: ErrorReporter()
@@ -12277,13 +9443,6 @@ end
 
 rule 'Remittance Sequence Number Should Be Left Empty For Organization'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         $provider: ProviderInformationType(remittanceSequenceNumber != null, remittanceSequenceNumber != "")
@@ -12300,13 +9459,6 @@ end
 
 rule 'Remittance Sequence Number Should Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y", remittanceSequenceNumber != null, remittanceSequenceNumber != "")
@@ -12322,13 +9474,6 @@ end
 
 rule 'Effective Date Is Required For Organizations'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization($provider: provider, provider.providerType not in (
@@ -12413,13 +9558,6 @@ end
 
 rule 'Require Highest Degree Earned For this Provider'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         IndividualApplicantType(highestDegreeEarned  == null || highestDegreeEarned matches "^[\\s]*$")
@@ -12436,13 +9574,6 @@ end
 
 rule 'Residential Address Cannot Be A PO Box'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual()
@@ -12462,13 +9593,6 @@ end
 
 rule 'Residential Address Is Required For The Specified Provider Types II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider, provider.providerType == ProviderType.PERSONAL_CARE_ASSISTANT.value())
@@ -12485,13 +9609,6 @@ end
 
 rule 'Residential Address Is Required For The Specified Provider Types'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual($provider : provider, provider.providerType == ProviderType.PERSONAL_CARE_ASSISTANT.value())
@@ -12508,13 +9625,6 @@ end
 
 rule 'Residential Address Must Be Valid'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PERSONAL_INFORMATION.value())
         IsIndividual()
@@ -12531,13 +9641,6 @@ end
 
 rule 'Residential Property Ownership Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 salience 10
     when
     then
@@ -12547,13 +9650,6 @@ end
 
 rule 'Rule 29 License Is required for Community Mental Health Center'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value())
@@ -12571,13 +9667,6 @@ end
 
 rule 'Rule 36 Licensed Facility Is Required For Intensive Residential Treatment Facility'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.INTENSIVE_RESIDENTIAL_TREATMENT_FACILITY.value())
@@ -12595,13 +9684,6 @@ end
 
 rule 'Rule 5 License Is Required For CMHR treatment facility'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.CHILDRENS_MENTAL_HEALTH_RESIDENTIAL_TREATMENT_FACILITY.value())
@@ -12619,13 +9701,6 @@ end
 
 rule 'Selected Clinical Services Must Be One Of The Defined Options'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
@@ -12646,13 +9721,6 @@ end
 
 rule 'Selected Service Categories Must Be One Of Defined Values For This Provider Type'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization($provider: provider)
@@ -12672,13 +9740,6 @@ end
 
 rule 'Selected Service Units Must Be One Of The Defined Options'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
@@ -12699,13 +9760,6 @@ end
 
 rule 'Selected Supervision And Qualification Must Be One Of The Defined Options'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
@@ -12726,13 +9780,6 @@ end
 
 rule 'Selected Target Population Must Be One Of The Defined Options'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.AGENCY_ELIGIBILITY.value())
         IsOrganization($provider : provider)
@@ -12753,13 +9800,6 @@ end
 
 rule 'Setup validation reporting'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         not ErrorReporter()
         $validation: ValidationResultType()
@@ -12770,13 +9810,6 @@ end
 
 rule 'Sliding Fee Schedule Is Required For The Specified Provider Typers II'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType in (ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()))
@@ -12794,13 +9827,6 @@ end
 
 rule 'Sliding Fee Schedule Is Required For The Specified Provider Typers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 9
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType in (ProviderType.COMMUNITY_MENTAL_HEALTH_CENTER.value()))
@@ -12816,13 +9842,6 @@ dialect 'mvel'
 end
 
 rule 'Specialty certification from PHS is required for pharmacists working at a PHS Indian Hospital.'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 10
- */
 dialect 'mvel'
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
@@ -12841,13 +9860,6 @@ end
 
 rule 'Specialty Type And License Type Cannot Both Be Provided If the Specialty Certificate Behavior Defined is XOR'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -12867,13 +9879,6 @@ end
 
 rule 'Specialty Type Is Required If Defined Specialty Certificate Behavior Is AND'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -12893,13 +9898,6 @@ end
 
 rule 'Specialty Type Or License Type Must Be Provided If the Defined Specialty Certificate Behavior is OR, XOR'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 1
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType($providerType: providerType)
@@ -12919,13 +9917,6 @@ end
 
 rule 'Specified Providers Must Have A license in the state of practice'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType(
@@ -12967,13 +9958,6 @@ end
 
 rule 'State Tax Id Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -12990,13 +9974,6 @@ end
 
 rule 'State Tax Id Should Be Left Empty'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 2
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.PRACTICE_INFORMATION.value())
         $provider: ProviderInformationType( maintainsOwnPrivatePractice != "Y" )
@@ -13013,13 +9990,6 @@ end
 
 rule 'TaxPayer Name Is Required For PCPO'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization(provider.providerType == ProviderType.PERSONAL_CARE_PROVIDER_ORGANIZATION.value())
@@ -13088,13 +10058,6 @@ end
 
 rule 'TCM Contract With County Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -13114,13 +10077,6 @@ end
 
 rule 'TCM Cover Sheet Type Is Required'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -13140,13 +10096,6 @@ end
 
 rule 'TCM Cover Sheet Type Must Be One Of The Following'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         IsOrganization()
@@ -13166,13 +10115,6 @@ end
 
 rule 'TCM Form Is Asked For The Specified Providers'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 7
- */
 salience 10
     when
     then
@@ -13182,13 +10124,6 @@ end
 
 rule 'Trading Partner Type Is Required For EDI Trading Partner'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         ProviderInformationType(providerType == ProviderType.EDI_TRADING_PARTNER.value())
@@ -13205,13 +10140,6 @@ end
 
 rule 'Trading Partner Type Must Be One Of Enumerated Types'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.ORGANIZATION_INFORMATION.value())
         IsOrganization()
@@ -13229,13 +10157,6 @@ end
 
 rule 'Tribal Code Is Required If Employed By a PHS Indian Hospital'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -13252,13 +10173,6 @@ end
 
 rule 'Tribal Code Should be left Empty If Not Employed By a PHS Indian Hospital'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 3
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
         $provider: ProviderInformationType( )
@@ -13275,13 +10189,6 @@ end
 
 rule 'UMPI Maximum Length Check'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         ProviderInformationType(UMPI != null, UMPI not matches "^.{0,10}$")
         $report: ErrorReporter()
@@ -13296,13 +10203,6 @@ end
 
 rule 'Verification of IHS status Is Required For Indian Health Service Facility'
 dialect 'mvel'
-/*
- * Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Provider Enrollment Drools Front End Validation Part 5
- */
     when
         LookupEntry(type == "FieldGroup", value == UISection.FACILITY_CREDENTIALS.value())
         $provider: ProviderInformationType(providerType == ProviderType.INDIAN_HEALTH_SERVICE_FACILITY.value())
@@ -13405,9 +10305,6 @@ salience 10
         insertLogical(new CertificateException("RenewalEndDate", "PCA Training Certificate", (String) "*"));
 end
 
-/**
- * Added by cyberjag - Fix for PESP-297
-**/
 rule 'CMS 1539 Form Is Required For Renal Dialysis Facility'
 dialect 'mvel'
     when
@@ -13440,9 +10337,6 @@ dialect 'mvel'
         );
 end
 
-/**
- * Added by cyberjag - Fix for PESP-307
-**/
 rule 'Provider age should be 18 or above during enrollment'
 dialect 'mvel'
     when
@@ -13530,9 +10424,6 @@ dialect 'mvel'
         );
 end
 
-/**
- * Added by cyberjag - Fix for PESP-282
- */
 rule 'Dental License is required for Dentist'
 dialect 'mvel'
     when
@@ -13549,9 +10440,6 @@ dialect 'mvel'
         );
 end
 
-/**
- * Added by cyberjag - Fix for PESP-259
- */
 rule "Acupuncturist License in the state of practice is required for Acupuncturist"
     when
         LookupEntry(type == "FieldGroup", value == UISection.LICENSE_INFORMATION.value())
@@ -13974,9 +10862,6 @@ rule "Copy of license as a podiatrist from the MN Board of Podiatric Medicine or
         );
 end
 
-/**
- * Added by cyberjag - Fix for PESP-308
- */
 rule 'Minimum of 2 licensed chiropractors working at the clinic'
 activation-group "member-info-license-required"
 dialect 'mvel'
@@ -14030,9 +10915,6 @@ activation-group "duplicate-member-npi"
         );
 end
 
-/**
- * Added by cyberjag - Fix for PESP-308
-**/
 rule 'Birth Center license from the MN Department of Health is Required for Birthing Center'
 dialect 'mvel'
     when
@@ -14113,9 +10995,6 @@ activation-group "billing-entity-for-phy-svc-members"
         );
 end
 
-/**
- * Added by cyberjag - PESP-313
- */
 rule 'Billing Entity for Mental Health - Cannot accept any other providers except LICSW, LMFT, LP, LPCC, or CNS with mental health specialty.'
 dialect 'mvel'
 activation-group "billing-entity-for-mh"

--- a/psm-app/cms-business-process/src/test/groovy/HelloSpec.groovy
+++ b/psm-app/cms-business-process/src/test/groovy/HelloSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import spock.lang.*
 
 @Unroll

--- a/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ExternalScreeningTimerBeanTest.groovy
+++ b/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ExternalScreeningTimerBeanTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.services.impl
 
 import gov.medicaid.entities.ScreeningSchedule

--- a/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ProviderEnrollmentServiceBeanTest.groovy
+++ b/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ProviderEnrollmentServiceBeanTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.services.impl
 
 import gov.medicaid.entities.CMSUser

--- a/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ScreeningServiceBeanTest.groovy
+++ b/psm-app/cms-business-process/src/test/groovy/gov/medicaid/services/impl/ScreeningServiceBeanTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.services.impl
 
 import gov.medicaid.entities.AutomaticScreening

--- a/psm-app/cms-business-process/src/test/java/gov/medicaid/domain/rules/DSLTester.java
+++ b/psm-app/cms-business-process/src/test/java/gov/medicaid/domain/rules/DSLTester.java
@@ -46,9 +46,6 @@ import java.util.List;
 
 /**
  * Simple test case for the Domain Specific Language Rules.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class DSLTester {
 

--- a/psm-app/cms-business-process/src/test/java/gov/medicaid/domain/rules/DSLTester.java
+++ b/psm-app/cms-business-process/src/test/java/gov/medicaid/domain/rules/DSLTester.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/accounts/register_success.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
@@ -1,8 +1,6 @@
 <%--
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
 
- @author TCSASSEMBLER
- @version 1.0
 
  The advanced search results page.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/advanced-search-results-system-admin.jsp
@@ -1,7 +1,20 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
-
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
  The advanced search results page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/automatic_screening_leie.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/automatic_screening_leie.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html>
 <html lang="en-US">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the dashboard service agent page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/dashboard.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the dashboard service agent page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_buttons.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_buttons.jsp
@@ -1,6 +1,4 @@
 <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: it is used to build the enrollment search form.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_buttons.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_buttons.jsp
@@ -1,6 +1,20 @@
 <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   - Description: it is used to build the enrollment search form.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_notes_dialog.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_notes_dialog.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <div id="modalBackground"></div>
 <div id="modal">
   <div class="modal" id="writeNotesModal">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_filter_panel.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_filter_panel.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   The filter panel for: admin user login > Enrollments > All, Draft, etc. pages.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
@@ -1,6 +1,4 @@
 <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: it is used to build the enrollment search form.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_form.jsp
@@ -1,6 +1,20 @@
 <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   - Description: it is used to build the enrollment search form.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_search_result_table.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <table
   id="${searchTableId}"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_tab_section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollment_tab_section.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <div class="tabHead">
   <div class="tabR">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollments_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/enrollments_link.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <c:choose>
   <c:when test="${isServiceAdministrator}">
     <a href="<c:url value="/provider/enrollments/all?showFilterPanel=true" />">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/filter-panel.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/filter-panel.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   The filter panel for the system admin login > User Accounts pages (Providers, Service Agents, etc.).
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
@@ -1,6 +1,4 @@
 <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: it is used to render the high risk level.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/high_risk_level_means.jsp
@@ -1,6 +1,20 @@
 <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   - Description: it is used to render the high risk level.
 --%>
 <!--

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
@@ -1,7 +1,20 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
-
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
  The modal jsp for deleting user account.
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" isELIgnored="false"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/modal.jsp
@@ -1,8 +1,6 @@
 <%--
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
 
- @author TCSASSEMBLER
- @version 1.0
 
  The modal jsp for deleting user account.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/no-result-section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/no-result-section.jsp
@@ -1,8 +1,6 @@
 <%--
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
 
- @author TCSASSEMBLER
- @version 1.0
 
  The no search result section for user accounts search.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/no-result-section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/no-result-section.jsp
@@ -1,7 +1,20 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
-
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
  The no search result section for user accounts search.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_filter_panel.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_filter_panel.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   The filter panel for: admin user login > Screenings > All/Passed/Failed/etc.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_tab_section.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_tab_section.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <div class="tabHead">
   <div class="tabR">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/screenings_table.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <table
   id="screeningsTable"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/service_admin_create_edit_provider_type_common.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/service_admin_create_edit_provider_type_common.jsp
@@ -1,3 +1,22 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+ <%--
+  - Description: This is the admin provider types create/edit common page.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <form:form id="providerTypeForm" modelAttribute="providerType" action="${editCreateProviderTypeFormAction}" method="post">
   <form:hidden path="code"/>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sort_column_header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sort_column_header.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <th class="${thClass}">
   <c:choose>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sortable-table-headers.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sortable-table-headers.jsp
@@ -1,7 +1,20 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
-
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
  The sort-able user accounts table header section.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sortable-table-headers.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/sortable-table-headers.jsp
@@ -1,8 +1,6 @@
 <%--
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
 
- @author TCSASSEMBLER
- @version 1.0
 
  The sort-able user accounts table header section.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/taglibs.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/taglibs.jsp
@@ -1,6 +1,4 @@
 <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This page fragment is to be included in all pages.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/taglibs.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/includes/taglibs.jsp
@@ -1,6 +1,20 @@
 <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   - Description: This page fragment is to be included in all pages.
   - It includes the commonly used tag libraries.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/applications_by_reviewer.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html>
 <html lang="en-US">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/draft_applications.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/draft_applications.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <!DOCTYPE html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/provider_types.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html>
 <html lang="en-US">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reports.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reports.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html>
 <html lang="en-US">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/reviewed_documents.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <!DOCTYPE html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/risk_levels.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <!DOCTYPE html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/reports/time_to_review.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <!DOCTYPE html>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/screenings.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html>
 <html lang="en-US">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
@@ -1,8 +1,6 @@
 <%--
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
 
- @author TCSASSEMBLER
- @version 1.0
 
  The search accounts result page.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/search-result-system-admin.jsp
@@ -1,7 +1,20 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
-
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
  The search accounts result page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the admin agreement documents page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_agreement_documents.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the admin agreement documents page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the admin provider types create page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_create_provider_type.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the admin provider types create page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the admin agreement document edit/create page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_agreement_document.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the admin agreement document edit/create page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the admin provider types edit page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_provider_type.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the admin provider types edit page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the admin screening schedules edit page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_edit_schedule.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the admin screening schedules edit page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the admin provider types page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_provider_types.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the admin provider types page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the admin agreement document view page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_agreement_document.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the admin agreement document view page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the admin provider types page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_provider_type.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the admin provider types page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the admin screening schedules page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_admin_view_schedule.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the admin screening schedules page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
@@ -1,6 +1,4 @@
 <%--
-  - Author: cyberjag
-  - Version: 1.0
   - Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the cos service agent page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_cos.jsp
@@ -1,6 +1,20 @@
 <%--
-  - Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
-  -
+  Copyright 2013 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   - Description: This is the cos service agent page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_list.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>
 <!DOCTYPE html>
 <html lang="en-US">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
@@ -1,6 +1,4 @@
 <%--
-  - Author: cyberjag
-  - Version: 1.0
   - Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the cos service agent page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_pending_cos.jsp
@@ -1,6 +1,20 @@
 <%--
-  - Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
-  -
+  Copyright 2013 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   - Description: This is the cos service agent page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the enrollment status service agent page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_enrollment_status.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the enrollment status service agent page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the enrollments pending page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_print_enrollments.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the enrollments pending page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -1,6 +1,4 @@
 <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the approval page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_review_screening.jsp
@@ -1,6 +1,20 @@
 <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   - Description: This is the approval page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the advanced search page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_advanced.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the advanced search page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the quick search result page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_search_enrollments_quick.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the quick search result page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
@@ -1,6 +1,20 @@
+<%--
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
  <%--
-  - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-  -
   - Description: This is the enrollment service agent details page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/service_agent_view_enrollment_details.jsp
@@ -1,6 +1,4 @@
  <%--
-  - Author: TCSASSEMBLER
-  - Version: 1.0
   - Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
   -
   - Description: This is the enrollment service agent details page.

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
@@ -1,7 +1,20 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
-
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
  The user account details page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-details-system-admin.jsp
@@ -1,8 +1,6 @@
 <%--
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
 
- @author TCSASSEMBLER
- @version 1.0
 
  The user account details page.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
@@ -1,8 +1,6 @@
 <%--
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
 
- @author TCSASSEMBLER
- @version 1.0
 
  The edit user account page.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-edit-system-admin.jsp
@@ -1,7 +1,20 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
-
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
  The edit user account page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
@@ -1,8 +1,6 @@
 <%--
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
 
- @author TCSASSEMBLER
- @version 1.0
 
  The user accounts page.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/admin/user-account-system-admin.jsp
@@ -1,7 +1,20 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
-
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
  The user accounts page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/error.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/forgot_password.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@page import="org.springframework.security.web.WebAttributes"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/login_form.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/login_form.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp"%>
 <form id="loginForm" action="<c:url value='/login'/>" method="post">
   <sec:csrfInput />

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/mnLogin.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@page import="org.springframework.security.web.WebAttributes"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/dashboard_filter.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
   The filter panel for the provider login > Dashboard page.
 --%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/external_home.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/internal_home.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/list_by_status.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/dashboard/status_results_table.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     Provider status list results table (Draft, Pending, etc.).
 --%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/edit_details.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/enrollment_step.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/errors.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/errors.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${not empty requestScope['flash_error']}">
     <div class="errorInfo formErrorMarker" style="display: block;">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for common practice lookup modal.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/practice_lookup.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for common practice lookup modal.
 
-    @author j3_guile
-    @version 1.0
  --%>
 <!-- /#practiceLookupModal-->
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/save_as_draft.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/save_as_draft.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for common save as draft modal.
 
-    @author j3_guile
-    @version 1.0
  --%>
 <!-- /#saveAsDraftModal-->
 <div id="saveAsDraftModal" class="outLay">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/save_as_draft.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/save_as_draft.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for common save as draft modal.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/stale_ticket.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/stale_ticket.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for common save as draft modal.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/stale_ticket.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/stale_ticket.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for common save as draft modal.
 
-    @author j3_guile
-    @version 1.0
  --%>
 <!-- /#saveAsDraftModal-->
 <div id="staleTicket" class="outLay">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/submit_enrollment.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/submit_enrollment.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for common save as draft modal.
 
-    @author j3_guile
-    @version 1.0
  --%>
 <!-- /#saveAsDraftModal-->
 <div id="submitEnrollmentModal" class="outLay">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/submit_enrollment.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/submit_enrollment.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for common save as draft modal.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/superseded_ticket.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/superseded_ticket.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for common save as draft modal.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/superseded_ticket.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/modal/superseded_ticket.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for common save as draft modal.
 
-    @author j3_guile
-    @version 1.0
  --%>
 <!-- /#saveAsDraftModal-->
 <div id="supersededTicket" class="outLay">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/additional_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/additional_practice.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <table class="generalTable noInput">
     <colgroup>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/contact_info.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <div class="row">
     <label>Contact Name</label>
     <span id="contactName">${requestScope['_02_contactName']}</span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_agency_rows.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_agency_rows.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <div class="row">
     <label>Agency Name</label>
     <span>${requestScope['_11_name']}</span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_pca_rows.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/ind_pca_rows.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <div class="row">
     <label>First Name</label>
     <span>${requestScope['_10_firstName']}</span>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/license_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/license_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <table
         class="generalTable noInput"

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/person_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/person_info.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
     <div class="leftCol">
         <div class="row">
             <label>First Name</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/practice_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/practice_type.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div class="row">
     <label>Do you maintain your own private practice?</label>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/primary_practice.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/private_practice.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/readonly_profile.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/readonly_profile.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div class="tabHead" style="width: 958px;">
     <div class="tabR">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/specialty_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/specialty_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <table class="generalTable noInput">
     <colgroup>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tab_name_mapping.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tab_name_mapping.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:choose>
     <c:when test="${tabName eq 'Personal Information'}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/tabs.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_agency.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/additional_practice.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/adult_day_treatment_application.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/adult_day_treatment_application.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ambulance_services.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ambulance_services.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for facility type selection form.
 
-    @author j3_guile
-    @version 1.0
  --%>
 
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ambulance_services.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ambulance_services.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for facility type selection form.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/clia_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/clia_license.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/cmhrt_contract.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/cmhrt_contract.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <input type="hidden" name="formNames" value="<%= ViewStatics.CMHRT_FORM %>">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ctcc_credentials.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <input type="hidden" name="formNames" value="<%= ViewStatics.CTCC_FORM %>">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_capacity.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_capacity.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%-- Used for Regional Treatment Center application --%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_contracts.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_contracts.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%-- Used in County Contracted Mental Health Rehab applications --%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_eligibility.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_eligibility.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_license.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_type.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for facility type selection form.
 
-    @author j3_guile
-    @version 1.0
  --%>
 
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/facility_type.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for facility type selection form.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/federal_qualification.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/federal_qualification.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for facility type selection form.
 
-    @author j3_guile
-    @version 1.0
  --%>
 
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/federal_qualification.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/federal_qualification.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for facility type selection form.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/highest_degree_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_agency_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_agency_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="ind_agency_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ind_pca_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="ind_pca_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/individual_disclosure.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/license_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@ page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/member_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="member_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/nonprofit_corporation.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/nonprofit_corporation.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <input type="hidden" name="formNames" value="<%= ViewStatics.NONPROFIT_CORPORATION_FORM %>">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_disclosure.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="organization_disclosure"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="organization_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/organization_statement.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="organization_statement"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for ownership form.
 
-    @author j3_guile
-    @version 1.0
  --%>
 
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/ownership_information.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for ownership form.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pca_billing.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pca_billing.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="pca_billing"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/pcpo_insurance.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/personal_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="personal_information"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/phn_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/phn_agency.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/physician_clinic_facility_qualification.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/physician_clinic_facility_qualification.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for facility type selection form.
 
-    @author j3_guile
-    @version 1.0
  --%>
 
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/physician_clinic_facility_qualification.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/physician_clinic_facility_qualification.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for facility type selection form.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/practice_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/practice_type.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/primary_practice.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/private_practice.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_setup.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="provider_setup"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
@@ -1,8 +1,6 @@
 <%--
     JSP Fragment for provider type selection form.
 
-    @author j3_guile
-    @version 1.0
  --%>
 
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/provider_type.jsp
@@ -1,4 +1,19 @@
 <%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
     JSP Fragment for provider type selection form.
 
  --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/qualified_professional.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@taglib prefix="cms" uri="CMSTags"  %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/remittance_sequence.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/remittance_sequence.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="remittance_sequence"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/sliding_fee.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/sliding_fee.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:set var="formIdPrefix" value="sliding_fee"></c:set>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/specialty_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/specialty_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tcm_contract.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tcm_contract.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%-- TCM is for Targeted Case Management application --%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/default/tribal_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@page import="gov.medicaid.binders.ProviderTypeFormBinder"%>
 <%@page import="gov.medicaid.entities.dto.ViewStatics"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/select_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/select_type.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 <div class="tabSection">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/additional_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/additional_agency.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <table class="generalTable noInput">
     <colgroup>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ambulance_services.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ambulance_services.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_39_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/clia_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/clia_license.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_22_bound'] eq 'Y'}">
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ctcc_credentials.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ctcc_credentials.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_30_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_capacity.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_capacity.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_27_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_contracts.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_contracts.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_34_bound'] eq 'Y'}">
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_eligibility.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_eligibility.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_38_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_license.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_license.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_21_bound'] eq 'Y'}">
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_type.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/facility_type.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_36_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/federal_qualification.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/federal_qualification.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_37_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/header.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/header.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 
 <div class="tableHeader ${status.first ? '' : 'otherTableHeader'}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/highest_degree_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/highest_degree_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_14_bound'] eq 'Y'}">
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_agency_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_agency_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%-- Used for Personal Care Assistant application --%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_11_bound'] eq 'Y'}">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_pca_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ind_pca_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%-- Used for Personal Care Assistant application --%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/member_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/member_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_16_bound'] eq 'Y'}">
 <table class="memberInfo">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_disclosure.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_18_bound'] eq 'Y'}">
 <div class="tableHeader">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/organization_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ownership_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/ownership_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="h" tagdir="/WEB-INF/tags" %>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/pca_billing.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/pca_billing.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_24_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/personal_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/personal_info.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div class="section">
     <%@include file="/WEB-INF/pages/provider/enrollment/steps/pageTemplates/common/person_info.jsp" %>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/phn_agency.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/phn_agency.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_26_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/physician_clinic_facility_qualification.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/physician_clinic_facility_qualification.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_40_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/practice_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/practice_info.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div class="practiceSection">
     <div class="wholeCol">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/provider_setup.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/provider_setup.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_20_bound'] eq 'Y'}">
 <table class="memberInfo">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/qualified_professional.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/qualified_professional.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_29_bound'] eq 'Y'}">
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/remittance_sequence.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/remittance_sequence.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_23_bound'] eq 'Y'}">
 <div class="section">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/tribal_information.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/summary/tribal_information.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${requestScope['_13_bound'] eq 'Y'}">
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_default.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_default.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div id="tabPractice" class="tabContent tabDefault">
     <div class="tableContainer">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_individual_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_individual_disclosure.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div id="tabStatement" class="tabContent">
     <div class="topPanel">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_organization_disclosure.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_organization_disclosure.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div id="tabStatement" class="tabContent">
     <div class="topPanel">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_personal_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_personal_info.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div id="tabPersonal" class="tabContent">
     <div class="topPanel">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_practice_info.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/pageTemplates/view_practice_info.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div id="tabPractice" class="tabContent">
     <div class="tableContainer">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/screening_errors.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/screening_errors.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:if test="${not empty errors}">
     <div class="errorInfo formErrorMarker" style="display: block;">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_details.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/steps/view_profile_details.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/view_agreement.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/enrollment/view_agreement.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <div>
     <div class="tabContent" id="tabAgreement">

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/notes.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/notes.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@taglib prefix="cms" uri="CMSTags"  %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/create_link.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/onboarding/profiles.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/confirm_edit.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/password.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/profile.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/provider/profile/profile.jsp
@@ -1,3 +1,18 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <!DOCTYPE html>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags"%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
@@ -1,8 +1,6 @@
 <%--
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
 
- @author TCSASSEMBLER
- @version 1.0
 
  The advanced search results page.
 --%>

--- a/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
+++ b/psm-app/cms-web/WebContent/WEB-INF/pages/system/advanced-search-system-admin.jsp
@@ -1,7 +1,20 @@
 <%--
- Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
-
-
+  Copyright 2012 TopCoder Inc.
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%--
  The advanced search results page.
 --%>
 <%@ include file="/WEB-INF/pages/admin/includes/taglibs.jsp" %>

--- a/psm-app/cms-web/WebContent/index.jsp
+++ b/psm-app/cms-web/WebContent/index.jsp
@@ -1,2 +1,17 @@
+<%--
+  Copyright 2018 The MITRE Corporation
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core_rt"%>
 <c:redirect url="/login" />

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/PsmApiServlet.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/PsmApiServlet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api;
 
 import ca.uhn.fhir.context.FhirContext;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/TaskResourceProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/TaskResourceProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api;
 
 import ca.uhn.fhir.rest.annotation.IdParam;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/BasicSecurityInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/BasicSecurityInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.interceptors;
 
 import ca.uhn.fhir.rest.api.server.RequestDetails;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/TaskResourceAuthorizationInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/interceptors/TaskResourceAuthorizationInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.interceptors;
 
 import ca.uhn.fhir.rest.api.server.RequestDetails;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers;
 
 import gov.medicaid.entities.Affiliation;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentStatusToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentStatusToFhir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers;
 
 import gov.medicaid.entities.EnrollmentStatus;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentStatusToPsmName.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentStatusToPsmName.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers;
 
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EnrollmentToFhir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers;
 
 import gov.medicaid.entities.Enrollment;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityAddressToFhirAddress.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityAddressToFhirAddress.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers;
 
 import org.hl7.fhir.dstu3.model.Address;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityNumberToContactPoint.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/EntityNumberToContactPoint.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers;
 
 import org.hl7.fhir.dstu3.model.ContactPoint;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/ProviderProfileToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/ProviderProfileToFhir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers;
 
 import gov.medicaid.entities.Affiliation;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/ProviderTypeToFhir.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/api/transformers/ProviderTypeToFhir.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers;
 
 import gov.medicaid.entities.ProviderType;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/BaseController.java
@@ -31,9 +31,6 @@ import java.util.logging.Logger;
  * <p>
  * <b>Thread Safety</b> This class is mutable and not thread safe, but used in thread safe manner by framework.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Controller
 public abstract class BaseController {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ControllerHelper.java
@@ -37,9 +37,6 @@ import static java.lang.Math.min;
 
 /**
  * Utility class for front end controllers.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ControllerHelper {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/EnrollmentPageFlowController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ErrorController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ErrorController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers;
 
 import gov.medicaid.interceptors.HandlebarsInterceptor;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ForgotPasswordController.java
@@ -31,8 +31,6 @@ import org.springframework.web.servlet.ModelAndView;
 /**
  * Handles requests to regenerated passwords.
  *
- * @author TCSASSEMBLER
- * @version 1.0
  * @endpoint "/forgotpassword"
  */
 @Controller

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
@@ -1,5 +1,18 @@
 /*
- * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
+ * Copyright 2013 TopCoder, Inc., All Rights Reserved.
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package gov.medicaid.controllers;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/FullnameTag.java
@@ -19,9 +19,6 @@ import java.io.IOException;
 
 /**
  * This tag library will print the full name of the user given the id.
- *
- * @author j3_guile
- * @version 1.0
  */
 public class FullnameTag extends SimpleTagSupport {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/LandingController.java
@@ -27,9 +27,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * Handles display of the default page for the users.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Controller
 public class LandingController extends BaseController {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/MyProfileController.java
@@ -42,8 +42,6 @@ import java.util.List;
 /**
  * Handles account maintenance.
  *
- * @author TCSASSEMBLER
- * @version 1.0
  * @endpoint "/provider/profile/*"
  */
 @Controller

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/OnboardingController.java
@@ -41,8 +41,6 @@ import java.util.List;
 /**
  * Handles data import flows.
  *
- * @author TCSASSEMBLER
- * @version 1.0
  * @endpoint "/provider/onboarding/*"
  */
 @Controller

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/ProviderDashboardController.java
@@ -44,8 +44,6 @@ import java.util.stream.Collectors;
 /**
  * Handles dashboard functions.
  *
- * @author TCSASSEMBLER
- * @version 1.0
  * @endpoint "/provider/dashboard/*"
  */
 @Controller

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/SelfRegistrationController.java
@@ -34,8 +34,6 @@ import org.springframework.web.servlet.ModelAndView;
 /**
  * Handles self-registration flow.
  *
- * @author TCSASSEMBLER
- * @version 1.0
  * @endpoint "/accounts/*"
  */
 @Controller

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/TruncateTextTag.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/TruncateTextTag.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 /**
  * This tag library will truncate a text to a specified limit and append an ellipsis.
  *
- * @author j3_guile
- * @version 1.0
  * since PESP
  */
 public class TruncateTextTag extends SimpleTagSupport {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/TruncateTextTag.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/TruncateTextTag.java
@@ -1,5 +1,18 @@
 /*
- * Copyright (C) 2013 TopCoder Inc., All Rights Reserved.
+ * Copyright 2013 TopCoder Inc.
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package gov.medicaid.controllers;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AgreementDocumentController.java
@@ -43,9 +43,6 @@ import java.security.Principal;
  * <p>
  * This class is mutable and not thread safe, but used in thread safe manner by framework.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Controller
 public class AgreementDocumentController {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AutomaticScreeningController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/AutomaticScreeningController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin;
 
 import gov.medicaid.controllers.BaseController;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/DashboardController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/DashboardController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/EnrollmentController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ProviderTypeController.java
@@ -52,9 +52,6 @@ import java.util.List;
  * <p>
  * This class is mutable and not thread safe, but used in thread safe manner by framework.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Controller
 public class ProviderTypeController {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ReportController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin;
 
 import org.springframework.stereotype.Controller;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ScreeningScheduleController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ScreeningScheduleController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ScreeningScheduleController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/ScreeningScheduleController.java
@@ -35,9 +35,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p>
  * This class is mutable and not thread safe, but used in thread safe manner by framework.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Controller
 public class ScreeningScheduleController {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserController.java
@@ -45,9 +45,6 @@ import java.util.Arrays;
  * <b>Thread Safety</b> This class is mutable and not thread safe, but used in thread safe manner by framework.
  * </p>
  *
- * @author argolite, TCSASSEMBLER
- * @version 1.1
- * @since 1.0
  * @endpoint "/system/user/*"
  */
 @Controller

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/SystemAdminUserSearchController.java
@@ -41,9 +41,6 @@ import java.util.List;
  * <b>Thread Safety</b> This class is mutable and not thread safe, but used in thread safe manner by framework.
  * </p>
  *
- * @author argolite, TCSASSEMBLER
- * @version 1.1
- * @since 1.0
  * @endpoint "/system/search/*"
  */
 @Controller
@@ -94,7 +91,6 @@ public class SystemAdminUserSearchController {
      *
      * @param rolesList the roles list
      * @return the all roles string
-     * @since 1.1
      */
     private String getRolesStr(List<String> rolesList) {
         if (null == rolesList) {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserController.java
@@ -36,9 +36,6 @@ import javax.servlet.http.HttpServletRequest;
  * <p>
  * This class is mutable and not thread safe, but used in thread safe manner by framework.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Controller
 public class UserController {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
@@ -33,9 +33,6 @@ import java.util.List;
  * <p>
  * <b>Thread Safety</b> This class is mutable and not thread safe, but used in thread safe manner by framework.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @Component
 public class UserValidator extends BaseValidator implements Validator {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/UserValidator.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report;
 
 import gov.medicaid.entities.Enrollment;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/DraftApplicationsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/DraftApplicationsReportController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report;
 
 import gov.medicaid.controllers.admin.report.ReportControllerUtils.EnrollmentMonth;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ProviderTypesReportController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report;
 
 import gov.medicaid.controllers.admin.report.ReportControllerUtils.EnrollmentMonth;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ReportControllerUtils.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ReportControllerUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report;
 
 import gov.medicaid.entities.Enrollment;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report;
 
 import gov.medicaid.controllers.admin.report.ReportControllerUtils.EnrollmentMonth;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/RiskLevelsReportController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report;
 
 import com.google.common.collect.ImmutableList;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/TimeToReviewReportController.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/admin/report/TimeToReviewReportController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report;
 
 import gov.medicaid.controllers.admin.report.ReportControllerUtils.EnrollmentMonth;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ApprovalDTO.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ApprovalDTO.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ApprovalDTO.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ApprovalDTO.java
@@ -18,10 +18,6 @@ package gov.medicaid.controllers.dto;
 
 /**
  * This class is used to perform manual verification.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Medicaid Provider Screening Portal - Service Agent Controllers
  */
 public class ApprovalDTO {
     /**

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/CMSUserDetailsWrapper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/CMSUserDetailsWrapper.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/CMSUserDetailsWrapper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/CMSUserDetailsWrapper.java
@@ -32,9 +32,6 @@ import java.util.Date;
 /**
  * Wraps the user details from the external authentication mechanism into one that tracks the external account source
  * and the corresponding internal CMS user record.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class CMSUserDetailsWrapper implements UserDetails, CMSPrincipal {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ScreeningDTO.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/ScreeningDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.dto;
 
 import gov.medicaid.entities.AutomaticScreening;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/StatusDTO.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/StatusDTO.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/StatusDTO.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/dto/StatusDTO.java
@@ -18,10 +18,6 @@ package gov.medicaid.controllers.dto;
 
 /**
  * This class is used to return an AJAX response.
- *
- * @author TCSASSEMBLER
- * @version 1.0
- * @since Medicaid Provider Screening Portal - Service Agent Controllers
  */
 public class StatusDTO {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/AccountLinkForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/AccountLinkForm.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/AccountLinkForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/AccountLinkForm.java
@@ -20,9 +20,6 @@ import java.io.Serializable;
 
 /**
  * Account link creation form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class AccountLinkForm implements Serializable {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/ForgotPasswordForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/ForgotPasswordForm.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/ForgotPasswordForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/ForgotPasswordForm.java
@@ -18,9 +18,6 @@ package gov.medicaid.controllers.forms;
 
 /**
  * Forgot password form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ForgotPasswordForm {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/RegistrationForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/RegistrationForm.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/RegistrationForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/RegistrationForm.java
@@ -20,9 +20,6 @@ import java.io.Serializable;
 
 /**
  * Contains all the fields needed during registration.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class RegistrationForm implements Serializable {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/UpdatePasswordForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/UpdatePasswordForm.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/UpdatePasswordForm.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/forms/UpdatePasswordForm.java
@@ -18,9 +18,6 @@ package gov.medicaid.controllers.forms;
 
 /**
  * Update password form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class UpdatePasswordForm {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/AccountLinkFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/AccountLinkFormValidator.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/AccountLinkFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/AccountLinkFormValidator.java
@@ -23,9 +23,6 @@ import org.springframework.validation.Errors;
 
 /**
  * Account link validator.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Component
 public class AccountLinkFormValidator extends BaseValidator {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/BaseValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/BaseValidator.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/BaseValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/BaseValidator.java
@@ -22,9 +22,6 @@ import org.springframework.validation.Validator;
 
 /**
  * Base class for validators.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public abstract class BaseValidator implements Validator {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/ForgotPasswordFormValidator.java
@@ -23,9 +23,6 @@ import org.springframework.validation.Errors;
 
 /**
  * Password reset request validator.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Component
 public class ForgotPasswordFormValidator extends BaseValidator {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/RegistrationFormValidator.java
@@ -25,9 +25,6 @@ import org.springframework.validation.Errors;
 
 /**
  * Registration request validator.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Component
 public class RegistrationFormValidator extends BaseValidator {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/StrictCustomDateEditor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/StrictCustomDateEditor.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/StrictCustomDateEditor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/StrictCustomDateEditor.java
@@ -22,9 +22,6 @@ import java.text.SimpleDateFormat;
 
 /**
  * This is a strict binder for MM/dd/yyyy date fields.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class StrictCustomDateEditor extends CustomDateEditor {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/UpdatePasswordFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/UpdatePasswordFormValidator.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/UpdatePasswordFormValidator.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/controllers/validators/UpdatePasswordFormValidator.java
@@ -23,9 +23,6 @@ import org.springframework.validation.Errors;
 
 /**
  * Validator for updating passwords.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Component
 public class UpdatePasswordFormValidator extends BaseValidator {

--- a/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/FlashMessageInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/FlashMessageInterceptor.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/FlashMessageInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/FlashMessageInterceptor.java
@@ -24,9 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Moves flash messages to request scope.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class FlashMessageInterceptor implements HandlerInterceptor {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/interceptors/HandlebarsInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.interceptors;
 
 import gov.medicaid.controllers.ControllerHelper;

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSLDAPUserDetailsMapper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSLDAPUserDetailsMapper.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSLDAPUserDetailsMapper.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSLDAPUserDetailsMapper.java
@@ -54,9 +54,6 @@ import java.util.logging.Logger;
 
 /**
  * Simple extension to the {@link LdapUserDetailsMapper} that ensures the LDAP users are also present in the database.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class CMSLDAPUserDetailsMapper extends LdapUserDetailsMapper {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSPrincipal.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSPrincipal.java
@@ -24,9 +24,6 @@ import java.util.Date;
 
 /**
  * Defines an extension to the security principal supporting linked user accounts.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface CMSPrincipal extends Principal {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSPrincipal.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSPrincipal.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSRememberMeUserDetailsService.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSRememberMeUserDetailsService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSRememberMeUserDetailsService.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CMSRememberMeUserDetailsService.java
@@ -33,9 +33,6 @@ import java.util.ArrayList;
 
 /**
  * User details implementation for use of the remember me services.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class CMSRememberMeUserDetailsService implements UserDetailsService {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/CustomAuthenticationProcessingFilter.java
@@ -27,9 +27,6 @@ import javax.servlet.http.HttpSession;
 
 /**
  * Custom authentication filter that supports additional fields in the login form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class CustomAuthenticationProcessingFilter extends UsernamePasswordAuthenticationFilter {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DefaultExternalAuthenticationProvider.java
@@ -40,9 +40,6 @@ import java.util.ArrayList;
 
 /**
  * Mock authentication provider for demonstrating possible integration point.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class DefaultExternalAuthenticationProvider implements AuthenticationProvider {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainAuthenticationToken.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainAuthenticationToken.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainAuthenticationToken.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainAuthenticationToken.java
@@ -20,9 +20,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 
 /**
  * An authentication token that supports the domain field.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class DomainAuthenticationToken extends UsernamePasswordAuthenticationToken {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainDatabaseAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainDatabaseAuthenticationProvider.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainDatabaseAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainDatabaseAuthenticationProvider.java
@@ -34,9 +34,6 @@ import java.util.logging.Logger;
 
 /**
  * Database authenticator that only handles the CMS domain requests.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class DomainDatabaseAuthenticationProvider implements AuthenticationProvider {
 

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainLdapAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainLdapAuthenticationProvider.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainLdapAuthenticationProvider.java
+++ b/psm-app/cms-web/src/main/java/gov/medicaid/security/DomainLdapAuthenticationProvider.java
@@ -26,9 +26,6 @@ import java.util.logging.Logger;
 
 /**
  * LDAP authenticator that only handles the CMS domain requests.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class DomainLdapAuthenticationProvider extends LdapAuthenticationProvider {
 

--- a/psm-app/cms-web/src/test/groovy/HelloSpec.groovy
+++ b/psm-app/cms-web/src/test/groovy/HelloSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import spock.lang.*
 
 @Unroll

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/TaskResourceProviderTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api
 
 import ca.uhn.fhir.rest.param.StringOrListParam

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/interceptors/BasicSecurityInterceptorTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/interceptors/BasicSecurityInterceptorTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.interceptors
 
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentAcceptsEftToFhirTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers
 
 import gov.medicaid.entities.Affiliation

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentStatusToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentStatusToFhirTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers
 
 import gov.medicaid.entities.EnrollmentStatus

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentStatusToPsmNameTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentStatusToPsmNameTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers
 
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/EnrollmentToFhirTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers
 
 import gov.medicaid.entities.Enrollment

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/ProviderProfileToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/ProviderProfileToFhirTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers
 
 import gov.medicaid.entities.Address

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/ProviderTypeToFhirTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/api/transformers/ProviderTypeToFhirTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.api.transformers
 
 import gov.medicaid.domain.model.ApplicantType

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/ControllerHelperTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/ControllerHelperTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers
 
 import gov.medicaid.entities.SearchResult

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/AutomaticScreeningControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/AutomaticScreeningControllerTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin
 
 import gov.medicaid.entities.AutomaticScreening

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ApplicationsByReviewerReportControllerTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report
 
 import java.time.LocalDate

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/DraftApplicationsReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/DraftApplicationsReportControllerTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report
 
 import java.time.LocalDate

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ProviderTypesReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ProviderTypesReportControllerTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report
 
 import java.time.LocalDate

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/ReviewedDocumentsReportControllerTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report
 
 import java.time.LocalDate

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/RiskLevelsReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/RiskLevelsReportControllerTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report
 
 import java.time.LocalDate

--- a/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/TimeToReviewReportControllerTest.groovy
+++ b/psm-app/cms-web/src/test/groovy/gov/medicaid/controllers/admin/report/TimeToReviewReportControllerTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.controllers.admin.report
 
 import java.time.LocalDate

--- a/psm-app/frontend/src/main/js/admin/script.js
+++ b/psm-app/frontend/src/main/js/admin/script.js
@@ -1,7 +1,5 @@
 /*
  Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
- @author TCSASSEBMLER
- @version 1.0
  */
 $(document).ready(function () {
   /**

--- a/psm-app/frontend/src/main/js/system/script.js
+++ b/psm-app/frontend/src/main/js/system/script.js
@@ -1,8 +1,6 @@
 /**
  *Copyright (C) 2012 TopCoder Inc., All Rights Reserved.
  *
- * @author TCSASSEMBLER
- * @version 1.0
  *
  * The js script makes the pages work.
  */

--- a/psm-app/frontend/src/vendor/js/jwysiwyg/plugins/spellchecker/SpellcheckController.java
+++ b/psm-app/frontend/src/vendor/js/jwysiwyg/plugins/spellchecker/SpellcheckController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package web;
 
 import java.util.List;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/IntegrationTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features;
 
 import cucumber.api.CucumberOptions;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features;
 
 import com.deque.axe.AXE;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/PsmStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features;
 
 import cucumber.api.java.en.Then;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/DataCoverageStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.steps;
 
 import cucumber.api.java.en.Then;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentListStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentListStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.steps;
 
 import cucumber.api.java.en.Then;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentListSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentListSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.steps;
 
 import gov.medicaid.features.enrollment.ui.EnrollmentListPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/EnrollmentSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.steps;
 
 import gov.medicaid.features.enrollment.ui.CcmhrCredentialsPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/IndividualEnrollmentStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/steps/ValidationStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.steps;
 
 import cucumber.api.java.en.Then;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentDetailsPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentDetailsPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentListPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentListPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/EnrollmentPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualInfoPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 public class IndividualInfoPage extends EnrollmentPage {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/IndividualSummaryPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/LicenseInfoPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationInfoPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import cucumber.api.PendingException;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationSummaryPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OrganizationSummaryPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/OwnershipInfoPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 /**

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalCareAssistantPersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalCareAssistantPersonalInfoPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PersonalInfoPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/PracticeInfoPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/ProviderStatementPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/ProviderStatementPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/SelectProviderTypePage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/enrollment/ui/SelectProviderTypePage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.enrollment.ui;
 
 public class SelectProviderTypePage extends EnrollmentPage {

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AccountSetupStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/AccountSetupStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ChangePasswordStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ForgotPasswordStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ForgotPasswordStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/GeneralSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LoginStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LogoutStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/LogoutStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ProviderEnrollmentsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/ProviderEnrollmentsStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import cucumber.api.java.en.When;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/RegisterNewAccountStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/RegisterNewAccountStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/SearchStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/SearchStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/SearchSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/steps/SearchSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.steps;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/AdvancedSearchPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/AdvancedSearchPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/AllEnrollmentsPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/AllEnrollmentsPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/LoginPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/MyProfilePage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/MyProfilePage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/UpdatePasswordPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/general/ui/UpdatePasswordPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.general.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ApplicationsByReviewerReportStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ApplicationsByReviewerReportStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ApplicationsByReviewerReportSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ApplicationsByReviewerReportSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import gov.medicaid.features.report.ui.ApplicationsByReviewerPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/DraftApplicationsReportStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/DraftApplicationsReportStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/DraftApplicationsReportSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/DraftApplicationsReportSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import gov.medicaid.features.report.ui.DraftApplicationsPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ProviderTypesReportStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ProviderTypesReportStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ProviderTypesReportSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ProviderTypesReportSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import gov.medicaid.features.report.ui.ProviderTypesPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ReportStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ReportStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ReportSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ReportSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import gov.medicaid.features.report.ui.ReportPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ReviewedDocumentsReportStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ReviewedDocumentsReportStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ReviewedDocumentsReportSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/ReviewedDocumentsReportSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import gov.medicaid.features.report.ui.ReviewedDocumentsPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/RiskLevelsReportStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/RiskLevelsReportStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/RiskLevelsReportSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/RiskLevelsReportSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import gov.medicaid.features.report.ui.RiskLevelsPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/TimeToReviewReportStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/TimeToReviewReportStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import cucumber.api.java.en.Given;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/TimeToReviewReportSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/steps/TimeToReviewReportSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.steps;
 
 import gov.medicaid.features.report.ui.TimeToReviewPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ApplicationsByReviewerPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ApplicationsByReviewerPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/DraftApplicationsPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/DraftApplicationsPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ProviderTypesPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ProviderTypesPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ReportPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ReportPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ReviewedDocumentsPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/ReviewedDocumentsPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/RiskLevelsPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/RiskLevelsPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/TimeToReviewPage.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/report/ui/TimeToReviewPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.report.ui;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.service_admin.steps;
 
 import cucumber.api.PendingException;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/AdminSteps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.service_admin.steps;
 
 import gov.medicaid.features.PsmPage;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/FunctionsStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.service_admin.steps;
 
 import cucumber.api.java.en.When;

--- a/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ViewEnrollmentStepDefinitions.java
+++ b/psm-app/integration-tests/src/test/java/gov/medicaid/features/service_admin/steps/ViewEnrollmentStepDefinitions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.features.service_admin.steps;
 
 import cucumber.api.java.en.When;

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AbstractPracticeFormBinder.java
@@ -47,9 +47,6 @@ import java.util.Map;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public abstract class AbstractPracticeFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
@@ -43,9 +43,6 @@ import java.util.Map;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class AdditionalAgencyFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalAgencyFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdditionalPracticeFormBinder.java
@@ -47,9 +47,6 @@ import java.util.Map;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class AdditionalPracticeFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdultDayTreatmentApplicationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdultDayTreatmentApplicationFormBinder.java
@@ -38,9 +38,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class AdultDayTreatmentApplicationFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AdultDayTreatmentApplicationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AdultDayTreatmentApplicationFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AmbulanceServicesFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AmbulanceServicesFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/AmbulanceServicesFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/AmbulanceServicesFormBinder.java
@@ -44,9 +44,6 @@ import java.util.Map;
 
 /**
  * This binder handles the ambulance services licenses.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class AmbulanceServicesFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BaseFormBinder.java
@@ -50,9 +50,6 @@ import java.util.Map;
 
 /**
  * Base class for the form binders.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public abstract class BaseFormBinder implements FormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BinderException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BinderException.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BinderException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BinderException.java
@@ -18,9 +18,6 @@ package gov.medicaid.binders;
 
 /**
  * Exception for invalid data formats.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class BinderException extends Exception {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BinderUtils.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BinderUtils.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/BinderUtils.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/BinderUtils.java
@@ -39,9 +39,6 @@ import java.util.List;
 
 /**
  * Utility methods for binding data.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class BinderUtils {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CLIAFormBinder.java
@@ -44,9 +44,6 @@ import java.util.Set;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class CLIAFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CMHRTContractFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CMHRTContractFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CMHRTContractFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CMHRTContractFormBinder.java
@@ -37,9 +37,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class CMHRTContractFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CTCCFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CTCCFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/CTCCFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/CTCCFormBinder.java
@@ -38,9 +38,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class CTCCFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityCapacityFormBinder.java
@@ -33,9 +33,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class FacilityCapacityFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityContractsFormBinder.java
@@ -43,9 +43,6 @@ import java.util.Set;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class FacilityContractsFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityEligibilityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityEligibilityFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityEligibilityFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityEligibilityFormBinder.java
@@ -36,9 +36,6 @@ import java.util.Map;
 
 /**
  * This binder handles the facility eligibility.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class FacilityEligibilityFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityLicenseFormBinder.java
@@ -47,9 +47,6 @@ import java.util.Set;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class FacilityLicenseFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FacilityTypeFormBinder.java
@@ -41,9 +41,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class FacilityTypeFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
@@ -41,9 +41,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class FederalQualificationFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FederalQualificationFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
@@ -33,9 +33,6 @@ import java.util.Map;
 
 /**
  * A form binder is a delegate that processes fields specific to the form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface FormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/FormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/HighestDegreeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/HighestDegreeFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/HighestDegreeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/HighestDegreeFormBinder.java
@@ -43,9 +43,6 @@ import java.util.Map;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class HighestDegreeFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualAgencyFormBinder.java
@@ -47,9 +47,6 @@ import java.util.Map;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class IndividualAgencyFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualDisclosureFormBinder.java
@@ -52,9 +52,6 @@ import java.util.stream.Collectors;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class IndividualDisclosureFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/IndividualPCAInfoFormBinder.java
@@ -41,9 +41,6 @@ import java.util.Map;
 
 /**
  * This binder handles the personal information form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class IndividualPCAInfoFormBinder extends BaseFormBinder implements FormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/LicenseInformationFormBinder.java
@@ -50,9 +50,6 @@ import java.util.Set;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class LicenseInformationFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/MemberInfoFormBinder.java
@@ -49,9 +49,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization information form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class MemberInfoFormBinder extends BaseFormBinder implements FormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/NonProfitCorporationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/NonProfitCorporationFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/NonProfitCorporationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/NonProfitCorporationFormBinder.java
@@ -37,9 +37,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class NonProfitCorporationFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationDisclosureFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationDisclosureFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationDisclosureFormBinder.java
@@ -35,9 +35,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class OrganizationDisclosureFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationInfoFormBinder.java
@@ -56,9 +56,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization information form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class OrganizationInfoFormBinder extends BaseFormBinder implements FormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OrganizationStatementFormBinder.java
@@ -45,9 +45,6 @@ import java.util.stream.Collectors;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class OrganizationStatementFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/OwnershipInfoFormBinder.java
@@ -51,9 +51,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization information form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class OwnershipInfoFormBinder extends BaseFormBinder implements FormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PCABillingContactFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PCABillingContactFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PCABillingContactFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PCABillingContactFormBinder.java
@@ -39,9 +39,6 @@ import java.util.Map;
 
 /**
  * This binder handles the personal information form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PCABillingContactFormBinder extends BaseFormBinder implements FormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PCPOInsuranceFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PCPOInsuranceFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PCPOInsuranceFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PCPOInsuranceFormBinder.java
@@ -36,9 +36,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PCPOInsuranceFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNAgencyFormBinder.java
@@ -40,9 +40,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PHNAgencyFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PHNFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PHNFormBinder.java
@@ -44,9 +44,6 @@ import java.util.Set;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PHNFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PersonalInformationFormBinder.java
@@ -48,9 +48,6 @@ import java.util.Map;
 
 /**
  * This binder handles the personal information form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PersonalInformationFormBinder extends BaseFormBinder implements FormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PhysicianClinicFacilityQualificationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PhysicianClinicFacilityQualificationFormBinder.java
@@ -43,9 +43,6 @@ import java.util.Map;
 
 /**
  * This binder handles the facility qualification licenses.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PhysicianClinicFacilityQualificationFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PhysicianClinicFacilityQualificationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PhysicianClinicFacilityQualificationFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PracticeTypeFormBinder.java
@@ -39,9 +39,6 @@ import java.util.Map;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PracticeTypeFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrimaryPracticeFormBinder.java
@@ -44,9 +44,6 @@ import java.util.Map;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PrimaryPracticeFormBinder extends AbstractPracticeFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/PrivatePracticeFormBinder.java
@@ -45,9 +45,6 @@ import java.util.Map;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PrivatePracticeFormBinder extends AbstractPracticeFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderSetupFormBinder.java
@@ -37,9 +37,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization information form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ProviderSetupFormBinder extends BaseFormBinder implements FormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/ProviderTypeFormBinder.java
@@ -39,9 +39,6 @@ import java.util.Map;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ProviderTypeFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
@@ -51,9 +51,6 @@ import java.util.Set;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class QualifiedProfessionalFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/QualifiedProfessionalFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/RemittanceSequenceFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/RemittanceSequenceFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/RemittanceSequenceFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/RemittanceSequenceFormBinder.java
@@ -37,9 +37,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class RemittanceSequenceFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/SlidingFeeScheduleFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/SlidingFeeScheduleFormBinder.java
@@ -38,9 +38,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class SlidingFeeScheduleFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/SlidingFeeScheduleFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/SlidingFeeScheduleFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/SpecialtyInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/SpecialtyInformationFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/SpecialtyInformationFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/SpecialtyInformationFormBinder.java
@@ -46,9 +46,6 @@ import java.util.Set;
 
 /**
  * This binder handles the provider type selection form.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class SpecialtyInformationFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/TCMContractFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/TCMContractFormBinder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/TCMContractFormBinder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/TCMContractFormBinder.java
@@ -37,9 +37,6 @@ import java.util.Map;
 
 /**
  * This binder handles the organization disclosure.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class TCMContractFormBinder extends BaseFormBinder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
+++ b/psm-app/services/src/main/java/gov/medicaid/binders/XMLUtility.java
@@ -58,9 +58,6 @@ import java.util.List;
 
 /**
  * Utility methods for manipulating the process model.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class XMLUtility {
 

--- a/psm-app/services/src/main/java/gov/medicaid/dao/IdentityProviderDAO.java
+++ b/psm-app/services/src/main/java/gov/medicaid/dao/IdentityProviderDAO.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/dao/IdentityProviderDAO.java
+++ b/psm-app/services/src/main/java/gov/medicaid/dao/IdentityProviderDAO.java
@@ -23,9 +23,6 @@ import java.util.List;
 
 /**
  * This service defines the API used to synchronize application users with the Identity provider.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface IdentityProviderDAO {
 

--- a/psm-app/services/src/main/java/gov/medicaid/dao/impl/LDAPIdentityProviderDAOBean.java
+++ b/psm-app/services/src/main/java/gov/medicaid/dao/impl/LDAPIdentityProviderDAOBean.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/dao/impl/LDAPIdentityProviderDAOBean.java
+++ b/psm-app/services/src/main/java/gov/medicaid/dao/impl/LDAPIdentityProviderDAOBean.java
@@ -54,9 +54,6 @@ import java.util.Properties;
 /**
  * This is an EJB implementation for the {@link IdentityProviderDAO} which connects directly to configurable LDAP
  * servers.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @Stateless
 @Local(IdentityProviderDAO.class)

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AcceptedAgreements.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AcceptedAgreements.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Address.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Affiliation.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocument.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentSearchCriteria.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentSearchCriteria.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * This represents the search criteria for agreement document.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 public class AgreementDocumentSearchCriteria extends SearchCriteria {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AgreementDocumentType.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * Represents the agreement document type.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 public enum AgreementDocumentType {
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditDetail.java
@@ -24,9 +24,6 @@ import javax.persistence.Table;
 
 /**
  * Audit record details.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Table(name = "audit_details")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AuditRecord.java
@@ -27,9 +27,6 @@ import java.util.List;
 
 /**
  * Represents an audit record header.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Table(name = "audit_records")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
@@ -23,9 +23,6 @@ import java.io.Serializable;
 
 /**
  * Represents a user entity.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Table(name = "cms_authentication")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Authentication.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/AutomaticScreening.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/AutomaticScreening.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwner.java
@@ -30,9 +30,6 @@ import java.math.BigDecimal;
 
 /**
  * Base class for beneficial owners of organizations.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BeneficialOwnerType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/BinaryContent.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CMSUser.java
@@ -33,9 +33,6 @@ import java.io.Serializable;
 
 /**
  * Represents a user entity.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CategoryOfService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactData.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactData.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactData.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactData.java
@@ -19,9 +19,6 @@ package gov.medicaid.entities;
 
 /**
  * Projection results from search of enrolled practices.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ContactData {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ContactInformation.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/CountyType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Degree.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Degree.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContact.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContactType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContactType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContactType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/DesignatedContactType.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * Represents supported designated contact values.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public enum DesignatedContactType {
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Document.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EmailTemplate.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EmailTemplate.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EmailTemplate.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EmailTemplate.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * Represents supported templates.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public enum EmailTemplate {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Enrollment.java
@@ -38,9 +38,6 @@ import java.util.List;
 
 /**
  * Represents a ticket/enrollment.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Table(name = "enrollments")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentSearchCriteria.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.entities;
 
 import java.util.Date;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentStatus.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EnrollmentStatus.java
@@ -20,9 +20,6 @@ import javax.persistence.Table;
 
 /**
  * Lookup entity for enrollment status (Draft/Pending/Approved/Rejected).
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Table(name = "enrollment_statuses")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Entity.java
@@ -31,9 +31,6 @@ import java.util.Date;
 
 /**
  * Represents a person or organization.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/EntityStructureType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Event.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalAccountLink.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ExternalProfileLink.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ExternalProfileLink.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/IdentifiableEntity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/IdentifiableEntity.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/IdentifiableEntity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/IdentifiableEntity.java
@@ -20,9 +20,6 @@ import java.io.Serializable;
 
 /**
  * This serves as the base class for all persisted entities.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public abstract class IdentifiableEntity implements Serializable {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/IssuingBoard.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LeieAutomaticScreening.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LeieAutomaticScreening.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.entities;
 
 import javax.persistence.CascadeType;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LeieAutomaticScreeningMatch.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LeieAutomaticScreeningMatch.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/License.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/License.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LicenseStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LicenseStatus.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LicenseType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LicenseType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/LookupEntity.java
@@ -23,9 +23,6 @@ import java.io.Serializable;
 
 /**
  * Represents a lookup entity.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @MappedSuperclass
 public class LookupEntity implements Serializable {

--- a/psm-app/services/src/main/java/gov/medicaid/entities/MemberSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/MemberSearchCriteria.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/MemberSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/MemberSearchCriteria.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * Represents a member search criteria.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class MemberSearchCriteria extends SearchCriteria {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Note.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Organization.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Organization.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OrganizationBeneficialOwner.java
@@ -21,9 +21,6 @@ import javax.persistence.Table;
 
 /**
  * A corporate beneficial owner.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Table(name = "organization_beneficial_owners")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/OwnershipInformation.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProvider.java
@@ -28,9 +28,6 @@ import java.util.Date;
 
 /**
  * Represents a pay-to provider.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Table(name = "pay_to_providers")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PayToProviderType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Person.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Person.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PersonBeneficialOwner.java
@@ -25,9 +25,6 @@ import java.util.Date;
 
 /**
  * A person beneficial owner.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Table(name = "person_beneficial_owners")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PracticeLookup.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PracticeLookup.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PracticeLookup.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PracticeLookup.java
@@ -22,9 +22,6 @@ import java.util.Date;
 
 /**
  * Projection results from search of enrolled practices.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PracticeLookup {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PracticeSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PracticeSearchCriteria.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/PracticeSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/PracticeSearchCriteria.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * Represents a practice search criteria.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PracticeSearchCriteria extends SearchCriteria {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProfileHeader.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProfileHeader.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProfileHeader.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProfileHeader.java
@@ -20,9 +20,6 @@ import java.util.Date;
 
 /**
  * Search result container for profiles.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ProfileHeader {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProfileStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProfileStatus.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderCategoryOfService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderCategoryOfService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderLookup.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderLookup.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderLookup.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderLookup.java
@@ -20,9 +20,6 @@ package gov.medicaid.entities;
 
 /**
  * Projection results from search of enrolled providers.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ProviderLookup {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderProfile.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderProfile.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderSearchCriteria.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderSearchCriteria.java
@@ -21,9 +21,6 @@ import java.util.List;
 
 /**
  * Represents a provider search criteria.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ProviderSearchCriteria extends SearchCriteria {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderService.java
@@ -11,9 +11,6 @@ import java.io.Serializable;
 
 /**
  * Represents services allowed for the given provider.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 
 @javax.persistence.Entity

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderStatement.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
@@ -32,9 +32,6 @@ import java.util.Set;
 
 /**
  * Represents a provider type.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @javax.persistence.Entity
 @Table(name = "provider_types")

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSearchCriteria.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSearchCriteria.java
@@ -19,9 +19,6 @@ package gov.medicaid.entities;
 
 /**
  * Represents a provider type search criteria.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 public class ProviderTypeSearchCriteria extends SearchCriteria {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSetting.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ProviderTypeSetting.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/QPType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RelationshipType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RemittanceSequenceOrder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RemittanceSequenceOrder.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RemittanceSequenceOrder.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RemittanceSequenceOrder.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * Represents supported Remittance sequence order.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public enum RemittanceSequenceOrder {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RequestType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RequestType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RiskLevel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RiskLevel.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Role.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Role.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/RoleView.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/RoleView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.entities;
 
 public enum RoleView {

--- a/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/ScreeningSchedule.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SearchCriteria.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SearchCriteria.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * This serves as the base class for all search criteria objects.
- *
- * @author sampath01, TCSASSEMBLER
- * @version 1.0
  */
 public abstract class SearchCriteria {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SearchResult.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SearchResult.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SearchResult.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SearchResult.java
@@ -21,8 +21,6 @@ import java.util.List;
 /**
  * Represents the search results.
  *
- * @author TCSASSEMBLER
- * @version 1.0
  * @param <T> the type of the result list
  */
 public class SearchResult<T> {

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SentNotification.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SentNotification.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.entities;
 
 import javax.persistence.Column;

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SpecialtyType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SpecialtyType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/StateType.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/StateType.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SystemId.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SystemId.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * Represents a user status.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public enum SystemId {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/SystemId.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/SystemId.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserRequest.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserRequest.java
@@ -21,9 +21,6 @@ import java.util.List;
 
 /**
  * Projection results from search of tickets.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class UserRequest {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserRequest.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserRequest.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserSearchCriteria.java
@@ -20,9 +20,6 @@ import java.util.List;
 
 /**
  * Represents a user search criteria.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 public class UserSearchCriteria extends SearchCriteria {
 
@@ -59,19 +56,16 @@ public class UserSearchCriteria extends SearchCriteria {
     /**
      * Specifies that the search should be "AND" related.
      * Defaults to false to preserve existing behavior.
-     * @since Medicaid Provider Screening Portal - System Admin Controllers
      */
     private boolean and = true;
 
     /**
      * Indicates to show the filter panel or not.
-     * @since v1.2 - Medicaid Provider Screening Portal - System Admin Front End Assembly
      */
     private boolean showFilterPanel;
 
     /**
      * Represents the search is from search box or not.
-     * @since v1.2 - Medicaid Provider Screening Portal - System Admin Front End Assembly
      */
     private boolean searchBox;
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserStatus.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/UserStatus.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/UserStatus.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * Represents a user status.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public enum UserStatus {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Validity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Validity.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/Validity.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/Validity.java
@@ -18,8 +18,6 @@ package gov.medicaid.entities;
 
 /**
  * Validity status for tickets.
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public enum Validity {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormError.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormError.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormError.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormError.java
@@ -18,9 +18,6 @@ package gov.medicaid.entities.dto;
 
 /**
  * Holder for validation errors.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class FormError {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormSettings.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormSettings.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormSettings.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/FormSettings.java
@@ -21,9 +21,6 @@ import java.util.Map;
 
 /**
  * Form settings.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class FormSettings {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/UITabModel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/UITabModel.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/UITabModel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/UITabModel.java
@@ -23,9 +23,6 @@ import java.util.Map;
 
 /**
  * Front end model for each tab.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class UITabModel {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewModel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewModel.java
@@ -24,9 +24,6 @@ import java.util.Map;
 
 /**
  * View model for the provider.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ViewModel {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewModel.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewModel.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
@@ -19,9 +19,6 @@ package gov.medicaid.entities.dto;
 
 /**
  * Constants shared throught the front-end application.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class ViewStatics {
 

--- a/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
+++ b/psm-app/services/src/main/java/gov/medicaid/entities/dto/ViewStatics.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/AgreementDocumentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/AgreementDocumentService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/AgreementDocumentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/AgreementDocumentService.java
@@ -26,9 +26,6 @@ import gov.medicaid.entities.SearchResult;
  * This represents the service API to manage agreement documents.</p>
  * <p>
  * Implementations should be effectively thread-safe.</p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 public interface AgreementDocumentService {
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/BusinessProcessService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/CMSConfigurator.java
@@ -41,8 +41,6 @@ import java.util.Set;
  * CMS configurator.
  *
  * v1.1 - WAS Porting - setting JNDI on persistence.xml for entity manager is JBOSS specific
- * @author TCSASSEMBLER
- * @version 1.1
  */
 public class CMSConfigurator {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EnrollmentWebService.java
@@ -22,8 +22,6 @@ import gov.medicaid.domain.model.SubmitTicketResponse;
 
 /**
  * Web service facade for enrollment requests.
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface EnrollmentWebService {
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/EntityNotFoundException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EntityNotFoundException.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/EntityNotFoundException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EntityNotFoundException.java
@@ -20,9 +20,6 @@ import javax.ejb.ApplicationException;
 
 /**
  * This exception is thrown by update and delete methods if an entity was not found.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @ApplicationException
 public class EntityNotFoundException extends PortalServiceException {

--- a/psm-app/services/src/main/java/gov/medicaid/services/EventService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EventService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/EventService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/EventService.java
@@ -28,8 +28,6 @@ import java.util.List;
  * <p>
  * Implementations should be effectively thread-safe.
  * </p>
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 public interface EventService {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/ExportService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ExportService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ExportService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ExportService.java
@@ -31,9 +31,6 @@ import java.util.Map;
  * <p>
  * <b>Thread Safety</b> Implementations should be effectively thread-safe.
  * </p>
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface ExportService {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -23,9 +23,6 @@ import java.util.List;
 
 /**
  * Defines the lookup related services.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface LookupService {
     /**

--- a/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/LookupService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/NotificationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/NotificationService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gov.medicaid.services;
 
 import gov.medicaid.domain.model.EnrollmentType;

--- a/psm-app/services/src/main/java/gov/medicaid/services/OnboardingService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/OnboardingService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/OnboardingService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/OnboardingService.java
@@ -24,9 +24,6 @@ import java.util.List;
 
 /**
  * This service defines the interface for importing external data.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface OnboardingService {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/PartnerSystemService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PartnerSystemService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/PartnerSystemService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PartnerSystemService.java
@@ -22,9 +22,6 @@ import java.util.List;
 
 /**
  * Interface for external services related activities.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface PartnerSystemService {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceConfigurationException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceConfigurationException.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceConfigurationException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceConfigurationException.java
@@ -19,9 +19,6 @@ package gov.medicaid.services;
 /**
  * This exception is thrown by implementations' init methods if there are required injection fields that are not
  * injected.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 public class PortalServiceConfigurationException extends RuntimeException {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceException.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceException.java
@@ -20,9 +20,6 @@ import javax.ejb.ApplicationException;
 
 /**
  * This is the top-level exception. It is thrown by all methods if there is an error.
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @ApplicationException
 public class PortalServiceException extends Exception {

--- a/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceRuntimeException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceRuntimeException.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceRuntimeException.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PortalServiceRuntimeException.java
@@ -20,9 +20,6 @@ import javax.ejb.ApplicationException;
 
 /**
  * This is the top-level exception. It is thrown by all methods if there is an error.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 @ApplicationException
 public class PortalServiceRuntimeException extends RuntimeException {

--- a/psm-app/services/src/main/java/gov/medicaid/services/PresentationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PresentationService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/PresentationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/PresentationService.java
@@ -26,9 +26,6 @@ import java.util.List;
 
 /**
  * Defines the UI related services.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface PresentationService {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderEnrollmentService.java
@@ -44,9 +44,6 @@ import java.util.Set;
 
 /**
  * Interface for enrollment related activities.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface ProviderEnrollmentService {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ProviderTypeService.java
@@ -31,9 +31,6 @@ import java.util.List;
  * <p>
  * <b>Thread Safety</b> Implementations should be effectively thread-safe.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @WebService
 public interface ProviderTypeService {

--- a/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/RegistrationService.java
@@ -24,9 +24,6 @@ import gov.medicaid.entities.UserSearchCriteria;
 
 /**
  * This service defines the self service registration.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public interface RegistrationService {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/ScreeningService.java
@@ -31,9 +31,6 @@ import java.util.Optional;
  * <p>
  * <b>Thread Safety</b> Implementations should be effectively thread-safe.
  * </p>
- *
- * @author argolite, TCSASSEMBLER
- * @version 1.0
  */
 @WebService
 public interface ScreeningService {

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/PDFHelper.java
@@ -26,9 +26,6 @@ import java.util.Map;
 
 /**
  * Common utility methods.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class PDFHelper {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/Util.java
@@ -26,9 +26,6 @@ import java.util.List;
 
 /**
  * Common utility methods.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public class Util {
 

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/XMLAdapter.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/XMLAdapter.java
@@ -1,12 +1,13 @@
 /*
- * Copyright 2012-2013 TopCoder, Inc.
- *
- * This code was developed under U.S. government contract NNH10CD71C.
+ * Copyright 2012, 2013 TopCoder, Inc.
+ * Copyright 2018 The MITRE Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/psm-app/services/src/main/java/gov/medicaid/services/util/XMLAdapter.java
+++ b/psm-app/services/src/main/java/gov/medicaid/services/util/XMLAdapter.java
@@ -53,9 +53,6 @@ import java.util.Map;
 
 /**
  * Translates the hibernate model to the business process model.
- *
- * @author TCSASSEMBLER
- * @version 1.0
  */
 public final class XMLAdapter {
 

--- a/psm-app/services/src/test/groovy/HelloSpec.groovy
+++ b/psm-app/services/src/test/groovy/HelloSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The MITRE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import spock.lang.*
 
 @Unroll


### PR DESCRIPTION
Related to #300, update license headers for most files and filetypes.  Not marking as fixed because there may still be more to do.